### PR TITLE
Topic/smooth filter cutoff and volume

### DIFF
--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -46,6 +46,7 @@ AnalogFilter::AnalogFilter(unsigned char Ftype,
     firsttime  = true;
     coeff.d[0] = 0; //this is not used
     outgain    = 1.0f;
+    freq_smoothing.sample_rate(samplerate_f);
 }
 
 AnalogFilter::~AnalogFilter()
@@ -280,15 +281,6 @@ void AnalogFilter::setfreq(float frequency)
 
     bool nyquistthresh = (abovenq ^ oldabovenq);
 
-
-    //if the frequency is changed fast, it needs interpolation
-    if((rap > 3.0f) || nyquistthresh) { //(now, filter and coefficients backup)
-        oldCoeff = coeff;
-        for(int i = 0; i < MAX_FILTER_STAGES + 1; ++i)
-            oldHistory[i] = history[i];
-        if(!firsttime)
-            needsinterpolation = true;
-    }
     freq = frequency;
     computefiltercoefs();
     firsttime = false;
@@ -383,26 +375,70 @@ void AnalogFilter::singlefilterout(float *smp, fstage &hist,
     }
 }
 
-void AnalogFilter::filterout(float *smp)
+
+void AnalogFilter::singlefilterout_freqbuf(float *smp, fstage &hist,
+                                   float *freqbuf)
 {
-    for(int i = 0; i < stages + 1; ++i)
-        singlefilterout(smp, history[i], coeff);
+    assert((buffersize % 8) == 0);
 
-    if(needsinterpolation) {
-        //Merge Filter at old coeff with new coeff
-        float ismp[buffersize];
-        memcpy(ismp, smp, bufferbytes);
+    for ( int i = 0; i < buffersize; i += 8 )
+    {
+	/* recompute coeffs for each 8 samples */
+	freq = freqbuf[i];
+	computefiltercoefs();
+	
+	if(order == 1) {  //First order filter
+	    for ( int j = 0; j < 8; j++ )
+	    {
+		float y0 = smp[i+j] * coeff.c[0] + hist.x1 * coeff.c[1]
+		    + hist.y1 * coeff.d[1];
+		hist.y1 = y0;
+		hist.x1 = smp[i+j];
+		smp[i+j]  = y0;
+	    }
+	} else if(order == 2) {//Second order filter
 
-        for(int i = 0; i < stages + 1; ++i)
-            singlefilterout(ismp, oldHistory[i], oldCoeff);
-
-        for(int i = 0; i < buffersize; ++i) {
-            float x = (float)i / buffersize_f;
-            smp[i] = ismp[i] * (1.0f - x) + smp[i] * x;
-        }
-        needsinterpolation = false;
+	    const float coeff_[5] = {coeff.c[0], coeff.c[1], coeff.c[2],  coeff.d[1], coeff.d[2]};
+	    float work[4]  = {hist.x1, hist.x2, hist.y1, hist.y2};
+	    
+	    AnalogBiquadFilterA(coeff_, smp[i + 0], work);
+	    AnalogBiquadFilterB(coeff_, smp[i + 1], work);
+	    AnalogBiquadFilterA(coeff_, smp[i + 2], work);
+	    AnalogBiquadFilterB(coeff_, smp[i + 3], work);
+	    AnalogBiquadFilterA(coeff_, smp[i + 4], work);
+	    AnalogBiquadFilterB(coeff_, smp[i + 5], work);
+	    AnalogBiquadFilterA(coeff_, smp[i + 6], work);
+	    AnalogBiquadFilterB(coeff_, smp[i + 7], work);
+	    
+	    hist.x1 = work[0];
+	    hist.x2 = work[1];
+	    hist.y1 = work[2];
+	    hist.y2 = work[3];
+	}
     }
 
+    freq = freqbuf[buffersize-1];
+    computefiltercoefs();
+}
+
+void AnalogFilter::filterout(float *smp)
+{
+
+    float freqbuf[buffersize];
+    
+    if ( freq_smoothing.apply( freqbuf, buffersize, freq ) )
+    {
+	/* in transition, need to do fine grained interpolation */
+	for(int i = 0; i < stages + 1; ++i)
+	    singlefilterout_freqbuf(smp, history[i], freqbuf);
+    }
+    else
+    {
+	/* stable state, just use one coeff */
+	for(int i = 0; i < stages + 1; ++i)
+	    singlefilterout(smp, history[i], coeff);
+    }
+    
     for(int i = 0; i < buffersize; ++i)
         smp[i] *= outgain;
 }

--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -47,6 +47,7 @@ AnalogFilter::AnalogFilter(unsigned char Ftype,
     coeff.d[0] = 0; //this is not used
     outgain    = 1.0f;
     freq_smoothing.sample_rate(samplerate_f);
+    freq_smoothing.reset( freq );
 }
 
 AnalogFilter::~AnalogFilter()

--- a/src/DSP/AnalogFilter.h
+++ b/src/DSP/AnalogFilter.h
@@ -18,6 +18,7 @@
 
 #include "../globals.h"
 #include "Filter.h"
+#include "Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -61,6 +62,7 @@ class AnalogFilter:public Filter
 
         //Apply IIR filter to Samples, with coefficients, and past history
         void singlefilterout(float *smp, fstage &hist, const Coeff &coeff);
+        void singlefilterout_freqbuf(float *smp, fstage &hist, float *freqbuf);
         //Update coeff and order
         void computefiltercoefs(void);
 
@@ -77,6 +79,9 @@ class AnalogFilter:public Filter
         bool abovenq,                 //if the frequency is above the nyquist
              oldabovenq;              //if the last time was above nyquist
                                       //(used to see if it needs interpolation)
+
+
+    Value_Smoothing_Filter freq_smoothing; /* for smoothing freq modulations to avoid zipper effect */
 };
 
 }

