### PR TITLE
src/Nio: Fix missing CMake include when JACK is enabled

### DIFF
--- a/src/Nio/CMakeLists.txt
+++ b/src/Nio/CMakeLists.txt
@@ -21,6 +21,7 @@ add_definitions(-DOUT_DEFAULT="${DefaultOutput}")
 add_definitions(-DIN_DEFAULT="${DefaultInput}")
 
 if(JackEnable)
+    INCLUDE(CheckIncludeFiles)
     include_directories(${JACK_INCLUDE_DIR})
     list(APPEND zynaddsubfx_nio_SRCS JackEngine.cpp JackMultiEngine.cpp)
     list(APPEND zynaddsubfx_nio_lib ${JACK_LIBRARIES})


### PR DESCRIPTION
Small fix for a missing CMake include. Compilation would fail when building with only JACK enabled because `CheckIncludeFiles` wasn't included. It wouldn't fail when for example ALSA was enabled as well because within the CMake config for ALSA it would include `CheckIncludeFiles` which made it work for JACK as well, it's probably gone unnoticed so far because of this.