### PR TITLE
unison-size  minimum: 0 corrected to 1

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -71,7 +71,7 @@ static const Ports voicePorts = {
     rRecurp(VoiceFilter,    "Optional Voice Filter"),
 
 //    rToggle(Enabled,       rShort("enable"), "Voice Enable"),
-    rParamI(Unison_size, rShort("size"), rMap(min, 0), rMap(max, 50),
+    rParamI(Unison_size, rShort("size"), rMap(min, 1), rMap(max, 50),
         rDefault(1), "Number of subvoices"),
     rParamZyn(Unison_phase_randomness, rShort("ph.rnd."), rDefault(127),
         "Phase Randomness"),


### PR DESCRIPTION
So, test.json in osc-bridge needs to be updated too, with the output from zynaddsubfx  -D option?
Like here in the version i just generated: [https://github.com/strongheart1/osc-bridge/commit/0d47f471b23d8a6106f1fa35a285641f435f1ebd](https://github.com/strongheart1/osc-bridge/commit/0d47f471b23d8a6106f1fa35a285641f435f1ebd) there are also other changes, due to envelope time parameter changes. 