### PR TITLE
path-search/save_osc: include non-RT ports

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -388,6 +388,7 @@ static const Ports master_ports = {
     rRecursp(part, 16, "Part"),//NUM_MIDI_PARTS
     rRecursp(sysefx, 4, "System Effect"),//NUM_SYS_EFX
     rRecursp(insefx, 8, "Insertion Effect"),//NUM_INS_EFX
+    rRecur(HDDRecorder, "HDD recorder"),
     rRecur(microtonal, "Microtonal Mapping Functionality"),
     rRecur(ctl, "Controller"),
     rArrayOption(Pinsparts, NUM_INS_EFX, rOpt(-2, Master), rOpt(-1, Off),
@@ -569,18 +570,6 @@ static const Ports master_ports = {
         SNIP
             preset_ports.dispatch(msg, data);
         rBOIL_END},
-    {"HDDRecorder/preparefile:s", rDoc("Init WAV file"), 0, [](const char *msg, RtData &d) {
-       Master *m = (Master*)d.obj;
-       m->HDDRecorder.preparefile(rtosc_argument(msg, 0).s, 1);}},
-    {"HDDRecorder/start:", rDoc("Start recording"), 0, [](const char *, RtData &d) {
-       Master *m = (Master*)d.obj;
-       m->HDDRecorder.start();}},
-    {"HDDRecorder/stop:", rDoc("Stop recording"), 0, [](const char *, RtData &d) {
-       Master *m = (Master*)d.obj;
-       m->HDDRecorder.stop();}},
-    {"HDDRecorder/pause:", rDoc("Pause recording"), 0, [](const char *, RtData &d) {
-       Master *m = (Master*)d.obj;
-       m->HDDRecorder.pause();}},
     {"watch/", rDoc("Interface to grab out live synthesis state"), &watchPorts,
         rBOIL_BEGIN;
         SNIP;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -75,17 +75,8 @@ class Master
          * @return 0 for ok or -1 if there is an error*/
         int loadXML(const char *filename);
 
-        /**Save all settings to an OSC file (as specified by RT OSC)
-         * When the function returned, the OSC file has been either saved or
-         * an error occurred.
-         * @param filename File to save to or NULL (useful for testing)
-         * @param dispatcher Message dispatcher and modifier
-         * @param master2 An empty master dummy where the savefile will be
-         *                loaded to and compared with the current master
-         * @return 0 for ok or <0 if there is an error*/
-        int saveOSC(const char *filename,
-                    class master_dispatcher_t* dispatcher,
-                    Master* master2);
+        /**Append all settings to an OSC savefile (as specified by RT OSC)*/
+        std::string saveOSC(std::string savefile);
         /**loads all settings from an OSC file (as specified by RT OSC)
          * @param dispatcher Message dispatcher and modifier
          * @return 0 for ok or <0 if there is an error*/
@@ -228,6 +219,13 @@ class Master
         constexpr static std::size_t dnd_buffer_size = 1024;
         char dnd_buffer[dnd_buffer_size] = {0};
 
+        //Return XML data as string. Must be freed.
+        char* getXMLData();
+        //Load OSC from OSC savefile
+        //Returns 0 if OK, <0 in case of failure
+        int loadOSCFromStr(const char *file_content,
+                           rtosc::savefile_dispatcher_t* dispatcher);
+
     private:
         std::atomic<bool> run_osc_in_use = { false };
 
@@ -245,11 +243,6 @@ class Master
         void(*mastercb)(void*,Master*);
         void* mastercb_ptr;
 
-        //Return XML data as string. Must be freed.
-        char* getXMLData();
-        //Used by loadOSC and saveOSC
-        int loadOSCFromStr(const char *file_content,
-                           rtosc::savefile_dispatcher_t* dispatcher);
         //! apply an OSC event with a DataObj parameter
         //! @note This may be called by MiddleWare if we are offline
         //!   (in this case, the param offline is true)

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -708,7 +708,7 @@ public:
             doReadOnlyOp([this,filename,&dispatcher,&master2,&savefile,&res]()
             {
                 savefile = master->saveOSC(savefile);
-
+#if 1
                 // load the savefile string into another master to compare the results
                 // between the original and the savefile-loaded master
                 // this requires a temporary master switch
@@ -732,7 +732,7 @@ public:
                 printf("Saved in less than %d ms.\n", 50*i);
 
                 dispatcher.updateMaster(old_master);
-
+#endif
                 if(res < 0)
                 {
                     std::cerr << "invalid savefile (or a backend error)!" << std::endl;

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -95,6 +95,11 @@ static void liblo_error_cb(int i, const char *m, const char *loc)
     fprintf(stderr, "liblo :-( %d-%s@%s\n",i,m,loc);
 }
 
+// we need to access those earlier
+// bad style?
+static const rtosc::MergePorts& getParameterPorts();
+static const rtosc::Ports& getNonRtParamPorts();
+
 static int handler_function(const char *path, const char *types, lo_arg **argv,
         int argc, lo_message msg, void *user_data)
 {
@@ -122,7 +127,7 @@ static int handler_function(const char *path, const char *types, lo_arg **argv,
     {
         char reply_buffer[1024*20];
         std::size_t length =
-            rtosc::path_search(Master::ports, buffer, 128,
+            rtosc::path_search(getParameterPorts(), buffer, 128,
                                reply_buffer, sizeof(reply_buffer));
         if(length) {
             lo_message msg  = lo_message_deserialise((void*)reply_buffer,
@@ -343,6 +348,10 @@ struct NonRtObjStore
 
     void handleOscil(const char *msg, rtosc::RtData &d) {
         string obj_rl(d.message, msg);
+        assert(d.message);
+        assert(msg);
+        assert(msg >= d.message);
+        assert(msg - d.message < 256);
         void *osc = get(obj_rl);
         if(osc)
         {
@@ -646,7 +655,11 @@ public:
         return 0;
     }
 
-    int saveMaster(const char *filename, bool osc_format = false)
+    // Save all possible parameters
+    // In user language, this is called "saving a master", but we
+    // are saving parameters owned by Master and by MiddleWare
+    // Return 0 if OK, <0 if not
+    int saveParams(const char *filename, bool osc_format = false)
     {
         int res;
         if(osc_format)
@@ -665,9 +678,98 @@ public:
             master->copyMasterCbTo(&master2);
             master2.frozenState = true;
 
-            doReadOnlyOp([this,filename,&dispatcher,&master2,&res](){
-                             res = master->saveOSC(filename, &dispatcher,
-                                                   &master2);});
+            std::string savefile;
+            rtosc_version m_version =
+            {
+                (unsigned char) version.get_major(),
+                (unsigned char) version.get_minor(),
+                (unsigned char) version.get_revision()
+            };
+            savefile = rtosc::save_to_file(getNonRtParamPorts(), this, "ZynAddSubFX", m_version);
+            savefile += '\n';
+
+            doReadOnlyOp([this,filename,&dispatcher,&master2,&savefile,&res]()
+            {
+                savefile = master->saveOSC(savefile);
+
+                // load the savefile string into another master to compare the results
+                // between the original and the savefile-loaded master
+                // this requires a temporary master switch
+                Master* old_master = master;
+                dispatcher.updateMaster(&master2);
+
+                res = master2.loadOSCFromStr(savefile.c_str(), &dispatcher);
+                // TODO: compare MiddleWare, too?
+
+                // The above call is done by this thread (i.e. the MiddleWare thread), but
+                // it sends messages to master2 in order to load the values
+                // We need to wait until savefile has been loaded into master2
+                int i;
+                for(i = 0; i < 20 && master2.uToB->hasNext(); ++i)
+                    os_usleep(50000);
+                if(i >= 20) // >= 1 second?
+                {
+                    // Master failed to fetch its messages
+                    res = -1;
+                }
+                printf("Saved in less than %d ms.\n", 50*i);
+
+                dispatcher.updateMaster(old_master);
+
+                if(res < 0)
+                {
+                    std::cerr << "invalid savefile (or a backend error)!" << std::endl;
+                    std::cerr << "complete savefile:" << std::endl;
+                    std::cerr << savefile << std::endl;
+                    std::cerr << "first entry that could not be parsed:" << std::endl;
+
+                    for(int i = -res + 1; savefile[i]; ++i)
+                    if(savefile[i] == '\n')
+                    {
+                        savefile.resize(i);
+                        break;
+                    }
+                    std::cerr << (savefile.c_str() - res) << std::endl;
+
+                    res = -1;
+                }
+                else
+                {
+                    char* xml = master->getXMLData(),
+                        * xml2 = master2.getXMLData();
+                    // TODO: below here can be moved out of read only op
+
+                    res = strcmp(xml, xml2) ? -1 : 0;
+
+                    if(res == 0)
+                    {
+                        if(filename && *filename)
+                        {
+                            std::ofstream ofs(filename);
+                            ofs << savefile;
+                        }
+                        else {
+                            std::cout << "The savefile content follows" << std::endl;
+                            std::cout << "---->8----" << std::endl;
+                            std::cout << savefile << std::endl;
+                            std::cout << "---->8----" << std::endl;
+                        }
+                    }
+                    else
+                    {
+                        std::cout << savefile << std::endl;
+                        std::cerr << "Can not write OSC savefile!! (see tmp1.txt and tmp2.txt)"
+                                  << std::endl;
+                        std::ofstream tmp1("tmp1.txt"), tmp2("tmp2.txt");
+                        tmp1 << xml;
+                        tmp2 << xml2;
+                        res = -1;
+                    }
+
+                    free(xml);
+                    free(xml2);
+                }
+            });
         }
         else // xml format
         {
@@ -1289,7 +1391,7 @@ void save_cb(const char *msg, RtData &d)
     if(rtosc_narguments(msg) > 1)
         request_time = rtosc_argument(msg, 1).t;
 
-    int res = impl.saveMaster(file.c_str(), osc_format);
+    int res = impl.saveParams(file.c_str(), osc_format);
     d.broadcast(d.loc, (res == 0) ? "stT" : "stF",
                 file.c_str(), request_time);
 }
@@ -1322,7 +1424,7 @@ void gcc_10_1_0_is_dumb(const std::vector<std::string> &files,
  * BASE/part#/kit#/padpars/prepare
  * BASE/part#/kit#/padpars/oscil/\*
  */
-static rtosc::Ports middwareSnoopPorts = {
+static rtosc::Ports nonRtParamPorts = {
     {"part#" STRINGIFY(NUM_MIDI_PARTS)
         "/kit#" STRINGIFY(NUM_KIT_ITEMS) "/adpars/VoicePar#"
             STRINGIFY(NUM_VOICES) "/OscilSmp/", 0, &OscilGen::non_realtime_ports,
@@ -1340,6 +1442,9 @@ static rtosc::Ports middwareSnoopPorts = {
         rBegin
         impl.obj_store.handlePad(chomp(chomp(chomp(msg))), d);
         rEnd},
+};
+
+static rtosc::Ports middwareSnoopPortsWithoutNonRtParams = {
     {"bank/", 0, &bankPorts,
         rBegin;
         d.obj = &impl.master->bank;
@@ -1630,6 +1735,22 @@ static rtosc::Ports middwareSnoopPorts = {
         rEnd
     }
 };
+
+static rtosc::MergePorts middwareSnoopPorts =
+{
+    &nonRtParamPorts,
+    &middwareSnoopPortsWithoutNonRtParams
+};
+
+static rtosc::MergePorts parameterPorts =
+{
+    // order is important: params should be queried on Master first
+    // (because MiddleWare often just redirects, hiding the metadata)
+    &Master::ports,
+    &nonRtParamPorts
+};
+const rtosc::MergePorts& getParameterPorts() { return parameterPorts; }
+const rtosc::Ports& getNonRtParamPorts() { return nonRtParamPorts; }
 
 static rtosc::Ports middlewareReplyPorts = {
     {"echo:ss", 0, 0,

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -378,7 +378,7 @@ struct NonRtObjStore
         }
         else {
             // print warning, except in rtosc::walk_ports
-            if(obj_rl.find("/pointer") == obj_rl.npos)
+            if(!strstr(d.message, "/pointer"))
             {
                 fprintf(stderr, "Warning: trying to access oscil object \"%s\","
                                 "which does not exist\n", obj_rl.c_str());
@@ -409,7 +409,7 @@ struct NonRtObjStore
             }
             else {
                 // print warning, except in rtosc::walk_ports
-                if(obj_rl.find("/pointer") == obj_rl.npos)
+                if(!strstr(d.message, "/pointer"))
                 {
                     fprintf(stderr, "Warning: trying to access pad synth object "
                                     "\"%s\", which does not exist\n",

--- a/src/Misc/MiddleWare.h
+++ b/src/Misc/MiddleWare.h
@@ -16,6 +16,10 @@
 
 class Fl_Osc_Interface;
 
+namespace rtosc {
+    struct MergePorts;
+}
+
 namespace zyn {
 
 struct SYNTH_T;
@@ -86,6 +90,9 @@ class MiddleWare
         //!Make @p new_master the current master
         //!@warning use with care, and only in frozen state
         void switchMaster(Master* new_master);
+
+        static const rtosc::MergePorts& getAllPorts();
+
     private:
         class MiddleWareImpl *impl;
 };

--- a/src/Misc/Recorder.cpp
+++ b/src/Misc/Recorder.cpp
@@ -11,6 +11,8 @@
   of the License, or (at your option) any later version.
 */
 
+#include <rtosc/ports.h>
+#include <rtosc/port-sugar.h>
 #include <sys/stat.h>
 #include "Recorder.h"
 #include "WavFile.h"
@@ -18,6 +20,27 @@
 #include "../Nio/Nio.h"
 
 namespace zyn {
+
+#define rObject Recorder
+const rtosc::Ports Recorder::ports = {
+    {"preparefile:s", rDoc("Init WAV file"), 0,
+        rBOIL_BEGIN
+        obj->preparefile(rtosc_argument(msg, 0).s, 1);
+        rBOIL_END },
+    {"start:", rDoc("Start recording"), 0,
+        rBOIL_BEGIN
+        obj->start();
+        rBOIL_END },
+    {"stop:", rDoc("Stop recording"), 0,
+        rBOIL_BEGIN
+        obj->stop();
+        rBOIL_END },
+    {"pause:", rDoc("Pause recording"), 0,
+        rBOIL_BEGIN;
+        obj->pause();
+        rBOIL_END}
+};
+#undef rObject
 
 Recorder::Recorder(const SYNTH_T &synth_)
     :status(0), notetrigger(0),synth(synth_)

--- a/src/Misc/Recorder.h
+++ b/src/Misc/Recorder.h
@@ -13,6 +13,7 @@
 
 #ifndef RECORDER_H
 #define RECORDER_H
+#include <rtosc/ports.h>
 #include <string>
 
 namespace zyn {
@@ -39,6 +40,8 @@ class Recorder
          *  1 - ready
          *  2 - recording */
         int status;
+
+        static const rtosc::Ports ports;
 
     private:
         int notetrigger;

--- a/src/Params/EnvelopeParams.cpp
+++ b/src/Params/EnvelopeParams.cpp
@@ -35,7 +35,7 @@ namespace zyn {
 #define dTREAL(var) (powf(2.0f, var / 127.0f * 12.0f) - 1.0f) / 100.0f
 
 #define rParamDT(name, ...) \
-  {"P" STRINGIFY(name) "::i",  rProp(parameter) DOC(__VA_ARGS__), NULL, rParamDTCb(name)}
+  {"P" STRINGIFY(name) "::i", rProp(alias) rProp(parameter) DOC(__VA_ARGS__), NULL, rParamDTCb(name)}
 
 #define rParamDTCb(name) rBOIL_BEGIN \
         if(!strcmp("", args)) {\

--- a/src/Params/LFOParams.cpp
+++ b/src/Params/LFOParams.cpp
@@ -95,7 +95,7 @@ static const rtosc::Ports _ports = {
             "Enable for global operation"),
     rParamZyn(Pstretch, rShort("str"), rCentered, rDefault(64),
         "Note frequency stretch"),
-// these are currently not yet implemented at must be hidden therefore
+// these are currently not yet implemented and must be hidden therefore
 #ifdef DEAD_PORTS
     //Float valued aliases
     {"delay::f", rProp(parameter) rMap(units, ms) rLog(0,4000), 0,

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -110,14 +110,18 @@ static const rtosc::Ports realtime_ports =
         [](const char *msg, RtData &d)
         {
             PADnoteParameters *obj = (PADnoteParameters *)d.obj;
-            if(!rtosc_narguments(msg)) {
+            auto get_octave = [&obj](){
                 int k=obj->PCoarseDetune/1024;
                 if (k>=8) k-=16;
-                d.reply(d.loc, "i", k);
+                return k;
+            };
+            if(!rtosc_narguments(msg)) {
+                d.reply(d.loc, "i", get_octave());
             } else {
                 int k=(int) rtosc_argument(msg, 0).i;
                 if (k<0) k+=16;
                 obj->PCoarseDetune = k*1024 + obj->PCoarseDetune%1024;
+                d.broadcast(d.loc, "i", get_octave());
             }
         }},
     {"coarsedetune::c:i", rProp(parameter) rShort("coarse") rLinear(-64, 63)
@@ -125,14 +129,18 @@ static const rtosc::Ports realtime_ports =
         [](const char *msg, RtData &d)
         {
             PADnoteParameters *obj = (PADnoteParameters *)d.obj;
-            if(!rtosc_narguments(msg)) {
+            auto get_coarse = [&obj](){
                 int k=obj->PCoarseDetune%1024;
                 if (k>=512) k-=1024;
-                d.reply(d.loc, "i", k);
+                return k;
+            };
+            if(!rtosc_narguments(msg)) {
+                d.reply(d.loc, "i", get_coarse());
             } else {
                 int k=(int) rtosc_argument(msg, 0).i;
                 if (k<0) k+=1024;
                 obj->PCoarseDetune = k + (obj->PCoarseDetune/1024)*1024;
+                d.broadcast(d.loc, "i", get_coarse());
             }
         }},
     {"paste:b", rProp(internal) rDoc("paste port"), 0,
@@ -238,6 +246,7 @@ static const rtosc::Ports non_realtime_ports =
             PADnoteParameters *p = ((PADnoteParameters*)d.obj);
             if(rtosc_narguments(msg)) {
                 p->setPbandwidth(rtosc_argument(msg, 0).i);
+                d.broadcast(d.loc, "i", p->Pbandwidth);
             } else {
                 d.reply(d.loc, "i", p->Pbandwidth);
             }}},

--- a/src/Params/SUBnoteParameters.cpp
+++ b/src/Params/SUBnoteParameters.cpp
@@ -146,28 +146,36 @@ static const rtosc::Ports SUBnotePorts = {
     {"octave::c:i", rProp(parameter) rShort("octave") rLinear(-8,7)
         rDoc("Note octave shift"), NULL,
         rBegin;
-        if(!rtosc_narguments(msg)) {
-            int k=obj->PCoarseDetune/1024;
-            if (k>=8) k-=16;
-            d.reply(d.loc, "i", k);
-        } else {
-            int k=(int) rtosc_argument(msg, 0).i;
-            if (k<0) k+=16;
-            obj->PCoarseDetune = k*1024 + obj->PCoarseDetune%1024;
-        }
+            auto get_octave = [&obj](){
+                int k=obj->PCoarseDetune/1024;
+                if (k>=8) k-=16;
+                return k;
+            };
+            if(!rtosc_narguments(msg)) {
+                d.reply(d.loc, "i", get_octave());
+            } else {
+                int k=(int) rtosc_argument(msg, 0).i;
+                if (k<0) k+=16;
+                obj->PCoarseDetune = k*1024 + obj->PCoarseDetune%1024;
+                d.broadcast(d.loc, "i", get_octave());
+            }
         rEnd},
     {"coarsedetune::c:i", rProp(parameter) rShort("coarse") rLinear(-64, 63)
         rDoc("Note coarse detune"), NULL,
         rBegin;
-        if(!rtosc_narguments(msg)) {
-            int k=obj->PCoarseDetune%1024;
-            if (k>=512) k-=1024;
-            d.reply(d.loc, "i", k);
-        } else {
-            int k=(int) rtosc_argument(msg, 0).i;
-            if (k<0) k+=1024;
-            obj->PCoarseDetune = k + (obj->PCoarseDetune/1024)*1024;
-        }
+            auto get_coarse = [&obj](){
+                int k=obj->PCoarseDetune%1024;
+                if (k>=512) k-=1024;
+                return k;
+            };
+            if(!rtosc_narguments(msg)) {
+                d.reply(d.loc, "i", get_coarse());
+            } else {
+                int k=(int) rtosc_argument(msg, 0).i;
+                if (k<0) k+=1024;
+                obj->PCoarseDetune = k + (obj->PCoarseDetune/1024)*1024;
+                d.broadcast(d.loc, "i", get_coarse());
+            }
         rEnd},
     {"response:", rDoc("Filter response at 440Hz. with 48kHz sample rate\n\n"
             "Format: stages, filter*active_filters\n"

--- a/src/Tests/check-ports.rb
+++ b/src/Tests/check-ports.rb
@@ -6,11 +6,15 @@ rval=0
 my_path=File.dirname(__FILE__)
 
 # start zyn, grep the lo server port, and connect the port checker to it
+# NOTE: If you add too much debug output to zyn, it will be blocked when writing into the pipe,
+#       leading to MiddleWare to not reply and to port-checker to fail.
+#       This script should be rewritten to keep reading (and printing) zyn's messages.
 Open3.popen3(my_path + "/../zynaddsubfx -O null --no-gui") do |stdin, stdout, stderr, wait_thr|
   pid = wait_thr[:pid]
   while line=stderr.gets do 
     # print "line: " + line;
     if /^lo server running on (\d+)$/.match(line) then
+      sleep 3 # give zyn more time to setup
       port_checker_rval = system(my_path + "/../../rtosc/port-checker 'osc.udp://localhost:" + $1 + "/'")
       if port_checker_rval != true then
         puts "Error: port-checker has returned #{$?.exitstatus}."

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -459,7 +459,7 @@ int main(int argc, char *argv[])
                     rtosc::OscDocFormatter s;
                     ofstream outfile(optarguments);
                     s.prog_name    = "ZynAddSubFX";
-                    s.p            = &Master::ports;
+                    s.p            = &MiddleWare::getAllPorts();
                     s.uri          = "http://example.com/fake/";
                     s.doc_origin   = "http://example.com/fake/url.xml";
                     s.author_first = "Mark";
@@ -471,7 +471,7 @@ int main(int argc, char *argv[])
                 if(optarguments)
                 {
                     ofstream outfile(optarguments);
-                    dump_json(outfile, Master::ports);
+                    dump_json(outfile, MiddleWare::getAllPorts());
                 }
                 break;
             case 'Z':


### PR DESCRIPTION
Split MW snoop ports into non-RT ports and other snoop ports, and then

* Let path-search iterate over non-RT ports, too (e.g. to let port-checker see those ports)
* Let save_osc save non-RT ports, too (to build complete savefiles)

This commit is a bug fix, because currently, port-checker does not look at the non-RT MW-ports, and it would make the SaveOsc tests fail if the test xmz would have non-RT ports changed (in comparison to the default values).

This commit is preparation for the wavetable-branch (SaveOsc failed there with the new non-RT ports).