### PR TITLE
Do not define HAVE_SCHEDULER if OS does not have it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   add_definitions(-static)
 endif()
 
-if(NOT "Darwin" STREQUAL ${CMAKE_SYSTEM_NAME})
+if(HAVE_SCHEDULER AND (NOT "Darwin" STREQUAL ${CMAKE_SYSTEM_NAME}))
     # Add scheduler function existence info (OSX compatibility)
     add_definitions(-DHAVE_SCHEDULER=${HAVE_SCHEDULER})
 endif()


### PR DESCRIPTION
"#ifdef HAVE_SCHEDULER" in Util.cpp does not work correctly,
since cmake always defines "add_definitions(-DHAVE_SCHEDULER=" except Darwin.
It should not define HAVE_SCHEDULER if OS does not have it.