### PR TITLE
in fractional tunings, allow numerator/denominator greater than 127

### DIFF
--- a/src/Misc/Microtonal.cpp
+++ b/src/Misc/Microtonal.cpp
@@ -820,8 +820,8 @@ void Microtonal::getfromXML(XMLwrapper& xml)
                 octave[i].x2     = 0;
                 octave[i].tuning_log2 = log2f(xml.getparreal("cents",
                     powf(2.0f, octave[i].tuning_log2))) / log2(2.0f);
-                octave[i].x1     = xml.getpar127("numerator", octave[i].x1);
-                octave[i].x2     = xml.getpar127("denominator", octave[i].x2);
+                octave[i].x1     = xml.getpar("numerator", octave[i].x1, 0, 65535);
+                octave[i].x2     = xml.getpar("denominator", octave[i].x2, 0, 65535);
 
                 if(octave[i].x2 != 0)
                     octave[i].type = 2;


### PR DESCRIPTION
Tunings with numerators/denominators work during a session, but when loaded from a file, the values are limited to 0 <= x <= 127. This commit increases that limit to a safe one.

N.B. It's quite easy to end up with very complex fractions when tinkering with exotic tunings; see for instance the table at https://en.wikipedia.org/wiki/The_Well-Tuned_Piano#Tuning .