### PR TITLE
make the cutoff in LFO a member variable

### DIFF
--- a/src/Synth/LFO.cpp
+++ b/src/Synth/LFO.cpp
@@ -126,7 +126,6 @@ float LFO::baseOut(const char waveShape, const float phase)
 float LFO::biquad(float input)
 {
     float output;
-    char cutoff = 127;
     if (lfopars_.Pcutoff!=cutoff ) // calculate coeffs only if cutoff changed
     {
         cutoff = lfopars_.Pcutoff;

--- a/src/Synth/LFO.h
+++ b/src/Synth/LFO.h
@@ -77,6 +77,8 @@ class LFO
         float a2 = 0.0007508914611009499;
         float b1 = -1.519121359805288;
         float b2 =  0.5221249256496917;
+        
+        char cutoff = 127;
 
         VecWatchPoint watchOut;
 


### PR DESCRIPTION
fix a small bug that lets the biquad calculate also at unchanged cutoff value.