### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -59,7 +59,7 @@ rtosc::Ports DynamicFilter::ports = {
 #undef rEnd
 #undef rObject
 
-DynamicFilter::DynamicFilter(EffectParams pars, const AbsTime *time)
+DynamicFilter::DynamicFilter(EffectParams pars)
     :Effect(pars),
       lfo(pars.srate, pars.bufsize),
       Pvolume(110),

--- a/src/Effects/DynamicFilter.h
+++ b/src/Effects/DynamicFilter.h
@@ -23,7 +23,7 @@ namespace zyn {
 class DynamicFilter:public Effect
 {
     public:
-        DynamicFilter(EffectParams pars, const AbsTime *time = nullptr);
+        DynamicFilter(EffectParams pars);
         ~DynamicFilter();
         void out(const Stereo<float *> &smp);
 

--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -236,7 +236,7 @@ void EffectMgr::changeeffectrt(int _nefx, bool avoidSmash)
                 efx = memory.alloc<EQ>(pars);
                 break;
             case 8:
-                efx = memory.alloc<DynamicFilter>(pars, time);
+                efx = memory.alloc<DynamicFilter>(pars);
                 break;
             //put more effect here
             default:

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -139,7 +139,7 @@ static const rtosc::Ports ports = {
             d.broadcast(d.loc, "i", (int)(log(c.cfg.OscilSize*1.0)/log(2.0)));
         }},
     {"clear-favorites:", rDoc("Clear favorite directories"), 0,
-        [](const char *msg, rtosc::RtData &d) {
+        [](const char *, rtosc::RtData &d) {
             Config &c = *(Config*)d.obj;
             for(int i=0; i<MAX_BANK_ROOT_DIRS; ++i)
                 c.cfg.favoriteList[i] = "";
@@ -158,7 +158,7 @@ static const rtosc::Ports ports = {
 
         }},
     {"favorites:", /*rProp(parameter)*/ 0, 0,
-        [](const char *msg, rtosc::RtData &d)
+        [](const char *, rtosc::RtData &d)
         {
             Config &c = *(Config*)d.obj;
             char        *argt = new char[MAX_BANK_ROOT_DIRS+1];

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -370,7 +370,7 @@ static const Ports automate_ports = {
 
 #undef  rBegin
 #undef  rEnd
-#define rBegin [](const char *msg, RtData &d) { Master *m = (Master*)d.obj
+#define rBegin [](const char *msg, RtData &d) { (void)msg; Master *m = (Master*)d.obj
 #define rEnd }
 
 static const Ports watchPorts = {

--- a/src/Misc/Microtonal.cpp
+++ b/src/Misc/Microtonal.cpp
@@ -637,8 +637,10 @@ int Microtonal::loadscl(SclInfo &scl, const char *filename)
         if(tmp[i] < 32)
             tmp[i] = 0;
 
-    snprintf(scl.Pname,    MICROTONAL_MAX_NAME_LEN, "%s", tmp);
-    snprintf(scl.Pcomment, MICROTONAL_MAX_NAME_LEN, "%s", tmp);
+    strncpy(scl.Pname,    tmp, MICROTONAL_MAX_NAME_LEN);
+    strncpy(scl.Pcomment, tmp, MICROTONAL_MAX_NAME_LEN);
+    scl.Pname[MICROTONAL_MAX_NAME_LEN-1] = 0;
+    scl.Pcomment[MICROTONAL_MAX_NAME_LEN-1] = 0;
 
     //loads the number of the notes
     if(loadline(file, &tmp[0]) != 0)

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -1096,7 +1096,7 @@ static int extractInt(const char *msg)
 
 static const char *chomp(const char *msg)
 {
-    while(*msg && *msg!='/') ++msg; \
+    while(*msg && *msg!='/') ++msg;
     msg = *msg ? msg+1 : msg;
     return msg;
 };

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -353,7 +353,9 @@ void Part::cloneTraits(Part &p) const
     CLONE(Plegatomode);
     CLONE(Pkeylimit);
 
-    CLONE(ctl);
+    // Controller has a refence, so it can not be re-assigned
+    // So, destroy and reconstruct it.
+    p.ctl.~Controller(); new (&p.ctl) Controller(this->ctl);
 }
 
 void Part::defaults()

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -154,7 +154,7 @@ static const Ports partPorts = {
         }
     },
     {"clear:", rProp(internal) rDoc("Reset Part To Defaults"), 0,
-        [](const char *, RtData &d)
+        [](const char *, RtData &)
         {
             //XXX todo forward this event for middleware to handle
             //Part *p = (Part*)d.obj;

--- a/src/Misc/Stereo.cpp
+++ b/src/Misc/Stereo.cpp
@@ -23,12 +23,4 @@ Stereo<T>::Stereo(const T &val)
     :l(val), r(val)
 {}
 
-template<class T>
-Stereo<T> &Stereo<T>::operator=(const Stereo<T> &nstr)
-{
-    l = nstr.l;
-    r = nstr.r;
-    return *this;
-}
-
 }

--- a/src/Misc/Stereo.h
+++ b/src/Misc/Stereo.h
@@ -23,9 +23,6 @@ struct Stereo {
         /**Initializes Stereo with left and right set to val
          * @param val the value for both channels*/
         Stereo(const T &val);
-        ~Stereo() {}
-
-        Stereo<T> &operator=(const Stereo<T> &smp);
 
         //data
         T l, r;

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -93,16 +93,6 @@ Controller::Controller(const SYNTH_T &synth_, const AbsTime *time_)
     resetall();
 }
 
-Controller &Controller::operator=(const Controller &c)
-{
-    //just pretend that undefined behavior doesn't exist...
-    memcpy(this, &c, sizeof(Controller));
-    return *this;
-}
-
-Controller::~Controller()
-{}
-
 void Controller::defaults()
 {
     pitchwheel.bendrange = 200; //2 halftones

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -25,8 +25,7 @@ class Controller
 {
     public:
         Controller(const SYNTH_T &synth, const AbsTime *time = nullptr);
-        Controller&operator=(const Controller &c);
-        ~Controller();
+
         void resetall();
 
         void add2XML(XMLwrapper& xml);

--- a/src/Params/EnvelopeParams.cpp
+++ b/src/Params/EnvelopeParams.cpp
@@ -28,7 +28,7 @@ namespace zyn {
 
 #define rObject EnvelopeParams
 #define rBegin [](const char *msg, RtData &d) { \
-    EnvelopeParams *env = (rObject*) d.obj
+    (void)* msg; EnvelopeParams *env = (rObject*) d.obj
 #define rEnd }
 
 #define dT127(var) limit( (int)roundf(log2f(var*100.0f + 1.0f) * 127.0f/12.0f), 0, 127 )

--- a/src/Plugin/CMakeLists.txt
+++ b/src/Plugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_compile_options(-Wno-parentheses) # disable warnings from Lv2 headers
 
 add_executable(lv2-ttl-generator ${CMAKE_SOURCE_DIR}/DPF/utils/lv2-ttl-generator/lv2_ttl_generator.c)
 

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI.cpp
@@ -80,6 +80,7 @@ protected:
     */
     void stateChanged(const char* key, const char* value) override
     {
+        (void)key; (void)value;
     }
 
 private:

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -200,9 +200,6 @@ const rtosc::Ports OscilGen::non_realtime_ports = {
             d.broadcast("/damage", "s", repath);
         }}};
 
-//unused:
-//#define rForwardCb [](const char *msg, rtosc::RtData &d) {\
-//    printf("forwarding...\n"); d.forward();}
 const rtosc::Ports OscilGen::realtime_ports{
     rSelf(OscilGen),
     rPresetType,

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -269,7 +269,8 @@ const rtosc::MergePorts OscilGen::ports{
 //operations on FFTfreqs
 inline void clearAll(fft_t *freqs, int oscilsize)
 {
-    memset(freqs, 0, oscilsize / 2 * sizeof(fft_t));
+    fft_t zero = 0;
+    std::fill_n(freqs, oscilsize / 2, zero);
 }
 
 inline void clearDC(fft_t *freqs)
@@ -1185,8 +1186,8 @@ void OscilGen::getspectrum(int n, float *spc, int what)
     if(what == 0) {
         for(int i = 0; i < n; ++i)
             outoscilFFTfreqs[i] = fft_t(spc[i], spc[i]);
-        memset(outoscilFFTfreqs + n, 0,
-               (synth.oscilsize / 2 - n) * sizeof(fft_t));
+        fft_t zero = 0;
+        std::fill_n(outoscilFFTfreqs + n, synth.oscilsize / 2 - n, zero);
         adaptiveharmonic(outoscilFFTfreqs, 0.0f);
         adaptiveharmonicpostprocess(outoscilFFTfreqs, n - 1);
         for(int i = 0; i < n; ++i)

--- a/src/UI/EnvelopeFreeEdit.cpp
+++ b/src/UI/EnvelopeFreeEdit.cpp
@@ -283,6 +283,7 @@ int EnvelopeFreeEdit::handle(int event)
               if (pair!=NULL) pair->redraw();
               return 1;
           }
+          // fall through
       case FL_DRAG:
           if (currentpoint>=0){
               old_mod_state = mod_state;

--- a/src/UI/EnvelopeUI.fl
+++ b/src/UI/EnvelopeUI.fl
@@ -60,7 +60,7 @@ class PointButton {open : {public Fl_Button, public Fl_Osc_Widget}}
 {
   Function {PointButton(int x,int y, int w, int h, const char *label=0):Fl_Button(x,y,w,h,label),Fl_Osc_Widget(this)} {open
   } {
-    code {} {}
+    code {(void)label;} {}
   }
   Function {rebase(std::string new_base)} {open
   } {
@@ -74,7 +74,8 @@ class PointButton {open : {public Fl_Button, public Fl_Osc_Widget}}
 class EnvelopeUI {open : {public Fl_Osc_Group,PresetsUI_}
 } {
   Function {EnvelopeUI(int x,int y, int w, int h, const char *label=0):Fl_Osc_Group(x,y,w,h)} {} {
-    code {freemodeeditwindow=NULL;
+    code {(void)label;
+freemodeeditwindow=NULL;
 envADSR=NULL;
 envASR=NULL;
 envADSRfilter=NULL;

--- a/src/UI/FilterUI.fl
+++ b/src/UI/FilterUI.fl
@@ -74,7 +74,7 @@ decl {using namespace zyn;} {public local
 class FilterUI {open : {public Fl_Osc_Group,PresetsUI_}
 } {
   Function {FilterUI(int x,int y, int w, int h, const char *label=0):Fl_Osc_Group(x,y,w,h)} {} {
-    code {nvowel=0;nformant=0;nseqpos=0;} {}
+    code {nvowel=0;nformant=0;nseqpos=0;(void)label;} {}
   }
   Function {~FilterUI()} {} {
     code {filterui->hide();

--- a/src/UI/Fl_Osc_Pane.cpp
+++ b/src/UI/Fl_Osc_Pane.cpp
@@ -48,7 +48,7 @@ void Fl_Osc_Window::init(Fl_Osc_Interface *osc_, std::string loc_)
         this->label(title_new.c_str());
     };
 #else
-    title_ext->callback = [this](string next) {};
+    title_ext->callback = [](string ) {};
 #endif
     title_orig = label();
 

--- a/src/UI/Fl_Osc_Slider.cpp
+++ b/src/UI/Fl_Osc_Slider.cpp
@@ -70,8 +70,8 @@ void Fl_Osc_Slider::cb(void)
     else if(osc_type == 'i')
         oscWrite(ext, "i", (int)(val-min_));
     else {
-	fprintf(stderr, "invalid `c' from slider %s%s, using `i'\n", loc.c_str(), ext.c_str());
-	oscWrite(ext, "i", (int)(val-min_));
+        fprintf(stderr, "invalid `c' from slider %s%s, using `i'\n", loc.c_str(), ext.c_str());
+        oscWrite(ext, "i", (int)(val-min_));
     }
     //OSC_value(val);
 
@@ -132,6 +132,7 @@ int Fl_Osc_Slider::handle(int ev, int X, int Y, int W, int H)
                         break;
                     case FL_CTRL:
                         divisor = 128;
+                        // fall through
                     default:
                         step_ = absrange / divisor;
                         if (step_ < 1)

--- a/src/UI/Fl_Osc_TSlider.cpp
+++ b/src/UI/Fl_Osc_TSlider.cpp
@@ -54,6 +54,7 @@ int Fl_Osc_TSlider::handle(int event)
                 return(1);
             tipwin->position(Fl::event_x_root()-Fl::event_x()+x(),
                              Fl::event_y_root()-Fl::event_y()+h()+y()+5);
+            // fall through
         case FL_DRAG:
             tipwin->showValue(transform(value()));
             break;

--- a/src/UI/Fl_Resonance_Graph.cpp
+++ b/src/UI/Fl_Resonance_Graph.cpp
@@ -135,8 +135,10 @@ int Fl_Resonance_Graph::handle(int event)
     if((event==FL_PUSH)||(event==FL_DRAG)){
         const bool leftbutton = Fl::event_button() == FL_LEFT_MOUSE;
 
-        if (x_<0) x_=0;if (y_<0) y_=0;
-        if (x_>=w()) x_=w();if (y_>=h()-1) y_=h()-1;
+        if (x_<0) x_=0;
+        if (y_<0) y_=0;
+        if (x_>=w()) x_=w();
+        if (y_>=h()-1) y_=h()-1;
 
         if ((oldx<0)||(oldx==x_)){
             int sn=(int)(x_*1.0/w()*N_RES_POINTS);

--- a/src/UI/FormantFilterGraph.cpp
+++ b/src/UI/FormantFilterGraph.cpp
@@ -63,7 +63,7 @@ void FormantFilterGraph::OSC_value(int x, const char *loc)
 }
 void FormantFilterGraph::OSC_value(unsigned x, void *v)
 {
-    assert(x = sizeof(Pvowels));
+    assert(x == sizeof(Pvowels));
     memcpy(&Pvowels[0], v, x);
     redraw();
 }

--- a/src/UI/NSM.C
+++ b/src/UI/NSM.C
@@ -73,6 +73,7 @@ NSM_Client::command_open(const char *name,
                          const char *client_id,
                          char **out_msg)
 {
+    (void) out_msg;
     zyn::Nio::stop();
 
     if(instance_name)
@@ -171,5 +172,7 @@ NSM_Client::command_active(bool active)
         ui->sm_indicator1->tooltip(NULL);
         ui->sm_indicator2->tooltip(NULL);
     }
+#else
+    (void)active;
 #endif
 }

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -149,13 +149,13 @@ maxkcounter->do_callback();}
         Fl_Button adeditbutton {
           label edit
           callback {
-	  if (Fl::event_shift())
-	      partui->showvoiceparams(n, true);
-	  else if (Fl::event_ctrl())
-	      partui->showvoiceparams(n, false);
-	  else
-	      partui->showparameters(n,0);
-	  }
+          if (Fl::event_shift())
+              partui->showvoiceparams(n, true);
+          else if (Fl::event_ctrl())
+              partui->showvoiceparams(n, false);
+          else
+              partui->showparameters(n,0);
+          }
           xywh {420 0 40 15} box THIN_UP_BOX labelsize 11
         }
         Fl_Button subeditbutton {
@@ -177,7 +177,7 @@ maxkcounter->do_callback();}
           label {Bass Drum}
           xywh {90 0 130 15} box THIN_DOWN_BOX labelfont 1 labelsize 10 align 20
           code0 {o->init("Pname");}
-	  callback { o->oscWrite(o->ext, "s", o->value()); }
+          callback { o->oscWrite(o->ext, "s", o->value()); }
           class Fl_Osc_Input
         }
         Fl_Check_Button adcheck {
@@ -532,8 +532,8 @@ else {bendrng->oscMove("pitchwheel.bendrange");}}
       Fl_Button {} {
         label {Reset all controllers}
         callback {o->oscWrite("defaults");//part->SetController(C_resetallcontrollers,0);
-	ctlwindow->update();
-	}
+        ctlwindow->update();
+        }
         xywh {5 110 210 20} box THIN_UP_BOX
         class Fl_Osc_Button
       }
@@ -724,7 +724,7 @@ inseffectui->refresh();}
         callback {(void)o;/*int x=(int) o->value();
 part->Pefxroute[ninseff]=x;
 if (x==2) part->partefx[ninseff]->setdryonly(true);
-	else part->partefx[ninseff]->setdryonly(false);*/}
+        else part->partefx[ninseff]->setdryonly(false);*/}
         xywh {235 110 80 15} down_box BORDER_BOX labelsize 10 align 6
         code0 {/*int x=part->Pefxroute[ninseff]; if (x==127) x=1;*/}
         code1 {o->init(("Pefxroute"+to_s(ninseff)).c_str());}
@@ -809,13 +809,13 @@ if (x==2) part->partefx[ninseff]->setdryonly(true);
       Fl_Choice {} {
         label Mode
         callback {if (o->value()==0) {
-		 for (int i=1;i<NUM_KIT_ITEMS;i++)
-		   partkititem[i]->deactivate();
-		 partkititem[0]->mutedcheck->deactivate();
+                 for (int i=1;i<NUM_KIT_ITEMS;i++)
+                   partkititem[i]->deactivate();
+                 partkititem[0]->mutedcheck->deactivate();
         } else {
-		 for (int i=1;i<NUM_KIT_ITEMS;i++)
-		   partkititem[i]->activate();
-                   partkititem[0]->mutedcheck->activate(); };}
+                 for (int i=1;i<NUM_KIT_ITEMS;i++)
+                   partkititem[i]->activate();
+                 partkititem[0]->mutedcheck->activate(); };}
         xywh {35 350 70 15} down_box BORDER_BOX labelsize 11 textfont 1 textsize 11
         code0 {o->init("Pkitmode");}
         class Fl_Osc_Choice
@@ -909,13 +909,13 @@ if (x==2) part->partefx[ninseff]->setdryonly(true);
           Fl_Button adeditbutton {
             label Edit
             callback {
-	    if (Fl::event_shift()) {
-	        showvoiceparams(0, true);
-	    } else if (Fl::event_ctrl()) {
-	        showvoiceparams(0, false);
-	    } else
-	        showparameters(0,0);
-	    }
+            if (Fl::event_shift()) {
+                showvoiceparams(0, true);
+            } else if (Fl::event_ctrl()) {
+                showvoiceparams(0, false);
+            } else
+                showparameters(0,0);
+            }
             xywh {15 281 80 34} color 51 selection_color 51 labelfont 1 labelsize 13 align 128
           }
         }
@@ -956,7 +956,7 @@ if (x==2) part->partefx[ninseff]->setdryonly(true);
           xywh {5 60 385 50} type Multiline color 124 labelsize 10 align 5
           code0 {o->maximum_size(MAX_INFO_TEXT_SIZE);}
           code1 {o->init("info.Pauthor");}
-	  callback { o->oscWrite(o->ext, "s", o->value()); }
+          callback { o->oscWrite(o->ext, "s", o->value()); }
           class Fl_Osc_Input
         }
         Fl_Input {} {
@@ -964,7 +964,7 @@ if (x==2) part->partefx[ninseff]->setdryonly(true);
           xywh {5 125 385 90} type Multiline color 124 labelsize 11 align 5
           code0 {o->maximum_size(MAX_INFO_TEXT_SIZE);}
           code1 {o->init("info.Pcomments");}
-	  callback { o->oscWrite(o->ext, "s", o->value()); }
+          callback { o->oscWrite(o->ext, "s", o->value()); }
           class Fl_Osc_Input
         }
         Fl_Choice {} {
@@ -1141,10 +1141,10 @@ if(adnoteui ||
         adnoteui->ADnoteVoiceList->show();
     else {
         if (adnoteui->advoice->mod_type->value() == 0)
-	    adnoteui->advoice->voiceFMparametersgroup->deactivate();
-	else
-	    adnoteui->advoice->voiceFMparametersgroup->activate();
-	adnoteui->ADnoteVoice->show();
+            adnoteui->advoice->voiceFMparametersgroup->deactivate();
+        else
+            adnoteui->advoice->voiceFMparametersgroup->activate();
+        adnoteui->ADnoteVoice->show();
     }}} {}}
 
   Function {~PartUI()} {} {

--- a/src/UI/VirKeyboard.fl
+++ b/src/UI/VirKeyboard.fl
@@ -155,6 +155,8 @@ for (i=0;i<N_OCT*12;i++){
      key->draw( ox + (kv + 7 * noct ) * white_up->w() - black_up->w() / 2 + 2, oy );
    }
 }
+(void)lx;
+(void)ly;
 \#else
 if (damage()!=1){
  fl_color(250,240,230);

--- a/src/UI/VirKeyboard.fl
+++ b/src/UI/VirKeyboard.fl
@@ -152,7 +152,7 @@ for (i=0;i<N_OCT*12;i++){
      else
        key = black_down;
 
-       key->draw( ox + (kv + 7 * noct ) * white_up->w() - black_up->w() / 2 + 2, oy );
+     key->draw( ox + (kv + 7 * noct ) * white_up->w() - black_up->w() / 2 + 2, oy );
    }
 }
 \#else

--- a/src/UI/WidgetPDial.cpp
+++ b/src/UI/WidgetPDial.cpp
@@ -84,6 +84,7 @@ int WidgetPDial::handle(int event)
             }
             oldvalue = value();
             old_y = Fl::event_y();
+            // fall through
         case FL_DRAG:
             getPos();
             old_mod_state = mod_state;

--- a/tlsf/tlsf.c
+++ b/tlsf/tlsf.c
@@ -351,11 +351,11 @@ static block_header_t* search_suitable_block(control_t* control, int* fli, int* 
 	** First, search for a block in the list associated with the given
 	** fl/sl index.
 	*/
-	unsigned int sl_map = control->sl_bitmap[fl] & (~0 << sl);
+	unsigned int sl_map = control->sl_bitmap[fl] & (~0U << sl);
 	if (!sl_map)
 	{
 		/* No block exists. Search in the next largest first-level list. */
-		const unsigned int fl_map = control->fl_bitmap & (~0 << (fl + 1));
+		const unsigned int fl_map = control->fl_bitmap & (~0U << (fl + 1));
 		if (!fl_map)
 		{
 			/* No free blocks available, memory has been exhausted. */


### PR DESCRIPTION
Almost all warnings for gcc 10.2.0 and clang 11.0.0 are gone after this PR (together with #100 and #103).