### PR TITLE
performance improvements in distorsion and adnote

### DIFF
--- a/src/Effects/Distorsion.cpp
+++ b/src/Effects/Distorsion.cpp
@@ -135,11 +135,11 @@ void Distorsion::cleanup(void)
 //Apply the filters
 void Distorsion::applyfilters(float *efxoutl, float *efxoutr)
 {
-    lpfl->filterout(efxoutl);
-    hpfl->filterout(efxoutl);
+    if(Plpf!=127) lpfl->filterout(efxoutl);
+    if(Phpf!=0) hpfl->filterout(efxoutl);
     if(Pstereo != 0) { //stereo
-        lpfr->filterout(efxoutr);
-        hpfr->filterout(efxoutr);
+        if(Plpf!=127) lpfr->filterout(efxoutr);
+        if(Phpf!=0) hpfr->filterout(efxoutr);
     }
 }
 

--- a/src/Misc/WaveShapeSmps.cpp
+++ b/src/Misc/WaveShapeSmps.cpp
@@ -25,13 +25,13 @@ float polyblampres(float smp, float ws, float dMax)
     // [−T, 0] −d^5/40 + d^4/24 + d^3/12 + d^2/12 + d/24 + 1/120
     // [0, T] d^5/40 − d^4/12 + d^2/3 − d/2 + 7/30
     // [T, 2T] −d^5/120 + d^4/24 − d^3/12 + d^2/12 − d/24 + 1/120