--- a/src/DSP/CMakeLists.txt
+++ b/src/DSP/CMakeLists.txt
@@ -5,5 +5,6 @@ set(zynaddsubfx_dsp_SRCS
     DSP/FormantFilter.cpp
     DSP/SVFilter.cpp
     DSP/Unison.cpp
+    DSP/Value_Smoothing_Filter.cpp
     PARENT_SCOPE
 )

--- a/src/DSP/Value_Smoothing_Filter.cpp
+++ b/src/DSP/Value_Smoothing_Filter.cpp
@@ -1,0 +1,65 @@
+
+/*******************************************************************************/
+/* Copyright (C) 2008-2020 Jonathan Moore Liles                                */
+/*                                                                             */
+/* This program is free software; you can redistribute it and/or modify it     */
+/* under the terms of the GNU General Public License as published by the       */
+/* Free Software Foundation; either version 2 of the License, or (at your      */
+/* option) any later version.                                                  */
+/*                                                                             */
+/* This program is distributed in the hope that it will be useful, but WITHOUT */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for   */
+/* more details.                                                               */
+/*                                                                             */
+/* You should have received a copy of the GNU General Public License along     */
+/* with This program; see the file COPYING.  If not,write to the Free Software */
+/* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+/*******************************************************************************/
+
+#include "Value_Smoothing_Filter.h"
+#include <math.h>
+
+void
+Value_Smoothing_Filter::sample_rate ( nframes_t n )
+{
+    const float FS = n;
+    const float T = 0.05f;
+	    
+    w = _cutoff / (FS * T);
+}
+    
+bool
+Value_Smoothing_Filter::apply( sample_t * __restrict__ dst, nframes_t nframes, float gt )
+{
+    if ( target_reached(gt) )
+	return false;
+	    
+    /* sample_t * dst_ = (sample_t*) assume_aligned(dst); */
+    sample_t * dst_ = (sample_t*)(dst);
+	    
+    const float a = 0.07f;
+    const float b = 1 + a;
+	    
+    const float gm = b * gt;
+	    
+    float g1 = this->g1;
+    float g2 = this->g2;
+	    
+    for (nframes_t i = 0; i < nframes; i++)
+    {
+	g1 += w * (gm - g1 - a * g2);
+	g2 += w * (g1 - g2);
+	dst_[i] = g2;
+    }
+	    
+    g2 += 1e-10f;		/* denormal protection */
+	    
+    if ( fabsf( gt - g2 ) < 0.0001f )
+	g2 = gt;
+	    
+    this->g1 = g1;
+    this->g2 = g2;
+	    
+    return true;
+}

