### PR TITLE
Fix abort on pgm change to undefined part

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -471,12 +471,7 @@ public:
         if(actual_load[npart] != pending_load[npart])
             return;
         assert(actual_load[npart] <= pending_load[npart]);
-
-        if(!filename || !*filename){
-            fprintf(stderr, "Warning: failed to load undefined part<%s>\n",
-                    filename);
-            return;
-        }
+        assert(filename);
 
         //load part in async fashion when possible
 #ifndef WIN32
@@ -1582,6 +1577,11 @@ static rtosc::Ports middlewareReplyPorts = {
         Bank &bank        = impl.master->bank;
         const int part    = rtosc_argument(msg, 0).i;
         const int program = rtosc_argument(msg, 1).i + 128*bank.bank_lsb;
+        if (program >= BANK_SIZE) {
+            fprintf(stderr, "bank:program number %d:%d is out of range.",
+                    program >> 7, program & 0x7f);
+            return;
+        }
         const char *fn  = impl.master->bank.ins[program].filename.c_str();
         impl.loadPart(part, fn, impl.master, d);
         impl.uToB->write(("/part"+to_s(part)+"/Pname").c_str(), "s",

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -472,6 +472,12 @@ public:
             return;
         assert(actual_load[npart] <= pending_load[npart]);
 
+        if(!filename || !*filename){
+            fprintf(stderr, "Warning: failed to load undefined part<%s>\n",
+                    filename);
+            return;
+        }
+
         //load part in async fashion when possible
 #ifndef WIN32
         auto alloc = std::async(std::launch::async,
@@ -1576,8 +1582,10 @@ static rtosc::Ports middlewareReplyPorts = {
         Bank &bank        = impl.master->bank;
         const int part    = rtosc_argument(msg, 0).i;
         const int program = rtosc_argument(msg, 1).i + 128*bank.bank_lsb;
-        impl.loadPart(part, impl.master->bank.ins[program].filename.c_str(), impl.master, d);
-        impl.uToB->write(("/part"+to_s(part)+"/Pname").c_str(), "s", impl.master->bank.ins[program].name.c_str());
+        const char *fn  = impl.master->bank.ins[program].filename.c_str();
+        impl.loadPart(part, fn, impl.master, d);
+        impl.uToB->write(("/part"+to_s(part)+"/Pname").c_str(), "s",
+                         fn ? impl.master->bank.ins[program].name.c_str() : "");
         rEnd},
     {"setbank:c", 0, 0,
         rBegin;

--- a/src/Tests/MiddlewareTest.h
+++ b/src/Tests/MiddlewareTest.h
@@ -123,6 +123,20 @@ class PluginTest:public CxxTest::TestSuite
             //const string fdata = loadfile(fname);
         }
 
+        void testChangeToOutOfRangeProgram()
+        {
+            middleware[0]->transmitMsg("/bank/msb", "i", 0);
+            middleware[0]->tick();
+            middleware[0]->transmitMsg("/bank/lsb", "i", 1);
+            middleware[0]->tick();
+            middleware[0]->pendingSetProgram(0, 32);
+            middleware[0]->tick();
+            master[0]->GetAudioOutSamples(synth->buffersize, synth->samplerate, outL, outR);
+            // We should ideally be checking to verify that the part change
+            // didn't happen, but it's not clear how to do that.  We're
+            // currently relying on the assert(filename) in loadPart() failing
+            // if this logic gets broken.
+        }
 
     private:
         SYNTH_T *synth;


### PR DESCRIPTION
This fixes a bug where zyn aborts after a midi program change to an undefined patch.  I can consistently reproduce this by sending midi bank change MSB, bank change LSB and then a program change to a program that is not defined in the bank.  For some reason this does not occur when sending a just a program change for a program not defined in the current bank on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zynaddsubfx/zynaddsubfx/40)
<!-- Reviewable:end -->
