### PR TITLE
[CMAKE] Fix detection of OSS

### DIFF
--- a/cmake/FindOSS.cmake
+++ b/cmake/FindOSS.cmake
@@ -1,4 +1,11 @@
 # Find OSS (Open Sound System)
+
+# OSS is not for APPLE or WINDOWS
+
+IF(APPLE OR WIN32)
+  RETURN()
+ENDIF()
+
 find_path(OSS_INCLUDE_DIR sys/soundcard.h)
 set(OSS_LIBRARIES True)
 mark_as_advanced(OSS_INCLUDE_DIR)


### PR DESCRIPTION
When compiling for Windows, I discovered that CMake reported that OSS was found, which is not true since it is known to be unsupported by that platform.
I suggest to fix the included CMake script to avoid detection under WIN32 and also under APPLE.
This fix has been inspired by the FindOSS script implemented for GNUradio:

https://github.com/gnuradio/gnuradio/blob/master/cmake/Modules/FindOSS.cmake