### PR TITLE
Use an LPF smoothing filter for filter cutoff frequency changes, and …

### DIFF
--- a/src/DSP/AnalogFilter.h
+++ b/src/DSP/AnalogFilter.h
@@ -18,6 +18,7 @@
 
 #include "../globals.h"
 #include "Filter.h"
+#include "Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -61,6 +62,7 @@ class AnalogFilter:public Filter
 
         //Apply IIR filter to Samples, with coefficients, and past history
         void singlefilterout(float *smp, fstage &hist, const Coeff &coeff);
+        void singlefilterout_freqbuf(float *smp, fstage &hist, float *freqbuf);
         //Update coeff and order
         void computefiltercoefs(void);
 
@@ -72,11 +74,7 @@ class AnalogFilter:public Filter
 
         int order; //the order of the filter (number of poles)
 
-        bool needsinterpolation,      //Interpolation between coeff changes
-             firsttime;               //First Iteration of filter
-        bool abovenq,                 //if the frequency is above the nyquist
-             oldabovenq;              //if the last time was above nyquist
-                                      //(used to see if it needs interpolation)
+        Value_Smoothing_Filter freq_smoothing; /* for smoothing freq modulations to avoid zipper effect */
 };
 
 }

--- a/src/DSP/CMakeLists.txt
+++ b/src/DSP/CMakeLists.txt
@@ -5,5 +5,6 @@ set(zynaddsubfx_dsp_SRCS
     DSP/FormantFilter.cpp
     DSP/SVFilter.cpp
     DSP/Unison.cpp
+    DSP/Value_Smoothing_Filter.cpp
     PARENT_SCOPE
 )

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -40,7 +40,11 @@ FormantFilter::FormantFilter(const FilterParams *pars, Allocator *alloc, unsigne
         }
 
     for(int i = 0; i < FF_MAX_FORMANTS; ++i)
-        oldformantamp[i] = 1.0f;
+    {
+	formant_amp_smoothing[i].sample_rate(srate);
+	formant_amp_smoothing[i].reset(1.0f);
+    }
+
     for(int i = 0; i < numformants; ++i) {
         currentformants[i].freq = 1000.0f;
         currentformants[i].amp  = 1.0f;
@@ -138,7 +142,6 @@ void FormantFilter::setpos(float frequency)
                 formantpar[p1][i].q * (1.0f - pos) + formantpar[p2][i].q * pos;
             formant[i]->setfreq_and_q(currentformants[i].freq,
                                       currentformants[i].q * Qfactor);
-            oldformantamp[i] = currentformants[i].amp;
         }
         firsttime = false;
     }
@@ -198,23 +201,27 @@ void FormantFilter::filterout(float *smp)
     memcpy(inbuffer, smp, bufferbytes);
     memset(smp, 0, bufferbytes);
 
-    for(int j = 0; j < numformants; ++j) {
-        float tmpbuf[buffersize];
-        for(int i = 0; i < buffersize; ++i)
-            tmpbuf[i] = inbuffer[i] * outgain;
-        formant[j]->filterout(tmpbuf);
+    float formantbuf[buffersize];
 
-        if(ABOVE_AMPLITUDE_THRESHOLD(oldformantamp[j], currentformants[j].amp))
-            for(int i = 0; i < buffersize; ++i)
-                smp[i] += tmpbuf[i]
-                          * INTERPOLATE_AMPLITUDE(oldformantamp[j],
-                                                  currentformants[j].amp,
-                                                  i,
-                                                  buffersize);
-        else
-            for(int i = 0; i < buffersize; ++i)
+    for(int j = 0; j < numformants; ++j) {
+
+        float tmpbuf[buffersize];
+
+	for(int i = 0; i < buffersize; ++i)
+            tmpbuf[i] = inbuffer[i] * outgain;
+
+	formant[j]->filterout(tmpbuf);
+
+	if ( formant_amp_smoothing[j].apply( formantbuf, buffersize, currentformants[j].amp ) )
+	{
+	    for(int i = 0; i < buffersize; ++i)
+		smp[i] += tmpbuf[i] * formantbuf[i];
+	}
+	else
+	{
+	    for(int i = 0; i < buffersize; ++i)
                 smp[i] += tmpbuf[i] * currentformants[j].amp;
-        oldformantamp[j] = currentformants[j].amp;
+	}
     }
 }
 

--- a/src/DSP/FormantFilter.h
+++ b/src/DSP/FormantFilter.h
@@ -16,6 +16,7 @@
 
 #include "../globals.h"
 #include "Filter.h"