--- a/src/DSP/Value_Smoothing_Filter.h
+++ b/src/DSP/Value_Smoothing_Filter.h
@@ -1,0 +1,47 @@
+
+/*******************************************************************************/
+/* Copyright (C) 2008-2020 Jonathan Moore Liles                                */
+/*                                                                             */
+/* This program is free software; you can redistribute it and/or modify it     */
+/* under the terms of the GNU General Public License as published by the       */
+/* Free Software Foundation; either version 2 of the License, or (at your      */
+/* option) any later version.                                                  */
+/*                                                                             */
+/* This program is distributed in the hope that it will be useful, but WITHOUT */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for   */
+/* more details.                                                               */
+/*                                                                             */
+/* You should have received a copy of the GNU General Public License along     */
+/* with This program; see the file COPYING.  If not,write to the Free Software */
+/* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+/*******************************************************************************/
+
+typedef unsigned long nframes_t;
+typedef float sample_t;
+
+class Value_Smoothing_Filter
+{
+    float w, g1, g2;
+    
+    float _cutoff;
+
+public:
+
+    Value_Smoothing_Filter ( )
+	{
+	    g1 = g2 = 0;
+	    _cutoff = 10.0f;
+	}
+
+    void cutoff ( float v ) { _cutoff = v; }
+
+    void reset ( float v ) { g2 = g1 = v; }
+
+    inline bool target_reached ( float gt ) const { return gt == g2; }
+
+    void sample_rate ( nframes_t n );
+	
+    bool apply( sample_t * __restrict__ dst, nframes_t nframes, float gt );
+};
+

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -785,11 +785,13 @@ Master::Master(const SYNTH_T &synth_, Config* config)
                                config->cfg.Interpolation, &microtonal, fft, &watcher,
                                (ss+"/part"+npart+"/").c_str);
 	smoothing_part_l[npart].sample_rate( synth.samplerate );
+	smoothing_part_l[npart].reset( 1.0f );
 	smoothing_part_r[npart].sample_rate( synth.samplerate );
-	
+	smoothing_part_r[npart].reset( 0.992126f ); /* curious default, must be a bug in panning formula. */
     }
 
     smoothing.sample_rate( synth.samplerate );
+    smoothing.reset( 0.464159f ); /* master volume has this odd default for some reason, just go with it. */
     
     //Insertion Effects init
     for(int nefx = 0; nefx < NUM_INS_EFX; ++nefx)

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -777,12 +777,20 @@ Master::Master(const SYNTH_T &synth_, Config* config)
         fakepeakpart[npart]  = 0;
     }
 
+    
     ScratchString ss;
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
+    {
         part[npart] = new Part(*memory, synth, time, config->cfg.GzipCompression,
                                config->cfg.Interpolation, &microtonal, fft, &watcher,
                                (ss+"/part"+npart+"/").c_str);
+	smoothing_part_l[npart].sample_rate( synth.samplerate );
+	smoothing_part_r[npart].sample_rate( synth.samplerate );
+	
+    }
 
+    smoothing.sample_rate( synth.samplerate );
+    
     //Insertion Effects init
     for(int nefx = 0; nefx < NUM_INS_EFX; ++nefx)
         insefx[nefx] = new EffectMgr(*memory, synth, 1, &time);
@@ -891,7 +899,6 @@ void Master::defaults()
     union {float f; uint32_t i;} convert;
     convert.i = 0xC0D55556;
     Volume = convert.f;
-    oldVolume = Volume;
     setPkeyshift(64);
 
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
@@ -1252,15 +1259,15 @@ bool Master::AudioOut(float *outr, float *outl)
         }
 
 
+    float gainbuf[synth.buffersize];
+
     //Apply the part volumes and pannings (after insertion effects)
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
         if(!part[npart]->Penabled)
             continue;
 
-        Stereo<float> newvol(part[npart]->volume),
-        oldvol(part[npart]->oldvolumel,
-               part[npart]->oldvolumer);
-
+        Stereo<float> newvol(part[npart]->volume);
+	
         float pan = part[npart]->panning;
         if(pan < 0.5f)
             newvol.l *= pan * 2.0f;
@@ -1269,29 +1276,32 @@ bool Master::AudioOut(float *outr, float *outl)
         //if(npart==0)
         //printf("[%d]vol = %f->%f\n", npart, oldvol.l, newvol.l);
 
