### PR TITLE
Get the X11 library path only if libX11 exists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -341,7 +341,9 @@ message(STATUS "Compiling with liblo")
 include_directories(${ZLIB_INCLUDE_DIRS} ${MXML_INCLUDE_DIRS})
 include_directories(${CMAKE_BINARY_DIR}/src) # for zyn-version.h ...
 
-get_filename_component(X11_LIBRARY_DIRS ${X11_X11_LIB} DIRECTORY)
+if(NOT ${X11_X11_LIB} STREQUAL "")
+    get_filename_component(X11_LIBRARY_DIRS ${X11_X11_LIB} DIRECTORY)
+endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     add_definitions(-DWIN32)


### PR DESCRIPTION
Additional fix for merged PR #73 .
I had checked build on travis-ci only, and I should have thought about Windows build, too.
I think this PR is able to resolve this comment.
https://github.com/zynaddsubfx/zynaddsubfx/commit/4ad23b090e2ea64c637adfd41ffa81887080b43d#commitcomment-40545890

@carlo-bramini could you try to see if this PR resolves your issue, please ?
