### PR TITLE
update copyright info on the GUI

### DIFF
--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -2,7 +2,7 @@
 version 1.0302 
 header_name {.h} 
 code_name {.cc}
-decl {//Copyright (c) 2002-2009 Nasca Octavian Paul} {private local
+decl {//Copyright (c) 2002-2009 Nasca Octavian Paul - (c) 2009-2016 Mark McCurry} {private local
 } 
 
 decl {//License: GNU GPL version 2 or later} {private local
@@ -869,7 +869,7 @@ panelwindow->show();}
       xywh {411 344 365 280} type Double hide
     } {
       Fl_Box {} {
-        label {Copyright (c) 2002-2009 Nasca O. PAUL and others. Please read AUTHORS.txt}
+        label {Copyright (c) 2002-2009 Nasca O. PAUL, 2009-2016 Mark McCurry, and others. Please read AUTHORS.txt}
         xywh {15 35 335 55} labeltype EMBOSSED_LABEL labelsize 15 align 208
       }
       Fl_Box {} {


### PR DESCRIPTION
The idea is to update what's displayed when you go to : ZynAddSubFX menu -> File -> Copyright to something more updated/accurate.
I didn't test it. Please check if it's done correctly.