### PR TITLE
[CYGWIN] Add support for this platform.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,6 +338,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     add_definitions(-DWIN32)
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "CYGWIN")
+    add_definitions(-D_GNU_SOURCE=1 -D_POSIX_THREAD_PRIO_INHERIT=1)
+endif()
+
 add_definitions(
 	 -Wall
 	 -Wextra


### PR DESCRIPTION
When building under CYGWIN, I got few errors because some stuff, like `usleep()`, was not declared.
Actually, everything already exists in CYGWIN, but when compiling under C++11, some prototypes and symbols are intentionally deactivated and they need to be activated manually with some macros like `_GNU_SOURCE`, `_BSD_SOURCE` or others.
The addition of the required macros in this commit allows to activate the required symbols and compile the sources successfully.