### PR TITLE
[CMAKE] Fix configuration error on Windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -451,7 +451,7 @@ if(FltkGui)
 	find_program (FLTK_CONFIG fltk-config)
 	if (FLTK_CONFIG)
 		execute_process (COMMAND ${FLTK_CONFIG} --use-images --ldflags OUTPUT_VARIABLE FLTK_LDFLAGS)
-		string(STRIP ${FLTK_LDFLAGS} FLTK_LIBRARIES)
+		string(STRIP "${FLTK_LDFLAGS}" FLTK_LIBRARIES)
 	endif()
 
 	message(STATUS ${FLTK_LDFLAGS})


### PR DESCRIPTION
I'm trying to compile ZynAddSubFx with MinGW-W64, but I got this error when CMake configured the build:

```
CMake Error at src/CMakeLists.txt:455 (string):
  string sub-command STRIP requires two arguments.
```

While CMakeLists.txt file does syntactically contain two arguments, ${FLTK_LDFLAGS} can be empty. If this happens, then the string() function never receives the correct number of parameters, which then sees just one. If the string could be empty, then CMakeLists.txt must quote it.

EDIT: I just discovered that into `doc/win64-mingw64-msys2/README.txt` there is a `sed` command for patching the CMake file, but actually it is a bit unknown to me the reason because it has not been applied directly to `CMakeLists.txt`, since in my opinion it should be the right way to do it.