### PR TITLE
Bugfix: Removes occurences to HISTORY.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include(CTestConfig.cmake)
 add_subdirectory(src)
 add_subdirectory(doc) # Doxygen only
 
-install(FILES AUTHORS.txt COPYING HISTORY.txt README.adoc
+install(FILES AUTHORS.txt COPYING README.adoc
 	DESTINATION share/doc/zynaddsubfx
 	)
 install(FILES zynaddsubfx-jack-multi.desktop zynaddsubfx-jack.desktop zynaddsubfx-alsa.desktop zynaddsubfx-oss.desktop

--- a/TODO-release.md
+++ b/TODO-release.md
@@ -2,7 +2,6 @@
 
 - Update version number in CMakeLists.txt
 - Update version number in src/Tests/guitar-adnote.xmz
-- Update date of the new version in HISTORY.txt
 - Update news on sourceforge website
 - Upload source tarball to sourceforge website
 - Update the "Linux/BSD/Source" link on http://zynaddsubfx.sourceforge.net/download.html (do that here : https://github.com/zynaddsubfx/zyn-website/blob/master/download.html )


### PR DESCRIPTION
The build currently fails because of a missing file at the root of the build tree. This PR fixes it.