### PR TITLE
make Compressor in Audio Output optional

### DIFF
--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -322,7 +322,7 @@ void Config::readConfig(const char *filename)
                                        cfg.SwapStereo,
                                        0,
                                        1);
-        cfg.SwapStereo = xmlcfg.getpar("audio_output_compressor",
+        cfg.AudioOutputCompressor = xmlcfg.getpar("audio_output_compressor",
                                        cfg.AudioOutputCompressor,
                                        0,
                                        1);

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -47,6 +47,7 @@ static const rtosc::Ports ports = {
     rParamI(cfg.SoundBufferSize, "Size of processed audio buffer"),
     rParamI(cfg.OscilSize, "Size Of Oscillator Wavetable"),
     rToggle(cfg.SwapStereo, "Swap Left And Right Channels"),
+    rToggle(cfg.AudioOutputCompressor, "Apply Compressor to Audio Output"),
     rToggle(cfg.BankUIAutoClose, "Automatic Closing of BackUI After Patch Selection"),
     rParamI(cfg.GzipCompression, "Level of Gzip Compression For Save Files"),
     rParamI(cfg.Interpolation, "Level of Interpolation, Linear/Cubic"),
@@ -193,6 +194,7 @@ void Config::init()
     cfg.SoundBufferSize = 256;
     cfg.OscilSize  = 1024;
     cfg.SwapStereo = 0;
+    cfg.AudioOutputCompressor = 0;
 
     cfg.oss_devs.linux_wave_out = new char[MAX_STRING_SIZE];
     snprintf(cfg.oss_devs.linux_wave_out, MAX_STRING_SIZE, "/dev/dsp");
@@ -320,6 +322,10 @@ void Config::readConfig(const char *filename)
                                        cfg.SwapStereo,
                                        0,
                                        1);
+        cfg.SwapStereo = xmlcfg.getpar("audio_output_compressor",
+                                       cfg.AudioOutputCompressor,
+                                       0,
+                                       1);
         cfg.BankUIAutoClose = xmlcfg.getpar("bank_window_auto_close",
                                             cfg.BankUIAutoClose,
                                             0,
@@ -411,6 +417,7 @@ void Config::saveConfig(const char *filename) const
     xmlcfg->addpar("sound_buffer_size", cfg.SoundBufferSize);
     xmlcfg->addpar("oscil_size", cfg.OscilSize);
     xmlcfg->addpar("swap_stereo", cfg.SwapStereo);
+    xmlcfg->addpar("audio_output_compressor", cfg.AudioOutputCompressor);
     xmlcfg->addpar("bank_window_auto_close", cfg.BankUIAutoClose);
 
     xmlcfg->addpar("gzip_compression", cfg.GzipCompression);

--- a/src/Misc/Config.h
+++ b/src/Misc/Config.h
@@ -42,6 +42,7 @@ class Config
         struct {
             oss_devs_t oss_devs;
             int   SampleRate, SoundBufferSize, OscilSize, SwapStereo;
+            bool  AudioOutputCompressor;
             int   WindowsWaveOutId, WindowsMidiInId;
             int   BankUIAutoClose;
             int   GzipCompression;

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1139,6 +1139,10 @@ bool Master::hasMasterCb() const
     return !!mastercb;
 }
 
+void Master::setAudioCompressor(bool enabled)
+{
+    Nio::setAudioCompressor(enabled);
+}
 
 #if 0
 template <class T>

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -140,6 +140,7 @@ class Master
         //Copy callback to other master
         void copyMasterCbTo(Master* dest);
         bool hasMasterCb() const;
+        void setAudioCompressor(bool enabled);
 
         /**parts \todo see if this can be made to be dynamic*/
         class Part * part[NUM_MIDI_PARTS];

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -513,6 +513,11 @@ namespace Nio
                     d.reply(d.loc, "s", Nio::getSink().c_str());
                 else
                     Nio::setSink(rtosc_argument(msg,0).s);}},
