### PR TITLE
Disable gcc optimizations for a specific function

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -1282,8 +1282,12 @@ void save_cb(const char *msg, RtData &d)
                 file.c_str(), request_time);
 }
 
-void
-gcc_10_1_0_is_dumb(const std::vector<std::string> &files,
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#pragma GCC push_options
+#pragma GCC optimize("O0")
+#endif
+
+void gcc_10_1_0_is_dumb(const std::vector<std::string> &files,
         const int N,
         char *types,
         rtosc_arg_t *args)
@@ -1294,6 +1298,10 @@ gcc_10_1_0_is_dumb(const std::vector<std::string> &files,
             types[i]  = 's';
         }
 }
+
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#pragma GCC pop_options
+#endif
 
 /*
  * BASE/part#/kititem#
@@ -1440,7 +1448,6 @@ static rtosc::Ports middwareSnoopPorts = {
         const int N = files.size();
         rtosc_arg_t *args  = new rtosc_arg_t[N];
         char        *types = new char[N+1];
-        string      *data  = files.data();
         gcc_10_1_0_is_dumb(files, N, types, args);
 
         d.replyArray(d.loc, types, args);


### PR DESCRIPTION
Due to a gcc opt bug a piece of code was put in a separate function to
prevent gcc from optimizing it. Later versions of gcc inlined the
function and the bug reappeared. So now we explicitly tell gcc to not
optimize it.

https://github.com/zynaddsubfx/zyn-fusion-build/issues/65