### PR TITLE
Fix crash with mxml V3

### DIFF
--- a/src/Misc/XMLwrapper.cpp
+++ b/src/Misc/XMLwrapper.cpp
@@ -688,8 +688,11 @@ std::vector<XmlNode> XMLwrapper::getBranch(void) const
             XmlNode n(mxmlGetElement(current));
             int count = mxmlElementGetAttrCount(current);
             const char *name;
+            const char *attrib;
             for(int i = 0; i < count; ++i) {
-                n[name] = mxmlElementGetAttrByIndex(current, i, &name);
+                attrib = mxmlElementGetAttrByIndex(current, i, &name);
+                if(name)
+                    n[name] = attrib;
             }
 #else
             auto elm = current->value.element;


### PR DESCRIPTION
Loading my old qtractor-sessions started to crash on my Raspi. A remote debug
session lead to zynaddsubfx and the point of code:

![qtractor-crash](https://user-images.githubusercontent.com/2571823/56068680-086bf280-5d80-11e9-9115-3a8a3910e1fe.png)

Wih this modification the sessions load again without issues.
