### PR TITLE
Fix a typo: depricated -> deprecated

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -577,7 +577,7 @@ static const Ports master_ports = {
         rBOIL_END},
     {"bank/", rDoc("Controls for instrument banks"), &bankPorts,
             [](const char*,RtData&) {}},
-    {"learn:s", rProp(depricated) rDoc("MIDI Learn"), 0,
+    {"learn:s", rProp(deprecated) rDoc("MIDI Learn"), 0,
         rBegin;
         int free_slot = m->automate.free_slot();
         if(free_slot >= 0) {


### PR DESCRIPTION
This is a minor typo, but has an impact on documentation IIUC. 

Apologies if you feel I've been spamming you with minor fixes - I'm still learning the projects' work style. I can also package those small modifications with larger ones if you prefer fewer PRs.