### PR TITLE
Fix BashCompletion.cmake output script

### DIFF
--- a/cmake/BashCompletion.cmake
+++ b/cmake/BashCompletion.cmake
@@ -74,7 +74,7 @@ ELSE()
 #!${BASH}\n\
 set -e\n\
 BASHCOMP_PKG_PATH=\"${BASHCOMP_USER_PATH}\"\n\
-if [ -w \"${BASHCOMP_PKG_PATH}\" ]; then\n\
+if [ -n \"${BASHCOMP_PKG_PATH}\" ]; then\n\
   BASHCOMP_PKG_PATH=\"${BASHCOMP_PKG_PATH}\"\n\
 fi\n\
 echo -e \"\\nInstalling bash completion...\\n\"\n\


### PR DESCRIPTION
BASHCOMP_PKG_PATH is supposed to replace BASHCOMP_USER_PATH if set, rather than be existing file/dir, since it is about to be created.