-
+    if (dMax == 0) return 0.0;
     float dist = fabsf(smp) - ws;
     float res, d1, d2, d3, d4, d5;
     if(fabsf(dist) < dMax) {
         if(dist < -dMax/2.0f) {
             d1 = (dist + dMax)/dMax*2.0f;   // [-dMax ... -dMax/2] -> [0 ... 1]
-            res = powf(d1, 5.0f) / 120.0f;
+            res = d1 * d1 * d1 * d1 * d1 / 120.0f;
         }
         else if(dist < 0.0f) {
             d1 = (dist + dMax/2.0f)/dMax*2.0f; // [-dMax/2 ... 0] -> [0 ... 1]
@@ -100,7 +100,7 @@ void waveShapeSmps(int n,
             for(i = 0; i < n; ++i) {
                 smps[i] *= ws;
                 if(fabsf(smps[i]) < 1.0f) {
-                    smps[i] = (smps[i] - powf(smps[i], 3.0f)) * 3.0f;
+                    smps[i] = (smps[i] - smps[i] * smps[i] * smps[i]) * 3.0f;
                     if(ws < 1.0f)
                         smps[i] /= ws;
                 }
@@ -274,11 +274,11 @@ void waveShapeSmps(int n,
                 smps[i] *= ws; // multiply signal to drive it in the saturation of the function
                 smps[i] += offs; // add dc offset
                 if(fabsf(smps[i]) < 1.0f)
-                    smps[i] = 1.5 * (smps[i] - (powf(smps[i], 3.0) / 3.0) );
+                    smps[i] = 1.5 * (smps[i] - (smps[i]*smps[i]*smps[i] / 3.0) );
                 else
                     smps[i] = (smps[i] > 0 ? 1.0f : -1.0f);
                 //subtract offset with distorsion function applied
-                smps[i] -= 1.5 * (offs - (powf(offs, 3.0) / 3.0)); 
+                smps[i] -= 1.5 * (offs - (offs*offs*offs / 3.0)); 
             }
             break;
         case 17:

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1222,21 +1222,21 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
     Voice& vce = NoteVoicePar[nvoice];
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
-        int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
+        int    poslo  = (int)(vce.oscposlo[k] * (0x01000000));
         int    freqhi = vce.oscfreqhi[k];
-        int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
+        int    freqlo = (int)(vce.oscfreqlo[k] * (0x01000000));
         float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);
         for(int i = 0; i < synth.buffersize; ++i) {
-            tw[i]  = (smps[poshi] * ((1<<24) - poslo) + smps[poshi + 1] * poslo)/(1.0f*(1<<24));
+            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
             poslo += freqlo;
             poshi += freqhi + (poslo>>24);
             poslo &= 0xffffff;
             poshi &= synth.oscilsize - 1;
         }
         vce.oscposhi[k] = poshi;
-        vce.oscposlo[k] = poslo/(1.0f*(1<<24));
+        vce.oscposlo[k] = poslo/(16777216.0f);
     }
 }
 

--- a/src/Synth/ADnote.cpp.orig
+++ b/src/Synth/ADnote.cpp.orig
@@ -1218,16 +1218,24 @@ inline void ADnote::fadein(float *smps) const
  */
 inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
 {
+<<<<<<< HEAD
     Voice& vce = NoteVoicePar[nvoice];
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
+        int    poslo  = (int)(vce.oscposlo[k] * (0x01000000));
+        int    freqhi = vce.oscfreqhi[k];
+        int    freqlo = (int)(vce.oscfreqlo[k] * (0x01000000));
+=======
+    for(int k = 0; k < unison_size[nvoice]; ++k) {
+        int    poshi  = oscposhi[nvoice][k];
         // convert floating point fractional part (sample interval phase) 
         // with range [0.0 ... 1.0] to fixed point with 1 digit is 2^-24
         // by multiplying with precalculated 2^24 and casting to integer:
-        int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
-        int    freqhi = vce.oscfreqhi[k];
+        int    poslo  = (int)(oscposlo[nvoice][k] * 16777216.0f); 
+        int    freqhi = oscfreqhi[nvoice][k];
         // same for phase increment:
-        int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
+        int    freqlo = (int)(oscfreqlo[nvoice][k] * 16777216.0f);
+>>>>>>> adsynth more comments and small fixes
         float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);
@@ -1285,7 +1293,7 @@ inline void ADnote::ComputeVoiceOscillator_SincInterpolation(int nvoice)
         0.004273442181254887f,
         0.0010596256917418426f
         };
-
+<<<<<<< HEAD
         
     
     Voice& vce = NoteVoicePar[nvoice];
@@ -1296,7 +1304,18 @@ inline void ADnote::ComputeVoiceOscillator_SincInterpolation(int nvoice)
         int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
         int    ovsmpfreqhi = vce.oscfreqhi[k] / 2;
         int    ovsmpfreqlo = (int)((vce.oscfreqlo[k] / 2) * (1<<24));
+        
+=======
 
+    for(int k = 0; k < unison_size[nvoice]; ++k) {
+        int    poshi  = oscposhi[nvoice][k];
+        int    poslo  = (int)(oscposlo[nvoice][k] * (1<<24));
+        int    freqhi = oscfreqhi[nvoice][k];
+        int    freqlo = (int)(oscfreqlo[nvoice][k] * (1<<24));
+        int    ovsmpfreqhi = oscfreqhi[nvoice][k] / 2;
+        int    ovsmpfreqlo = (int)((oscfreqlo[nvoice][k] / 2) * (1<<24));
+
+>>>>>>> adsynth more comments and small fixes
         int    ovsmpposlo; 
         int    ovsmpposhi;
         int    uflow;
@@ -1321,7 +1340,6 @@ inline void ADnote::ComputeVoiceOscillator_SincInterpolation(int nvoice)
                 ovsmpposhi += ovsmpfreqhi + (ovsmpposlo>>24); // add the 24-bit overflow
                 ovsmpposlo &= 0xffffff;
                 ovsmpposhi &= synth.oscilsize - 1;
-
             }
 
             // advance to next sample
@@ -1337,7 +1355,6 @@ inline void ADnote::ComputeVoiceOscillator_SincInterpolation(int nvoice)
         vce.oscposlo[k] = poslo/(1.0f*(1<<24));
     }
 }
-
 
 /*
  * Computes the Oscillator (Mixing)


### PR DESCRIPTION
lp/hp filter in distorsion effect are only calculated if cutoff freq parameter is not at max/min value.
slow powf operations in waveshaper replaced by multiplications
some precalculations in adsynth to speed up linerar interp oscillator