### PR TITLE
finish addsynth ENVs sustaining at 0 with 0 release to free up cpu

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -597,7 +597,7 @@ void Part::NoteOff(note_t note) //release the key
 }
 
 void Part::PolyphonicAftertouch(note_t note,
-				unsigned char velocity)
+                unsigned char velocity)
 {
     if(!Pnoteon || !inRange(note, Pminkey, Pmaxkey) || Pdrummode)
         return;
@@ -728,7 +728,7 @@ void Part::SetController(unsigned int type, note_t note, float value,
         break;
     case C_pitch: {
         if (getNoteLog2Freq(masterkeyshift, value) == false)
-	    break;
+        break;
 
         /* Make sure MonoMem's frequency information is kept up to date */
         if(!Ppolymode)

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -728,7 +728,7 @@ void Part::SetController(unsigned int type, note_t note, float value,
         break;
     case C_pitch: {
         if (getNoteLog2Freq(masterkeyshift, value) == false)
-        break;
+            break;
 
         /* Make sure MonoMem's frequency information is kept up to date */
         if(!Ppolymode)

--- a/src/Params/EnvelopeParams.cpp
+++ b/src/Params/EnvelopeParams.cpp
@@ -275,7 +275,7 @@ EnvelopeParams::EnvelopeParams(unsigned char Penvstretch_,
     envdt[0]        = 0.0f; //no used
     Penvsustain     = 1;
     Penvpoints      = 1;
-    Envmode         = 1;
+    Envmode         = ADSR_lin;
     Penvstretch     = Penvstretch_;
     Pforcedrelease  = Pforcedrelease_;
     Pfreemode       = 1;
@@ -346,7 +346,7 @@ float EnvelopeParams::getdt(char i) const
 void EnvelopeParams::ADSRinit(float a_dt, float d_dt, char s_val, float r_dt)
 {
     setpresettype("Penvamplitude");
-    Envmode   = 1;
+    Envmode   = ADSR_lin;
     A_dt      = a_dt;
     D_dt      = d_dt;
     PS_val    = s_val;
@@ -360,7 +360,7 @@ void EnvelopeParams::ADSRinit(float a_dt, float d_dt, char s_val, float r_dt)
 void EnvelopeParams::ADSRinit_dB(float a_dt, float d_dt, char s_val, float r_dt)
 {
     setpresettype("Penvamplitude");
-    Envmode   = 2;
+    Envmode   = ADSR_dB;
     A_dt      = a_dt;
     D_dt      = d_dt;
     PS_val    = s_val;
@@ -374,7 +374,7 @@ void EnvelopeParams::ADSRinit_dB(float a_dt, float d_dt, char s_val, float r_dt)
 void EnvelopeParams::ASRinit(char a_val, float a_dt, char r_val, float r_dt)
 {
     setpresettype("Penvfrequency");
-    Envmode   = 3;
+    Envmode   = ASR_freqlfo;
     PA_val    = a_val;
     A_dt      = a_dt;
     PR_val    = r_val;
@@ -393,7 +393,7 @@ void EnvelopeParams::ADSRinit_filter(char a_val,
                                      char r_val)
 {
     setpresettype("Penvfilter");
-    Envmode   = 4;
+    Envmode   = ADSR_filter;
     PA_val    = a_val;
     A_dt      = a_dt;
     PD_val    = d_val;
@@ -408,7 +408,7 @@ void EnvelopeParams::ADSRinit_filter(char a_val,
 void EnvelopeParams::ASRinit_bw(char a_val, float a_dt, char r_val, float r_dt)
 {
     setpresettype("Penvbandwidth");
-    Envmode   = 5;
+    Envmode   = ASR_bw;
     PA_val    = a_val;
     A_dt      = a_dt;
     PR_val    = r_val;
@@ -424,8 +424,8 @@ void EnvelopeParams::ASRinit_bw(char a_val, float a_dt, char r_val, float r_dt)
 void EnvelopeParams::converttofree()
 {
     switch(Envmode) {
-        case 1:
-        case 2:
+        case ADSR_lin:
+        case ADSR_dB:
             Penvpoints  = 4;
             Penvsustain = 2;
             Penvval[0]  = 0;
@@ -436,8 +436,8 @@ void EnvelopeParams::converttofree()
             envdt[3]   = R_dt;
             Penvval[3]  = 0;
             break;
-        case 3:
-        case 5:
+        case ASR_freqlfo:
+        case ASR_bw:
             Penvpoints  = 3;
             Penvsustain = 1;
             Penvval[0]  = PA_val;
@@ -446,7 +446,7 @@ void EnvelopeParams::converttofree()
             envdt[2]   = R_dt;
             Penvval[2]  = PR_val;
             break;
-        case 4:
+        case ADSR_filter:
             Penvpoints  = 4;
             Penvsustain = 2;
             Penvval[0]  = PA_val;

--- a/src/Params/EnvelopeParams.h
+++ b/src/Params/EnvelopeParams.h
@@ -19,6 +19,14 @@
 #include "Presets.h"
 
 namespace zyn {
+    
+   enum envmode_enum {
+        ADSR_lin,
+        ADSR_dB,
+        ASR_freqlfo,
+        ADSR_filter,
+        ASR_bw
+    };
 
 class EnvelopeParams:public Presets
 {
@@ -55,12 +63,15 @@ class EnvelopeParams:public Presets
         unsigned char PA_val, PD_val, PS_val, PR_val;
 
 
+        
 
-        int Envmode; // 1 for ADSR parameters (linear amplitude)
+        envmode_enum Envmode; // 1 for ADSR parameters (linear amplitude)
                      // 2 for ADSR_dB parameters (dB amplitude)
                      // 3 for ASR parameters (frequency LFO)
                      // 4 for ADSR_filter parameters (filter parameters)
                      // 5 for ASR_bw parameters (bandwidth parameters)
+                    
+
 
         const AbsTime *time;
         int64_t last_update_timestamp;

--- a/src/Params/EnvelopeParams.h
+++ b/src/Params/EnvelopeParams.h
@@ -21,11 +21,11 @@
 namespace zyn {
     
    enum envmode_enum {
-        ADSR_lin,
-        ADSR_dB,
-        ASR_freqlfo,
-        ADSR_filter,
-        ASR_bw
+        ADSR_lin = 1,
+        ADSR_dB = 2,
+        ASR_freqlfo = 3,
+        ADSR_filter = 4,
+        ASR_bw = 5
     };
 
 class EnvelopeParams:public Presets

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -150,7 +150,7 @@ float Envelope::envout(bool doWatch)
         envoutval = envval[envsustain];
         bool zerorelease = true;
         for (auto i = envsustain; i<envpoints; i++)
-            if (envval[envsustain] != -40.0f) zerorelease = false;
+            if (envval[i] != -40.0f) zerorelease = false;
         if (zerorelease &&                             //if sustaining at zero with zero until env ends
             (mode == ADSR_lin || mode == ADSR_dB)) {   // and its an amp envelope
             envfinish = true;   // finish voice to free ressources

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -145,8 +145,12 @@ float Envelope::envout(bool doWatch)
         }
         return envoutval;
     }
+
     if((currentpoint == envsustain + 1) && !keyreleased) { //if it is sustaining now
         envoutval = envval[envsustain];
+        if (envval[envsustain] == -40.0f && envval[envsustain+1] == -40.0f) { //if sustaining at zero with zero release
+            envfinish = true;   // finish voice to free ressources
+        }
         if(doWatch) {
             watch(envsustain, envoutval);
         }
@@ -159,7 +163,7 @@ float Envelope::envout(bool doWatch)
         if(envdt[tmp] < 0.00000001f)
             out = envval[tmp];
         else
-            out = envoutval + (envval[tmp] - envoutval) * t;
+            out = envoutval + (envval[tmp] - envoutval) * t; // linear interpolation envoutval and envval[tmp]
 
         t += envdt[tmp] * envstretch;
 

--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -148,7 +148,11 @@ float Envelope::envout(bool doWatch)
 
     if((currentpoint == envsustain + 1) && !keyreleased) { //if it is sustaining now
         envoutval = envval[envsustain];
-        if (envval[envsustain] == -40.0f && envval[envsustain+1] == -40.0f) { //if sustaining at zero with zero release
+        bool zerorelease = true;
+        for (auto i = envsustain; i<envpoints; i++)
+            if (envval[envsustain] != -40.0f) zerorelease = false;
+        if (zerorelease &&                             //if sustaining at zero with zero until env ends
+            (mode == ADSR_lin || mode == ADSR_dB)) {   // and its an amp envelope
             envfinish = true;   // finish voice to free ressources
         }
         if(doWatch) {

--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -181,7 +181,7 @@ envfree->redraw();}
       }
       Fl_Button {} {
         label {Cancel}
-	tooltip {Cancel freemode editing}
+    tooltip {Cancel freemode editing}
         callback {disable_freemode();}
         xywh {5 155 80 20} box THIN_UP_BOX labelsize 11 labelcolor 1
         class Fl_Osc_Button

--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -181,7 +181,7 @@ envfree->redraw();}
       }
       Fl_Button {} {
         label {Cancel}
-    tooltip {Cancel freemode editing}
+        tooltip {Cancel freemode editing}
         callback {disable_freemode();}
         xywh {5 155 80 20} box THIN_UP_BOX labelsize 11 labelcolor 1
         class Fl_Osc_Button


### PR DESCRIPTION
This modification can free up some cpu time when playing with many sustained notes with many voices with different decay times. It should not have any sonical impact because it removes inaudible voices only.