### PR TITLE
Implement ZynAddSubFX::loadProgram

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -2433,6 +2433,11 @@ void MiddleWare::pendingSetProgram(int part, int program)
     impl->bToU->write("/setprogram", "cc", part, program);
 }
 
+std::string zyn::MiddleWare::getProgramName(int program) const
+{
+    return impl->master->bank.ins[program].name;
+}
+
 std::string MiddleWare::activeUrl(void) const
 {
     return impl->last_url;

--- a/src/Misc/MiddleWare.h
+++ b/src/Misc/MiddleWare.h
@@ -76,6 +76,8 @@ class MiddleWare
         //NOTE: Can only be called by realtime thread
         void pendingSetProgram(int part, int program);
 
+        std::string getProgramName(int program) const;
+
         //Get/Set the active bToU url
         std::string activeUrl(void) const;
         void activeUrl(std::string u);

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI.cpp
@@ -72,6 +72,7 @@ protected:
     */
     void programLoaded(uint32_t index) override
     {
+        (void)index; // ZynAddSubFX::loadProgram already informs the UI
     }
 
    /**

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -273,7 +273,7 @@ protected:
     */
     void initProgramName(uint32_t index, String& programName) override
     {
-        programName = "Default";
+        programName = middleware->getProgramName(index).c_str();
     }
 
    /**
@@ -282,7 +282,8 @@ protected:
     */
     void loadProgram(uint32_t index) override
     {
-        setState(nullptr, defaultState);
+        //in plugin mode, only the first part is useful
+        middleware->pendingSetProgram(0, index);
     }
 
    /* --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is a draft PR that I could not test, because I don't know how to use this functionality. falkTX said that these functions can not be accessed by Lv2, but by using jack "directly", but I gave up trying to find out how. fundamental said that I could copy the code mostly from `src/Nio/InMgr.cpp`.

As I could not test this, it's questionable if anything of this works. 

Intention of this PR: Fix compiler warnings (unused parameters).