-        //the volume or the panning has changed and needs interpolation
-        if(ABOVE_AMPLITUDE_THRESHOLD(oldvol.l, newvol.l)
-           || ABOVE_AMPLITUDE_THRESHOLD(oldvol.r, newvol.r)) {
-            for(int i = 0; i < synth.buffersize; ++i) {
-                Stereo<float> vol(INTERPOLATE_AMPLITUDE(oldvol.l, newvol.l,
-                                                        i, synth.buffersize),
-                                  INTERPOLATE_AMPLITUDE(oldvol.r, newvol.r,
-                                                        i, synth.buffersize));
-                part[npart]->partoutl[i] *= vol.l;
-                part[npart]->partoutr[i] *= vol.r;
-            }
-            part[npart]->oldvolumel = newvol.l;
-            part[npart]->oldvolumer = newvol.r;
-        }
-        else {
-            for(int i = 0; i < synth.buffersize; ++i) { //the volume did not changed
-                part[npart]->partoutl[i] *= newvol.l;
-                part[npart]->partoutr[i] *= newvol.r;
-            }
-        }
-    }
 
 
+	/* This is where the part volume (and pan) smoothing and application happens */
+	if ( smoothing_part_l[npart].apply( gainbuf, synth.buffersize, newvol.l ) )
+	{
+	    for ( int i = 0; i < synth.buffersize; ++i )
+		part[npart]->partoutl[i] *= gainbuf[i];
+	}
+	else
+	{
+	    for ( int i = 0; i < synth.buffersize; ++i )
+		part[npart]->partoutl[i] *= newvol.l;
+	}
+	
+	if ( smoothing_part_r[npart].apply( gainbuf, synth.buffersize, newvol.r ) )
+	{
+	    for ( int i = 0; i < synth.buffersize; ++i )
+		part[npart]->partoutr[i] *= gainbuf[i];
+	}
+	else
+	{
+	    for ( int i = 0; i < synth.buffersize; ++i )
+		part[npart]->partoutr[i] *= newvol.r;
+	}
+    }	
+	
     //System effects
     for(int nefx = 0; nefx < NUM_SYS_EFX; ++nefx) {
         if(sysefx[nefx]->geteffect() == 0)
@@ -1354,27 +1364,26 @@ bool Master::AudioOut(float *outr, float *outl)
         if(Pinsparts[nefx] == -2)
             insefx[nefx]->out(outl, outr);
 
+    float vol = dB2rap(Volume);
 
     //Master Volume
-    float oldvol = dB2rap(oldVolume);
-    float newvol = dB2rap(Volume);
-    if(ABOVE_AMPLITUDE_THRESHOLD(oldvol, newvol)) {
-        for(int i = 0; i < synth.buffersize; ++i) {
-            float vol = INTERPOLATE_AMPLITUDE(oldvol, newvol,
-                                              i, synth.buffersize);
-            outl[i] *= vol;
-            outr[i] *= vol;
-        }
+    /* this is where the master volume smoothing and application happens */
+    if ( smoothing.apply( gainbuf, synth.buffersize, vol ) )
+    {
+	for ( int i = 0; i < synth.buffersize; ++i )
+	{
+	    outl[i] *= gainbuf[i];
+	    outr[i] *= gainbuf[i];
+	}
     }
-    else {
-        // No interpolation
-        float vol = dB2rap(Volume);
-        for(int i = 0; i < synth.buffersize; ++i) {
-            outl[i] *= vol;
-            outr[i] *= vol;
-        }
+    else
+    {
+	for ( int i = 0; i < synth.buffersize; ++i )
+	{
+	    outl[i] *= vol;
+	    outr[i] *= vol;
+	}
     }
-    oldVolume = Volume;
 
     vuUpdate(outl, outr);
 
@@ -1666,7 +1675,6 @@ void Master::getfromXML(XMLwrapper& xml)
         Volume = xml.getparreal("volume", Volume);
     } else {
         Volume  = volume127ToFloat(xml.getpar127("volume", 0));
-        oldVolume = Volume;
     }
     setPkeyshift(xml.getpar127("key_shift", Pkeyshift));
     ctl.NRPN.receive = xml.getparbool("nrpn_receive", ctl.NRPN.receive);

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -26,6 +26,7 @@
 
 #include "../Params/Controller.h"
 #include "../Synth/WatchPoint.h"
+#include "../DSP/Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -186,7 +187,6 @@ class Master
         class FFTwrapper * fft;
 
         static const rtosc::Ports &ports;
-        float oldVolume;
         float  Volume;
 
         //Statistics on output levels
@@ -251,6 +251,13 @@ class Master
                            bool offline, bool nio,
                            class DataObj& d, int msg_id = -1,
                            Master* master_from_mw = nullptr);
+
+    Value_Smoothing_Filter smoothing;
+
+    Value_Smoothing_Filter smoothing_part_l[NUM_MIDI_PARTS];
+    Value_Smoothing_Filter smoothing_part_r[NUM_MIDI_PARTS];
+    
+    
 };
 
 class master_dispatcher_t : public rtosc::savefile_dispatcher_t


### PR DESCRIPTION
 Use a LPF smoothing filter for cutoff frequency changes and apply in 8 sample chunks.

This removes a zipper artifact that was apparent when using keyboard aftertouch
to modulate filter cutoff.  This commit introduces generic
Value_Smoothing_Filter class (taken from Non-DAW), which can be employed
anywhere else in the application that such smoothing may be required.

A smoothing filter cutoff frequency of 10hz was found by ear to be the minimum
required to suppress the zipper effect.

The filter only runs when the cutoff value is being changed, so the
steady-state performance characteristics are unchanged.

 Master: Use Value_Smoothing_Filter for part and master volume smoothin too (incudes part pan).