+        {"audio-compressor::T:F", 0, 0, [](const char *msg, rtosc::RtData &d) {
+                if(rtosc_narguments(msg) == 0)
+                    d.reply(d.loc, Nio::getAudioCompressor() ? "T" : "F");
+                else
+                    Nio::setAudioCompressor(rtosc_argument(msg,0).T);}},
     };
 }
 

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -292,7 +292,7 @@ short *AlsaEngine::interleave(const Stereo<float *> &smps)
     for(int frame = 0; frame < bufferSize; ++frame) { // with a nod to libsamplerate ...
         float l = smps.l[frame];
         float r = smps.r[frame];
-        stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
+        //~ stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
 
         scaled = l * (8.0f * 0x10000000);
         shortInterleaved[idx++] = (short int)(lrint(scaled) >> 16);

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -292,7 +292,8 @@ short *AlsaEngine::interleave(const Stereo<float *> &smps)
     for(int frame = 0; frame < bufferSize; ++frame) { // with a nod to libsamplerate ...
         float l = smps.l[frame];
         float r = smps.r[frame];
-        //~ stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
+        if(isOutputCompressionEnabled)
+            stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
 
         scaled = l * (8.0f * 0x10000000);
         shortInterleaved[idx++] = (short int)(lrint(scaled) >> 16);

--- a/src/Nio/AudioOut.h
+++ b/src/Nio/AudioOut.h
@@ -41,6 +41,8 @@ class AudioOut:public virtual Engine
 
         virtual void setAudioEn(bool nval) = 0;
         virtual bool getAudioEn() const    = 0;
+        
+        bool isOutputCompressionEnabled = 0;
 
     protected:
         /**Get the next sample for output.
@@ -50,6 +52,7 @@ class AudioOut:public virtual Engine
         const SYNTH_T &synth;
         int samplerate;
         int bufferSize;
+        
 };
 
 }

--- a/src/Nio/JackEngine.cpp
+++ b/src/Nio/JackEngine.cpp
@@ -348,11 +348,11 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
     memcpy(audio.portBuffs[1], smp.r, bufferSize * sizeof(float));
 
     //Make sure the audio output doesn't overflow
-    for(int frame = 0; frame != bufferSize; ++frame) {
-        float &l = audio.portBuffs[0][frame];
-        float &r = audio.portBuffs[1][frame];
-        stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
-    }
+    //~ for(int frame = 0; frame != bufferSize; ++frame) {
+        //~ float &l = audio.portBuffs[0][frame];
+        //~ float &r = audio.portBuffs[1][frame];
+        //~ stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
+    //~ }
     return true;
 }
 

--- a/src/Nio/JackEngine.cpp
+++ b/src/Nio/JackEngine.cpp
@@ -348,11 +348,14 @@ bool JackEngine::processAudio(jack_nframes_t nframes)
     memcpy(audio.portBuffs[1], smp.r, bufferSize * sizeof(float));
 
     //Make sure the audio output doesn't overflow
-    //~ for(int frame = 0; frame != bufferSize; ++frame) {
-        //~ float &l = audio.portBuffs[0][frame];
-        //~ float &r = audio.portBuffs[1][frame];
-        //~ stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
-    //~ }
+    if(isOutputCompressionEnabled)
+    {
+        for(int frame = 0; frame != bufferSize; ++frame) {
+            float &l = audio.portBuffs[0][frame];
+            float &r = audio.portBuffs[1][frame];
+            stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
+        }
+    }
     return true;
 }
 

--- a/src/Nio/JackMultiEngine.cpp
+++ b/src/Nio/JackMultiEngine.cpp
@@ -154,12 +154,13 @@ int JackMultiEngine::processAudio(jack_nframes_t nframes)
     const int maxFrames = (synth.bufferbytes / sizeof(float));
 
     //Make sure the audio output doesn't overflow
-    for(int frame = 0; frame != maxFrames; ++frame) {
-	float &p = impl->peaks[0];
-	float &l = buffers[0][frame];
-	float &r = buffers[1][frame];
-	stereoCompressor(synth.samplerate, p, l, r);
-    }
+    if(isOutputCompressionEnabled)
+        for(int frame = 0; frame != maxFrames; ++frame) {
+            float &p = impl->peaks[0];
+            float &l = buffers[0][frame];
+            float &r = buffers[1][frame];
+            stereoCompressor(synth.samplerate, p, l, r);
+        }
 
     //Gather other samples from individual parts
     Master &master = *middleware->spawnMaster();
@@ -170,11 +171,12 @@ int JackMultiEngine::processAudio(jack_nframes_t nframes)
         memcpy(buffers[2*i + 3], master.part[i]->partoutr, synth.bufferbytes);
 
         //Make sure the audio output doesn't overflow
-        for(int frame = 0; frame != maxFrames; ++frame) {
-            float &l = buffers[2*i + 2][frame];
-            float &r = buffers[2*i + 3][frame];
-            stereoCompressor(synth.samplerate, p, l, r);
-        }
+        if(isOutputCompressionEnabled)
+            for(int frame = 0; frame != maxFrames; ++frame) {
+                float &l = buffers[2*i + 2][frame];
+                float &r = buffers[2*i + 3][frame];
+                stereoCompressor(synth.samplerate, p, l, r);
+            }
     }
 
     return false;

--- a/src/Nio/Nio.cpp
+++ b/src/Nio/Nio.cpp
@@ -187,4 +187,14 @@ void Nio::waveEnd(void)
     out->wave->destroyFile();
 }
 
+void Nio::setAudioCompressor(bool isEnabled)
+{
+    out->setAudioCompressor(isEnabled);
+}
+
+bool Nio::getAudioCompressor(void)
+{
+    return out->getAudioCompressor();
+}
+
 }

--- a/src/Nio/Nio.h
+++ b/src/Nio/Nio.h
@@ -56,6 +56,9 @@ namespace Nio
     void waveStart(void);
     void waveStop(void);
     void waveEnd(void);
+    
+    void setAudioCompressor(bool isEnabled);
+    bool getAudioCompressor(void);
 
     extern bool autoConnect;
     extern bool pidInClientName;

--- a/src/Nio/OssEngine.cpp
+++ b/src/Nio/OssEngine.cpp
@@ -415,7 +415,8 @@ void *OssEngine::audioThreadCb()
         for(int i = 0; i < synth.buffersize; ++i) {
             float l = smps.l[i];
             float r = smps.r[i];
-            stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
+            if(isOutputCompressionEnabled)
+                stereoCompressor(synth.samplerate, audio.peaks[0], l, r);
 
             if (audio.is32bit) {
                 audio.smps.ps32[i * 2]     = (int) (l * 2147483647.0f);

--- a/src/Nio/OssMultiEngine.cpp
+++ b/src/Nio/OssMultiEngine.cpp
@@ -239,7 +239,8 @@ OssMultiEngine :: audioThreadCb()
                 for (y = 0; y != synth.buffersize; y++) {
                     float l = part->partoutl[y];
                     float r = part->partoutr[y];
-                    stereoCompressor(synth.samplerate, peaks[x/2], l, r);
+                    if(isOutputCompressionEnabled)
+                        stereoCompressor(synth.samplerate, peaks[x/2], l, r);
                     smps.ps32[y * channels + x] = (int)(l * 2147483647.0f);
                     smps.ps32[y * channels + x + 1] = (int)(r * 2147483647.0f);
                 }
@@ -247,7 +248,8 @@ OssMultiEngine :: audioThreadCb()
                 for (y = 0; y != synth.buffersize; y++) {
                     float l = part->partoutl[y];
                     float r = part->partoutr[y];
-                    stereoCompressor(synth.samplerate, peaks[x/2], l, r);
+                    if(isOutputCompressionEnabled)
+                        stereoCompressor(synth.samplerate, peaks[x/2], l, r);
                     smps.ps16[y * channels + x] = (short int)(l * 32767.0f);
                     smps.ps16[y * channels + x + 1] = (short int)(r * 32767.0f);
                 }

--- a/src/Nio/OutMgr.cpp
+++ b/src/Nio/OutMgr.cpp
@@ -127,7 +127,6 @@ string OutMgr::getSink() const
 
 void OutMgr::setAudioCompressor(bool isEnabled)
 {
-    printf("OutMgr - setting isOutputCompressionEnabled to: %d\n", isEnabled);
     currentOut->isOutputCompressionEnabled=isEnabled;
 }
 

--- a/src/Nio/OutMgr.cpp
+++ b/src/Nio/OutMgr.cpp
@@ -125,6 +125,17 @@ string OutMgr::getSink() const
     return "ERROR";
 }
 
+void OutMgr::setAudioCompressor(bool isEnabled)
+{
+    printf("OutMgr - setting isOutputCompressionEnabled to: %d\n", isEnabled);
+    currentOut->isOutputCompressionEnabled=isEnabled;
+}
+
+bool OutMgr::getAudioCompressor(void)
+{
+    return currentOut->isOutputCompressionEnabled;
+}
+
 void OutMgr::setMaster(Master *master_)
 {
     master=master_;

--- a/src/Nio/OutMgr.h
+++ b/src/Nio/OutMgr.h
@@ -49,7 +49,7 @@ class OutMgr
         std::string getDriver() const;
 
         bool setSink(std::string name);
-        
+
         std::string getSink() const;
         
         void setAudioCompressor(bool isEnabled);

--- a/src/Nio/OutMgr.h
+++ b/src/Nio/OutMgr.h
@@ -49,8 +49,11 @@ class OutMgr
         std::string getDriver() const;
 
         bool setSink(std::string name);
-
+        
         std::string getSink() const;
+        
+        void setAudioCompressor(bool isEnabled);
+        bool getAudioCompressor(void);
 
         class WavEngine * wave;     /**<The Wave Recorder*/
         friend class EngineMgr;

--- a/src/Output/DSSIaudiooutput.cpp
+++ b/src/Output/DSSIaudiooutput.cpp
@@ -47,6 +47,8 @@ namespace Nio {
     set<string> getSinks(void){return set<string>();}
     string getSource(void){return "";}
     string getSink(void){return "";}
+    void setAudioCompressor(bool){}
+    bool getAudioCompressor(void){return false;}
 }
 } // namespace zyn
 

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -606,5 +606,7 @@ namespace Nio {
    void waveNew(WavFile*){}
    void waveStart(){}
    void waveStop(){}
+   void setAudioCompressor(bool){}
+   bool getAudioCompressor(void){return false;}
 }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,7 @@ MiddleWare *middleware;
 
 Master   *master;
 int       swaplr = 0; //1 for left-right swapping
+bool      compr = false; // enables output audio compressor
 
 // forward declarations of namespace zyn
 namespace zyn
@@ -241,6 +242,7 @@ int main(int argc, char *argv[])
     synth.buffersize = config.cfg.SoundBufferSize;
     synth.oscilsize  = config.cfg.OscilSize;
     swaplr = config.cfg.SwapStereo;
+    compr = config.cfg.AudioOutputCompressor;
 
     Nio::preferredSampleRate(synth.samplerate);
 
@@ -607,6 +609,7 @@ int main(int argc, char *argv[])
     if(altered_master)
         middleware->updateResources(master);
 
+    master->setAudioCompressor(compr);
     //Run the Nio system
     printf("[INFO] Nio::start()\n");
     bool ioGood = Nio::start();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -609,7 +609,7 @@ int main(int argc, char *argv[])
     if(altered_master)
         middleware->updateResources(master);
 
-    master->setAudioCompressor(compr);
+    
     //Run the Nio system
     printf("[INFO] Nio::start()\n");
     bool ioGood = Nio::start();
@@ -622,7 +622,7 @@ int main(int argc, char *argv[])
     }
 
     InitWinMidi(wmidi);
-
+    master->setAudioCompressor(compr);
 
     gui = NULL;
 


### PR DESCRIPTION
in this branch the StereoCompressor in the audio output will be changed to be optional an per default off to keep compatibility.