### PR TITLE
path-search/save_osc: include non-RT ports

### DIFF
--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -27,7 +27,7 @@ namespace zyn {
 #define rEnd }
 
 rtosc::Ports DynamicFilter::ports = {
-    {"preset::i", rOptions(WahWah, AutoWah, Sweep, VocalMorph1, VocalMorph1)
+    {"preset::i", rOptions(WahWah, AutoWah, Sweep, VocalMorph1, VocalMorph2)
                   rDoc("Instrument Presets"), 0,
                   rBegin;
                   rObject *o = (rObject*)d.obj;
@@ -286,7 +286,7 @@ unsigned char DynamicFilter::getpresetpar(unsigned char npreset, unsigned int np
         {100, 64, 30, 0, 0, 50, 80, 0,  0, 60},
         //VocalMorph1
         {110, 64, 80, 0, 0, 64, 0,  64, 0, 60},
-        //VocalMorph1
+        //VocalMorph2
         {127, 64, 50, 0, 0, 96, 64, 0,  0, 60}
     };
     if(npreset < NUM_PRESETS && npar < PRESET_SIZE) {

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -68,15 +68,15 @@ static const Ports sysefxPort =
             assert(isdigit(*index_1));
             if(isdigit(index_1[-1]))
                 index_1--;
-            int ind1 = atoi(index_1);
+            int ind1 = atoi(index_1); //efx
 
             //Now get the second index like normal
             while(!isdigit(*m)) m++;
-            int ind2 = atoi(m);
+            int ind2 = atoi(m); //part
             Master &mast = *(Master*)d.obj;
 
             if(rtosc_narguments(m)) {
-                mast.setPsysefxvol(ind2, ind1, rtosc_argument(m,0).i);
+                mast.setPsysefxvol(ind2, ind1, rtosc_argument(m,0).i /*vol*/);
                 d.broadcast(d.loc, "i", mast.Psysefxvol[ind1][ind2]);
             } else
                 d.reply(d.loc, "i", mast.Psysefxvol[ind1][ind2]);

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -75,17 +75,8 @@ class Master
          * @return 0 for ok or -1 if there is an error*/
         int loadXML(const char *filename);
 
-        /**Save all settings to an OSC file (as specified by RT OSC)
-         * When the function returned, the OSC file has been either saved or
-         * an error occurred.
-         * @param filename File to save to or NULL (useful for testing)
-         * @param dispatcher Message dispatcher and modifier
-         * @param master2 An empty master dummy where the savefile will be
-         *                loaded to and compared with the current master
-         * @return 0 for ok or <0 if there is an error*/
-        int saveOSC(const char *filename,
-                    class master_dispatcher_t* dispatcher,
-                    Master* master2);
+        /**Append all settings to an OSC savefile (as specified by RT OSC)*/
+        std::string saveOSC(std::string savefile);
         /**loads all settings from an OSC file (as specified by RT OSC)
          * @param dispatcher Message dispatcher and modifier
          * @return 0 for ok or <0 if there is an error*/
@@ -228,6 +219,13 @@ class Master
         constexpr static std::size_t dnd_buffer_size = 1024;
         char dnd_buffer[dnd_buffer_size] = {0};
 
+        //Return XML data as string. Must be freed.
+        char* getXMLData();
+        //Load OSC from OSC savefile
+        //Returns 0 if OK, <0 in case of failure
+        int loadOSCFromStr(const char *file_content,
+                           rtosc::savefile_dispatcher_t* dispatcher);
+
     private:
         std::atomic<bool> run_osc_in_use = { false };
 
@@ -245,11 +243,6 @@ class Master
         void(*mastercb)(void*,Master*);
         void* mastercb_ptr;
 
-        //Return XML data as string. Must be freed.
-        char* getXMLData();
-        //Used by loadOSC and saveOSC
-        int loadOSCFromStr(const char *file_content,
-                           rtosc::savefile_dispatcher_t* dispatcher);
         //! apply an OSC event with a DataObj parameter
         //! @note This may be called by MiddleWare if we are offline
         //!   (in this case, the param offline is true)

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -95,6 +95,11 @@ static void liblo_error_cb(int i, const char *m, const char *loc)
     fprintf(stderr, "liblo :-( %d-%s@%s\n",i,m,loc);
 }
 
+// we need to access those earlier
+// bad style?
+static const rtosc::MergePorts& getParameterPorts();
+static const rtosc::Ports& getNonRtParamPorts();
+
 static int handler_function(const char *path, const char *types, lo_arg **argv,
         int argc, lo_message msg, void *user_data)
 {
@@ -122,7 +127,7 @@ static int handler_function(const char *path, const char *types, lo_arg **argv,
     {
         char reply_buffer[1024*20];
         std::size_t length =
-            rtosc::path_search(Master::ports, buffer, 128,
+            rtosc::path_search(getParameterPorts(), buffer, 128,
                                reply_buffer, sizeof(reply_buffer));
         if(length) {
             lo_message msg  = lo_message_deserialise((void*)reply_buffer,
@@ -343,6 +348,10 @@ struct NonRtObjStore
 
     void handleOscil(const char *msg, rtosc::RtData &d) {
         string obj_rl(d.message, msg);
+        assert(d.message);
+        assert(msg);
+        assert(msg >= d.message);
+        assert(msg - d.message < 256);
         void *osc = get(obj_rl);
         if(osc)
         {
@@ -646,7 +655,11 @@ public:
         return 0;
     }
 
-    int saveMaster(const char *filename, bool osc_format = false)
+    // Save all possible parameters
+    // In user language, this is called "saving a master", but we
+    // are saving parameters owned by Master and by MiddleWare
+    // Return 0 if OK, <0 if not
+    int saveParams(const char *filename, bool osc_format = false)
     {
         int res;
         if(osc_format)
@@ -665,9 +678,98 @@ public:
             master->copyMasterCbTo(&master2);
             master2.frozenState = true;
 
-            doReadOnlyOp([this,filename,&dispatcher,&master2,&res](){
-                             res = master->saveOSC(filename, &dispatcher,
-                                                   &master2);});
+            std::string savefile;
+            rtosc_version m_version =
+            {
+                (unsigned char) version.get_major(),
+                (unsigned char) version.get_minor(),
+                (unsigned char) version.get_revision()
+            };
+            savefile = rtosc::save_to_file(getNonRtParamPorts(), this, "ZynAddSubFX", m_version);
+            savefile += '\n';
+
+            doReadOnlyOp([this,filename,&dispatcher,&master2,&savefile,&res]()
+            {
+                savefile = master->saveOSC(savefile);
+
+                // load the savefile string into another master to compare the results
+                // between the original and the savefile-loaded master
+                // this requires a temporary master switch
+                Master* old_master = master;
+                dispatcher.updateMaster(&master2);
+
+                res = master2.loadOSCFromStr(savefile.c_str(), &dispatcher);
+                // TODO: compare MiddleWare, too?
+
+                // The above call is done by this thread (i.e. the MiddleWare thread), but
+                // it sends messages to master2 in order to load the values
+                // We need to wait until savefile has been loaded into master2
+                int i;
+                for(i = 0; i < 20 && master2.uToB->hasNext(); ++i)
+                    os_usleep(50000);
+                if(i >= 20) // >= 1 second?
+                {
+                    // Master failed to fetch its messages
+                    res = -1;
+                }
+                printf("Saved in less than %d ms.\n", 50*i);
+
+                dispatcher.updateMaster(old_master);
+
+                if(res < 0)
+                {
+                    std::cerr << "invalid savefile (or a backend error)!" << std::endl;
+                    std::cerr << "complete savefile:" << std::endl;
+                    std::cerr << savefile << std::endl;
+                    std::cerr << "first entry that could not be parsed:" << std::endl;
+
+                    for(int i = -res + 1; savefile[i]; ++i)
+                    if(savefile[i] == '\n')
+                    {
+                        savefile.resize(i);
+                        break;
+                    }
+                    std::cerr << (savefile.c_str() - res) << std::endl;
+
+                    res = -1;
+                }
+                else
+                {
+                    char* xml = master->getXMLData(),
+                        * xml2 = master2.getXMLData();
+                    // TODO: below here can be moved out of read only op
+
+                    res = strcmp(xml, xml2) ? -1 : 0;
+
+                    if(res == 0)
+                    {
+                        if(filename && *filename)
+                        {
+                            std::ofstream ofs(filename);
+                            ofs << savefile;
+                        }
+                        else {
+                            std::cout << "The savefile content follows" << std::endl;
+                            std::cout << "---->8----" << std::endl;
+                            std::cout << savefile << std::endl;
+                            std::cout << "---->8----" << std::endl;
+                        }
+                    }
+                    else
+                    {
+                        std::cout << savefile << std::endl;
+                        std::cerr << "Can not write OSC savefile!! (see tmp1.txt and tmp2.txt)"
+                                  << std::endl;
+                        std::ofstream tmp1("tmp1.txt"), tmp2("tmp2.txt");
+                        tmp1 << xml;
+                        tmp2 << xml2;
+                        res = -1;
+                    }
+
+                    free(xml);
+                    free(xml2);
+                }
+            });
         }
         else // xml format
         {
@@ -1289,7 +1391,7 @@ void save_cb(const char *msg, RtData &d)
     if(rtosc_narguments(msg) > 1)
         request_time = rtosc_argument(msg, 1).t;
 
-    int res = impl.saveMaster(file.c_str(), osc_format);
+    int res = impl.saveParams(file.c_str(), osc_format);
     d.broadcast(d.loc, (res == 0) ? "stT" : "stF",
                 file.c_str(), request_time);
 }
@@ -1322,7 +1424,7 @@ void gcc_10_1_0_is_dumb(const std::vector<std::string> &files,
  * BASE/part#/kit#/padpars/prepare
  * BASE/part#/kit#/padpars/oscil/\*
  */
-static rtosc::Ports middwareSnoopPorts = {
+static rtosc::Ports nonRtParamPorts = {
     {"part#" STRINGIFY(NUM_MIDI_PARTS)
         "/kit#" STRINGIFY(NUM_KIT_ITEMS) "/adpars/VoicePar#"
             STRINGIFY(NUM_VOICES) "/OscilSmp/", 0, &OscilGen::non_realtime_ports,
@@ -1340,6 +1442,9 @@ static rtosc::Ports middwareSnoopPorts = {
         rBegin
         impl.obj_store.handlePad(chomp(chomp(chomp(msg))), d);
         rEnd},
+};
+
+static rtosc::Ports middwareSnoopPortsWithoutNonRtParams = {
     {"bank/", 0, &bankPorts,
         rBegin;
         d.obj = &impl.master->bank;
@@ -1630,6 +1735,22 @@ static rtosc::Ports middwareSnoopPorts = {
         rEnd
     }
 };
+
+static rtosc::MergePorts middwareSnoopPorts =
+{
+    &nonRtParamPorts,
+    &middwareSnoopPortsWithoutNonRtParams
+};
+
+static rtosc::MergePorts parameterPorts =
+{
+    // order is important: params should be queried on Master first
+    // (because MiddleWare often just redirects, hiding the metadata)
+    &Master::ports,
+    &nonRtParamPorts
+};
+const rtosc::MergePorts& getParameterPorts() { return parameterPorts; }
+const rtosc::Ports& getNonRtParamPorts() { return nonRtParamPorts; }
 
 static rtosc::Ports middlewareReplyPorts = {
     {"echo:ss", 0, 0,

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -350,9 +350,15 @@ struct NonRtObjStore
             d.obj = osc;
             OscilGen::non_realtime_ports.dispatch(msg, d);
         }
-        else
-            fprintf(stderr, "Warning: trying to access oscil object \"%s\","
-                            "which does not exist\n", obj_rl.c_str());
+        else {
+            // print warning, except in rtosc::walk_ports
+            if(obj_rl.find("/pointer") == obj_rl.npos)
+            {
+                fprintf(stderr, "Warning: trying to access oscil object \"%s\","
+                                "which does not exist\n", obj_rl.c_str());
+            }
+            d.obj = nullptr; // tell walk_ports that there's nothing to recurse here...
+        }
     }
     void handlePad(const char *msg, rtosc::RtData &d) {
         string obj_rl(d.message, msg);
@@ -375,10 +381,16 @@ struct NonRtObjStore
                     }
                 }
             }
-            else
-                fprintf(stderr, "Warning: trying to access pad synth object "
-                                "\"%s\", which does not exist\n",
-                        obj_rl.c_str());
+            else {
+                // print warning, except in rtosc::walk_ports
+                if(obj_rl.find("/pointer") == obj_rl.npos)
+                {
+                    fprintf(stderr, "Warning: trying to access pad synth object "
+                                    "\"%s\", which does not exist\n",
+                            obj_rl.c_str());
+                }
+                d.obj = nullptr; // tell walk_ports that there's nothing to recurse here...
+            }
         }
     }
 };

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -44,6 +44,7 @@ using rtosc::RtData;
 
 #define rObject Part
 static const Ports partPorts = {
+    rSelf(Part, rEnabledBy(Penabled)),
     rRecurs(kit, 16, "Kit"),//NUM_KIT_ITEMS
     rRecursp(partefx, 3, "Part Effect"),
     rRecur(ctl,       "Controller"),

--- a/src/Tests/MessageTest.h
+++ b/src/Tests/MessageTest.h
@@ -99,6 +99,23 @@ class MessageTest:public CxxTest::TestSuite
             start_realtime();
             mw->transmitMsg("/presets/copy", "s", "/part0/kit0/adpars/VoicePar0/FMSmp/");
 
+            TS_ASSERT_EQUALS(mw->getPresetsStore().clipboard.type.c_str(), string("Poscilgen"));
+            // a regex would be better here...
+            // hopefully, mxml will not change its whitespace behavior
+            TS_ASSERT(strstr(mw->getPresetsStore().clipboard.data.c_str(), "<par name=\"base_function_par\" value=\"32\" />"));
+
+            /* // better test this without string comparison:
+            {
+                XMLwrapper xml;
+                bool couldPutXml = xml.putXMLdata(mw->getPresetsStore().clipboard.data.c_str());
+                TS_ASSERT(couldPutXml);
+                unsigned char copiedBasefuncPar = xml.getpar127("base_function_par", 0);
+                TS_ASSERT_EQUALS(copiedBasefuncPar, 32);
+            }*/
+
+            //printf("clipboard type: %s\n",mw->getPresetsStore().clipboard.type.c_str());
+            //printf("clipboard data:\n%s\n",mw->getPresetsStore().clipboard.data.c_str());
+
             TS_ASSERT_EQUALS(osc_dst.Pbasefuncpar, 64);
             TS_ASSERT_EQUALS(osc_oth.Pbasefuncpar, 64);
 

--- a/src/Tests/check-ports.rb
+++ b/src/Tests/check-ports.rb
@@ -2,15 +2,36 @@
 
 require 'open3'
 
+rval=0
+
 # start zyn, grep the lo server port, and connect the port checker to it
 Open3.popen3(Dir.pwd + "/../zynaddsubfx -O null --no-gui") do |stdin, stdout, stderr, wait_thr|
   pid = wait_thr[:pid]
   while line=stderr.gets do 
     # print "line: " + line;
     if /^lo server running on (\d+)$/.match(line) then
-      rval = system(Dir.pwd + "/../../rtosc/port-checker 'osc.udp://localhost:" + $1 + "/'")
-      Process.kill("KILL", pid)
-      exit rval
+      port_checker_rval = system(Dir.pwd + "/../../rtosc/port-checker 'osc.udp://localhost:" + $1 + "/'")
+      if port_checker_rval != true then
+        puts "Error: port-checker has returned #{$?.exitstatus}."
+        rval=1
+      end
+      begin
+        # Check if zyn has not crashed yet
+        # Wait 1 second before detection
+        sleep 1
+        Process.kill(0, pid)
+        # This is only executed if Process.kill did not raise an exception
+        Process.kill("KILL", pid)
+      rescue Errno::ESRCH
+        puts "Error: ZynAddSubFX (PID #{pid}) crashed!"
+        puts "       Missing replies or port-checker crashes could be due to the crash."
+        rval=1
+      rescue
+        puts "Error: Cannot kill ZynAddSubFX (PID #{pid})?"
+        rval=1
+      end
     end
   end
 end
+
+exit rval

--- a/src/Tests/check-ports.rb
+++ b/src/Tests/check-ports.rb
@@ -3,14 +3,15 @@
 require 'open3'
 
 rval=0
+my_path=File.dirname(__FILE__)
 
 # start zyn, grep the lo server port, and connect the port checker to it
-Open3.popen3(Dir.pwd + "/../zynaddsubfx -O null --no-gui") do |stdin, stdout, stderr, wait_thr|
+Open3.popen3(my_path + "/../zynaddsubfx -O null --no-gui") do |stdin, stdout, stderr, wait_thr|
   pid = wait_thr[:pid]
   while line=stderr.gets do 
     # print "line: " + line;
     if /^lo server running on (\d+)$/.match(line) then
-      port_checker_rval = system(Dir.pwd + "/../../rtosc/port-checker 'osc.udp://localhost:" + $1 + "/'")
+      port_checker_rval = system(my_path + "/../../rtosc/port-checker 'osc.udp://localhost:" + $1 + "/'")
       if port_checker_rval != true then
         puts "Error: port-checker has returned #{$?.exitstatus}."
         rval=1


### PR DESCRIPTION
Split MW snoop ports into non-RT ports and other snoop ports, and then
    
* Let path-search iterate over non-RT ports, too (e.g. to let port-checker see those ports)
* Let save_osc save non-RT ports, too (to build complete savefiles)

This commit is a bug fix, because currently, port-checker does not look at the non-RT MW-ports, and it would make the SaveOsc tests fail if the test xmz would have non-RT ports changed (in comparison to the default values).

This commit is preparation for the wavetable-branch (SaveOsc failed there with the new non-RT ports).