+#include "Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -47,14 +48,14 @@ class FormantFilter:public Filter
             unsigned char nvowel;
         } sequence [FF_MAX_SEQUENCE];
 
-        float oldformantamp[FF_MAX_FORMANTS];
-
         int   sequencesize, numformants;
         bool  firsttime;
         float oldinput, slowinput;
         float Qfactor, formantslowness, oldQfactor;
         float vowelclearness, sequencestretch;
         Allocator &memory;
+
+        Value_Smoothing_Filter formant_amp_smoothing[FF_MAX_FORMANTS];
 };
 
 }

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -26,12 +26,6 @@
 
 namespace zyn {
 
-enum FilterInterpolationType {
-    INTERPOLATE_EXTREME = 0x01,
-    INTERPOLATE_NON_ZERO,
-    INTERPOLATE_NONE
-};
-
 SVFilter::SVFilter(unsigned char Ftype, float Ffreq, float Fq,
                    unsigned char Fstages, unsigned int srate, int bufsize)
     :Filter(srate, bufsize),
@@ -39,15 +33,15 @@ SVFilter::SVFilter(unsigned char Ftype, float Ffreq, float Fq,
       stages(Fstages),
       freq(Ffreq),
       q(Fq),
-      gain(1.0f),
-      needsinterpolation(INTERPOLATE_NONE),
-      firsttime(true)
+      gain(1.0f)
 {
     if(stages >= MAX_FILTER_STAGES)
         stages = MAX_FILTER_STAGES;
     outgain = 1.0f;
     cleanup();
     setfreq_and_q(Ffreq, Fq);
+    freq_smoothing.reset(Ffreq);
+    freq_smoothing.sample_rate(srate);
 }
 
 SVFilter::~SVFilter()
@@ -57,8 +51,6 @@ void SVFilter::cleanup()
 {
     for(int i = 0; i < MAX_FILTER_STAGES + 1; ++i)
         st[i].low = st[i].high = st[i].band = st[i].notch = 0.0f;
-    oldabovenq = false;
-    abovenq    = false;
 }
 
 SVFilter::response::response(float b0, float b1, float b2,
@@ -127,26 +119,8 @@ void SVFilter::setfreq(float frequency)
     if(rap < 1.0f)
         rap = 1.0f / rap;
 
-    oldabovenq = abovenq;
-    abovenq    = frequency > (samplerate_f / 2 - 500.0f);
-
-    bool nyquistthresh = (abovenq ^ oldabovenq);
-
-    //if the frequency is changed fast, it needs interpolation
-    if((rap > 3.0f) || nyquistthresh) { //(now, filter and coefficients backup)
-        if(!firsttime)
-            needsinterpolation = INTERPOLATE_EXTREME;
-        ipar = par;
-    } else if(rap != 1.0) {
-        if (!firsttime)
-            needsinterpolation = INTERPOLATE_NON_ZERO;
-        ipar = par;
-    } else {
-        needsinterpolation = INTERPOLATE_NONE;
-    }
     freq = frequency;
     computefiltercoefs();
-    firsttime = false;
 }
 
 void SVFilter::setfreq_and_q(float frequency, float q_)
@@ -204,21 +178,6 @@ float *SVFilter::getfilteroutfortype(SVFilter::fstage &x) {
     return out;
 }
 
-void SVFilter::singlefilterout_with_par_interpolation(float *smp, fstage &x, parameters &par1, parameters &par2)
-{
-    float *out = getfilteroutfortype(x);
-    for(int i = 0; i < buffersize; ++i) {
-        float p = i / buffersize_f;
-        float f = par1.f + (par2.f - par1.f) * p;
-        float q = par1.q + (par2.q - par1.q) * p;
-        float q_sqrt = sqrtf(q);
-        x.low   = x.low + f * x.band;
-        x.high  = q_sqrt * smp[i] - x.low - q * x.band;
-        x.band  = f * x.high + x.band;
-        x.notch = x.high + x.low;
-        smp[i]  = *out;
-    }
-}
 
 // simplifying the responses
 // xl = xl*z(-1) +      pf*xb*z(-1)
@@ -232,7 +191,7 @@ void SVFilter::singlefilterout_with_par_interpolation(float *smp, fstage &x, par
 
 
 
-void SVFilter::singlefilterout(float *smp, SVFilter::fstage &x, SVFilter::parameters &par)
+void SVFilter::singlefilterout(float *smp, SVFilter::fstage &x, SVFilter::parameters &par, int buffersize )
 {
     float *out = getfilteroutfortype(x);
     for(int i = 0; i < buffersize; ++i) {
@@ -246,24 +205,28 @@ void SVFilter::singlefilterout(float *smp, SVFilter::fstage &x, SVFilter::parame
 
 void SVFilter::filterout(float *smp)
 {
-    if (needsinterpolation == INTERPOLATE_EXTREME) {
-        float ismp[buffersize];
-        for(int i = 0; i < stages + 1; ++i)
-            singlefilterout(smp, st[i], par);
-        memcpy(ismp, smp, bufferbytes);
-        for(int i = 0; i < stages + 1; ++i)
-            singlefilterout(ismp, st[i], ipar);
-        for(int i = 0; i < buffersize; ++i) {
-            float x = i / buffersize_f;
-            smp[i] = ismp[i] * (1.0f - x) + smp[i] * x;
-        }
-    } else if (needsinterpolation == INTERPOLATE_NON_ZERO) {
-        for(int i = 0; i < stages + 1; ++i)
-            singlefilterout_with_par_interpolation(smp, st[i], ipar, par);
-    } else {
-        for(int i = 0; i < stages + 1; ++i)
-            singlefilterout(smp, st[i], par);
+    assert((buffersize % 8) == 0);
+
+    float freqbuf[buffersize];
+
+    if ( freq_smoothing.apply( freqbuf, buffersize, freq ) )
+    {
+	/* 8 sample chunks seems to work OK for AnalogFilter, so do that here too. */
+	for ( int i = 0; i < buffersize; i += 8 )
+	{
+	    freq = freqbuf[i];
+	    computefiltercoefs();
+
+	    for(int j = 0; j < stages + 1; ++j)
+		singlefilterout(smp + i, st[j], par, 8 );
+	}
+
+	freq = freqbuf[buffersize - 1];
+	computefiltercoefs();
     }
+    else
+	for(int i = 0; i < stages + 1; ++i)
+            singlefilterout(smp, st[i], par, buffersize );
 
     for(int i = 0; i < buffersize; ++i)
         smp[i] *= outgain;

--- a/src/DSP/SVFilter.h
+++ b/src/DSP/SVFilter.h
@@ -16,6 +16,7 @@
 
 #include "../globals.h"
 #include "Filter.h"
+#include "Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -57,19 +58,16 @@ class SVFilter:public Filter
         } par, ipar;
 
         float *getfilteroutfortype(SVFilter::fstage &x);
-        void singlefilterout(float *smp, fstage &x, parameters &par);
-        void singlefilterout_with_par_interpolation(float *smp, fstage &x, parameters &par1, parameters &par2);
-        void computefiltercoefs(void);
+    void singlefilterout(float *smp, fstage &x, parameters &par, int buffersize );
+
+    void computefiltercoefs(void);
         int   type;    // The type of the filter (LPF1,HPF1,LPF2,HPF2...)
         int   stages;  // how many times the filter is applied (0->1,1->2,etc.)
         float freq; // Frequency given in Hz
         float q;    // Q factor (resonance or Q factor)
         float gain; // the gain of the filter (if are shelf/peak) filters
 
-        bool abovenq,   //if the frequency is above the nyquist
-             oldabovenq;
-        int needsinterpolation;
-        bool firsttime;
+    Value_Smoothing_Filter freq_smoothing;
 };
 
 }

--- a/src/DSP/Value_Smoothing_Filter.cpp
+++ b/src/DSP/Value_Smoothing_Filter.cpp
@@ -1,0 +1,74 @@
+
+/*******************************************************************************/
+/* Copyright (C) 2008-2020 Jonathan Moore Liles                                */
+/*                                                                             */
+/* This program is free software; you can redistribute it and/or modify it     */
+/* under the terms of the GNU General Public License as published by the       */
+/* Free Software Foundation; either version 2 of the License, or (at your      */
+/* option) any later version.                                                  */
+/*                                                                             */
+/* This program is distributed in the hope that it will be useful, but WITHOUT */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for   */
+/* more details.                                                               */
+/*                                                                             */
+/* You should have received a copy of the GNU General Public License along     */
+/* with This program; see the file COPYING.  If not,write to the Free Software */
+/* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+/*******************************************************************************/
+
+#include "Value_Smoothing_Filter.h"
+#include <math.h>
+
+/* compensate for missing nonlib macro */
+#define assume_aligned(x) (x)
+
+void
+Value_Smoothing_Filter::sample_rate ( nframes_t n )
+{
+    const float FS = n;
+    const float T = 0.05f;
+
+    w = _cutoff / (FS * T);
+}
+
+bool
+Value_Smoothing_Filter::apply( sample_t * __restrict__ dst, nframes_t nframes, float gt )
+{
+    if ( _reset_on_next_apply )
+    {
+	reset( gt );
+	_reset_on_next_apply = false;
+	return false;
+    }
+
+    if ( target_reached(gt) )
+	return false;
+
+    sample_t * dst_ = (sample_t*) assume_aligned(dst);
+
+    const float a = 0.07f;
+    const float b = 1 + a;
+
+    const float gm = b * gt;
+
+    float g1 = this->g1;
+    float g2 = this->g2;
+
+    for (nframes_t i = 0; i < nframes; i++)
+    {
+	g1 += w * (gm - g1 - a * g2);
+	g2 += w * (g1 - g2);
+	dst_[i] = g2;
+    }
+
+    g2 += 1e-10f;		/* denormal protection */
+
+    if ( fabsf( gt - g2 ) < 0.0001f )
+	g2 = gt;
+
+    this->g1 = g1;
+    this->g2 = g2;
+
+    return true;
+}

--- a/src/DSP/Value_Smoothing_Filter.h
+++ b/src/DSP/Value_Smoothing_Filter.h
@@ -1,0 +1,56 @@
+
+/*******************************************************************************/
+/* Copyright (C) 2008-2020 Jonathan Moore Liles                                */
+/*                                                                             */
+/* This program is free software; you can redistribute it and/or modify it     */
+/* under the terms of the GNU General Public License as published by the       */
+/* Free Software Foundation; either version 2 of the License, or (at your      */
+/* option) any later version.                                                  */
+/*                                                                             */
+/* This program is distributed in the hope that it will be useful, but WITHOUT */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for   */
+/* more details.                                                               */
+/*                                                                             */
+/* You should have received a copy of the GNU General Public License along     */
+/* with This program; see the file COPYING.  If not,write to the Free Software */
+/* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+/*******************************************************************************/
+
+#ifndef VALUE_SMOOTHING_FILTER_H
+#define VALUE_SMOOTHING_FILTER_H
+
+typedef unsigned long nframes_t;
+typedef float sample_t;
+
+class Value_Smoothing_Filter
+{
+    float w, g1, g2;
+
+    float _cutoff;
+
+    bool _reset_on_next_apply;
+
+public:
+
+    Value_Smoothing_Filter ( )
+	{
+	    g1 = g2 = 0;
+	    _cutoff = 10.0f;
+	    _reset_on_next_apply = false;
+	}
+
+    void reset_on_next_apply ( bool v ) { _reset_on_next_apply = v; }
+
+    void cutoff ( float v ) { _cutoff = v; }
+
+    void reset ( float v ) { g2 = g1 = v; }
+
+    inline bool target_reached ( float gt ) const { return gt == g2; }
+
+    void sample_rate ( nframes_t n );
+
+    bool apply( sample_t * __restrict__ dst, nframes_t nframes, float gt );
+};
+
+#endif

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -26,6 +26,7 @@
 
 #include "../Params/Controller.h"
 #include "../Synth/WatchPoint.h"
+#include "../DSP/Value_Smoothing_Filter.h"
 
 namespace zyn {
 
@@ -186,7 +187,6 @@ class Master
         class FFTwrapper * fft;
 
         static const rtosc::Ports &ports;
-        float oldVolume;
         float  Volume;
 
         //Statistics on output levels
@@ -251,6 +251,11 @@ class Master
                            bool offline, bool nio,
                            class DataObj& d, int msg_id = -1,
                            Master* master_from_mw = nullptr);
+
+        Value_Smoothing_Filter smoothing;
+
+        Value_Smoothing_Filter smoothing_part_l[NUM_MIDI_PARTS];
+        Value_Smoothing_Filter smoothing_part_r[NUM_MIDI_PARTS];
 };
 
 class master_dispatcher_t : public rtosc::savefile_dispatcher_t


### PR DESCRIPTION
…master, and part volume/pan changes.

This removes a zipper artifact that was apparent when using keyboard aftertouch
to modulate filter cutoff.  This commit introduces generic
Value_Smoothing_Filter class (taken from Non-DAW), which can be employed
anywhere else in the application that such smoothing may be required.

A smoothing filter cutoff frequency of 10Hz was found by ear to be the minimum
required to suppress the zipper effect.

The filter only runs when the cutoff value is being changed, so the
steady-state performance characteristics are unchanged.

Same as #98, but squashed.