### PR TITLE
Bump C++ version to C++14

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
 endif()
 
 CHECK_FUNCTION_EXISTS(sched_setscheduler HAVE_SCHEDULER)
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+set(CMAKE_REQUIRED_FLAGS "-std=c++14")
 CHECK_CXX_SOURCE_COMPILES(
     "#include <future>
     #if ATOMIC_INT_LOCK_FREE<2
@@ -262,14 +262,15 @@ set (BuildOptions_SSE
 
 check_cxx_compiler_flag("${BuildOptions_SSE} -Werror" SUPPORT_SSE)
 
+set (CMAKE_CXX_STANDARD 14)
 set (BuildOptionsBasic
-    "-std=c++11 -Wno-unused-parameter -O3 -ffast-math -fomit-frame-pointer"
+    "-Wno-unused-parameter -O3 -ffast-math -fomit-frame-pointer"
     CACHE STRING "basic X86 compiler options"
 )
 STRING(APPEND BuildOptionsBasic " ${BuildOptions_ExtendedWarnings}")
 
 set (BuildOptionsDebug
-    "-std=c++11 -O0 -g3 -ggdb -Wall -Wno-unused-parameter -Wpointer-arith"
+    "-O0 -g3 -ggdb -Wall -Wno-unused-parameter -Wpointer-arith"
     CACHE STRING "Debug build flags")
 STRING(APPEND BuildOptionsDebug " ${BuildOptions_ExtendedWarnings}")
 

--- a/src/Tests/CMakeLists.txt
+++ b/src/Tests/CMakeLists.txt
@@ -6,6 +6,7 @@ endfunction()
 #for tests looking for files stored in the source dir
 add_definitions(-DSOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
+CXXTEST_ADD_TEST(CppTest CppTest.cpp ${CMAKE_CURRENT_SOURCE_DIR}/CppTest.h)
 CXXTEST_ADD_TEST(ControllerTest ControllerTest.cpp ${CMAKE_CURRENT_SOURCE_DIR}/ControllerTest.h)
 CXXTEST_ADD_TEST(EchoTest EchoTest.cpp ${CMAKE_CURRENT_SOURCE_DIR}/EchoTest.h)
 #CXXTEST_ADD_TEST(SampleTest SampleTest.h)
@@ -41,6 +42,7 @@ set(test_lib zynaddsubfx_core ${GUI_LIBRARIES} ${ZLIB_LIBRARY} ${FFTW_LIBRARIES}
     ${MXML_LIBRARIES} pthread "-Wl,--no-as-needed -lpthread")
 
 message(STATUS "Linking tests with: ${test_lib}")
+target_link_libraries(CppTest        ${test_lib})
 target_link_libraries(ADnoteTest     ${test_lib})
 target_link_libraries(SUBnoteTest    ${test_lib})
 target_link_libraries(ControllerTest ${test_lib})

--- a/src/Tests/CppTest.h
+++ b/src/Tests/CppTest.h
@@ -1,0 +1,41 @@
+#ifndef MSGPARSETEST_H
+#define MSGPARSETEST_H
+
+#include <cstddef>
+#include <utility>
+#include <cxxtest/TestSuite.h>
+
+template<std::size_t N>
+class MyArray
+{
+    template<std::size_t ... Indices>
+    MyArray<N> copy_internal(std::index_sequence<Indices...>) const {
+        return MyArray<N>{{data[Indices]...}};
+    }
+
+public:
+    std::size_t data[N];
+    MyArray<N> copy() const
+    {
+        // make_index_sequence is introduced in C++14
+        return copy_internal(std::make_index_sequence<N>{});
+    }
+};
+
+class CppTest:public CxxTest::TestSuite
+{
+    public:
+        void setUp() {}
+        void tearDown() {}
+
+        void testCpp14() {
+            // test std::make_index_sequence
+            MyArray<3> a1 {1, 2, 3}, a2 {0, 0, 0};
+            a2 = a1.copy();
+            TS_ASSERT_EQUALS(a2.data[0], 1);
+            TS_ASSERT_EQUALS(a2.data[1], 2);
+            TS_ASSERT_EQUALS(a2.data[2], 3);
+        }
+};
+
+#endif // MSGPARSETEST_H


### PR DESCRIPTION
For use of `CMAKE_CXX_STANDARD`, this commit raises CMake's version from
3.0 to 3.1.