### PR TITLE
make /distorsion/waveform reflect the Pvolume par

### DIFF
--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -69,19 +69,20 @@ rtosc::Ports Distorsion::ports = {
     {"waveform:", 0, 0, [](const char *, rtosc::RtData &d)
         {
             Distorsion  &dd = *(Distorsion*)d.obj;
-            float        buffer[128];
+            float        buffer[128], orig[128];
             rtosc_arg_t  args[128];
             char         arg_str[128+1] = {};
 
             for(int i=0; i<128; ++i)
                 buffer[i] = 2*(i/128.0)-1;
+            memcpy(orig, buffer, sizeof(float_t)*128);
 
             waveShapeSmps(sizeof(buffer)/sizeof(buffer[0]), buffer,
                     dd.Ptype + 1, dd.Pdrive, dd.Poffset, dd.Pfuncpar);
 
             for(int i=0; i<128; ++i) {
                 arg_str[i] = 'f';
-                args[i].f  = buffer[i];
+                args[i].f  = (dd.Pvolume * buffer[i] + (127 - dd.Pvolume) * orig[i]) / 127.0f;
             }
 
             d.replyArray(d.loc, arg_str, args);


### PR DESCRIPTION
with this patch the waveform view in the distorsion effect reflects the effect of the AMT knob in zest (Pvolume par) in the way you hear it. At Pvolume=0 you hear no distorsion -> Transferfunction is linear. Now in waveview, too.