### PR TITLE
Plugin: Zest: Auto update UI when loading presets from host

### DIFF
--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI-Zest.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI-Zest.cpp
@@ -35,6 +35,7 @@ struct zest_handles {
     void (*zest_resize)(zest_t *z, int w, int h);
     void (*zest_special)(zest_t *z, int key, int press);
     int (*zest_tick)(zest_t*);
+    void (*zest_forget_all_state) (zest_t*);
     zest_t *zest;
 };
 
@@ -95,6 +96,7 @@ public:
             get_sym(mouse);
             get_sym(special);
             get_sym(resize);
+            get_sym(forget_all_state);
         }
         oscPort = -1;
         printf("[INFO] Ready to run\n");
@@ -142,6 +144,11 @@ protected:
     */
     void programLoaded(uint32_t index) override
     {
+        // Tell Zest that we need to reload the UI.
+        // Currently Zyn-Fusion doesn't use built-in program,
+        //   and this event may not be raised.
+        if(z.zest)
+            z.zest_forget_all_state(z.zest);
     }
 
    /**
@@ -150,6 +157,11 @@ protected:
     */
     void stateChanged(const char* key, const char* value) override
     {
+        // Tell Zest that we need to reload the UI.
+        // This event will be raised when you load a preset from your host,
+        //   or during UI loads.
+        if(z.zest)
+            z.zest_forget_all_state(z.zest);
     }
 
    /* --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
DAWs like REAPER support saving VST's state as so-called "user presets"
(or directly saving it into project file). And in most VST plugins,
when you load a "user preset", the state (aka. configurations) of that
plugin is restored, and the UI is also updated according to the state.
For example, when you load a state for Dragonfly Reverb, all the knobs
will point to where you've configured at that time.

However, currently ZynAddSubFX cannot do this whatever the UI module
I use (Zest or NTK). It can still load state, but the UI still keeps
unchanged, not showing my manually-configured parameters. This will
be great trouble to DAW users.

To solve this issue, I need to invoke a method to update Zest UI in
DISTHRO::UI::stateChanged(). This event is raised every time when VST
host loads presets, or reloads UI.

The corresponding UI-update method in Zest is zest_forget_all_state().
When invoke it in the Plugin side, Zest UI will automatically update to
match current settings.

Related commit (mruby-zest-build): d05c1af692b4faa0c2b99acc2af0