### PR TITLE
Add a .desktop to run zynaddsubfx without options, mandatory to make MIDI work

### DIFF
--- a/zynaddsubfx.desktop
+++ b/zynaddsubfx.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=ZynAddSubFX
+Comment=A powerful realtime software synthesizer
+Comment[fr]=Un synthétiseur logiciel temps-réel puissant
+Comment[pl]=Funkcjonalny syntezator wirtualny czasu rzeczywistego
+Keywords=audio;sound;jack;midi;synth;synthesizer;
+Exec=zynaddsubfx
+Icon=zynaddsubfx
+Terminal=false
+Type=Application
+Categories=AudioVideo;Audio;


### PR DESCRIPTION
When you run `zynaddsubfx` without any options, it seems to be equivalent to:

    zynaddsubfx -I alsa -O jack

which means that it takes the input from alsa, and sends the output to Jack. It turns out that for some reason (no idea why), any midi device is recognize as an alsa device, at least using qjackctl:

![image](https://user-images.githubusercontent.com/2164118/102535524-a01ef980-40a8-11eb-947e-92a6c37ef59b.png)

so if you run `zynaddsubfx -I jack -O jack` instead, then you will get a midi device that is impossible to connect to any other midi device:

![image](https://user-images.githubusercontent.com/2164118/102535845-13287000-40a9-11eb-8dd8-905ef11eb1dd.png)

Therefore, I don't really see why people would want to run `zynaddsubfx -I jack -O jack`... But it's what people will run if they naively click on the existing .desktop entry `ZynAddSubFX - Jack`.

This PR tries to mitigate that issue by making sure that people would, by default, click a version that can indeed connect to MIDI external keyboards.