### PR TITLE
Include <complex> other than APPLE and FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ CHECK_CXX_SOURCE_COMPILES(
 
 check_cxx_compiler_flag("-msse2" SUPPORT_SSE)
 check_cxx_compiler_flag("-mfpu=neon -Werror" SUPPORT_NEON)
+check_include_file_cxx(complex HAVE_CPP_STD_COMPLEX)
 
 set(CMAKE_REQUIRED_FLAGS "")
 
@@ -118,6 +119,10 @@ if(HAVE_ASYNC)
     add_definitions(-DHAVE_ASYNC=1)
 else()
     add_definitions(-DHAVE_ASYNC=0)
+endif()
+
+if(HAVE_CPP_STD_COMPLEX)
+    add_definitions(-DHAVE_CPP_STD_COMPLEX=1)
 endif()
 
 if(DemoMode)

--- a/src/globals.h
+++ b/src/globals.h
@@ -26,7 +26,7 @@
 
 //Forward Declarations
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(HAVE_CPP_STD_COMPLEX)
 #include <complex>
 #else
 namespace std {


### PR DESCRIPTION
Currently, only APPLE and FreeBSD can include C++ std::complex in globals.h.
Check if OS has C++ std::complex, and use this condition to include or not in globals.h, instead of checking OS macro.