### PR TITLE
Voice limit

### DIFF
--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -29,6 +29,18 @@ enum NoteStatus {
     KEY_LATCHED                = 0x04
 };
 
+const char *getStatus(int status)
+{
+    switch((enum NoteStatus)(status&NOTE_MASK))
+    {
+        case KEY_OFF:                     return "OFF ";
+        case KEY_PLAYING:                 return "PLAY";
+        case KEY_RELEASED_AND_SUSTAINED:  return "SUST";
+        case KEY_RELEASED:                return "RELA";
+        case KEY_LATCHED:                 return "LTCH";
+        default:                          return "INVD";
+    }
+}
 
 NotePool::NotePool(void)
     :needs_cleaning(0)
@@ -372,19 +384,6 @@ void NotePool::entomb(NoteDescriptor &d)
     d.setStatus(KEY_RELEASED);
     for(auto &s:activeNotes(d))
         s.note->entomb();
-}
-
-const char *getStatus(int status_bits)
-{
-    switch(status_bits)
-    {
-        case 0:  return "OFF ";
-        case 1:  return "PLAY";
-        case 2:  return "SUST";
-        case 3:  return "RELA";
-        case 4:  return "LTCH";
-        default: return "INVD";
-    }
 }
 
 void NotePool::cleanup(void)

--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -125,7 +125,7 @@ static int getMergeableDescriptor(note_t note, uint8_t sendto, bool legato,
     return desc_id;
 }
 
-NotePool::activeDescIter      NotePool::activeDesc(void)
+NotePool::activeDescIter NotePool::activeDesc(void)
 {
     cleanup();
     return activeDescIter{*this};
@@ -252,7 +252,7 @@ bool NotePool::synthFull(int sdesc_count) const
     return actually_free < sdesc_count;
 }
 
-//Note that isn't KEY_PLAYING or KEY_RELEASED_AND_SUSTAINING
+//Note that isn't KEY_PLAYING or KEY_RELEASED_AND_SUSTAINED
 bool NotePool::existsRunningNote(void) const
 {
     //printf("running note # =%d\n", getRunningNotes());
@@ -274,6 +274,7 @@ int NotePool::getRunningNotes(void) const
     }
     return running_count;
 }
+
 void NotePool::enforceKeyLimit(int limit)
 {
     int notes_to_kill = getRunningNotes() - limit;

--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -382,6 +382,7 @@ const char *getStatus(int status_bits)
         case 1:  return "PLAY";
         case 2:  return "SUST";
         case 3:  return "RELA";
+        case 4:  return "LTCH";
         default: return "INVD";
     }
 }

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -139,7 +139,8 @@ class NotePool
         int getRunningNotes(void) const;
         void enforceKeyLimit(int limit);
         int getRunningVoices(void) const;
-        void enforceVoiceLimit(int limit);
+        void enforceVoiceLimit(int limit, int preferred_note);
+        void limitVoice(int preferred_note);
 
         void releasePlayingNotes(void);
         void releaseNote(note_t note);

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -138,6 +138,8 @@ class NotePool
         bool existsRunningNote(void) const;
         int getRunningNotes(void) const;
         void enforceKeyLimit(int limit);
+        int getRunningVoices(void) const;
+        void enforceVoiceLimit(int limit);
 
         void releasePlayingNotes(void);
         void releaseNote(note_t note);

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -44,6 +44,8 @@ class NotePool
             bool off(void) const;
             bool sustained(void) const;
             bool released(void) const;
+            bool entombed(void) const;
+            bool dying(void) const;
             bool latched(void) const;
 
             //status transitions

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -585,7 +585,7 @@ bool Part::NoteOnInternal(note_t note,
         const int sendto = Pkitmode ? item.sendto() : 0;
 
         // Enforce voice limit, before we trigger new note
-        limit_voices(true);
+        limit_voices(note);
 
         try {
             if(item.Padenabled)
@@ -893,7 +893,7 @@ void Part::setkeylimit(unsigned char Pkeylimit_)
 /*
  * Enforce voice limit
  */
-void Part::limit_voices(bool account_for_new_note)
+void Part::limit_voices(int new_note)
 {
     int voicelimit = Pvoicelimit;
     if(voicelimit == 0) /* voice limit disabled */
@@ -903,12 +903,12 @@ void Part::limit_voices(bool account_for_new_note)
      * one less note than the limit, so we don't go above the limit when the
      * new note is triggered.
      */
-    if (account_for_new_note)
+    if (new_note >= 0)
         voicelimit--;
 
     int running_voices = notePool.getRunningVoices();
     if(running_voices >= voicelimit)
-        notePool.enforceVoiceLimit(voicelimit);
+        notePool.enforceVoiceLimit(voicelimit, new_note);
 }
 
 /*
@@ -918,7 +918,7 @@ void Part::setvoicelimit(unsigned char Pvoicelimit_)
 {
     Pvoicelimit = Pvoicelimit_;
 
-    limit_voices(false);
+    limit_voices(-1);
 }
 
 /*

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -123,6 +123,7 @@ class Part
 
         //Part parameters
         void setkeylimit(unsigned char Pkeylimit);
+        void setvoicelimit(unsigned char Pvoicelimit);
         void setkititemstatus(unsigned kititem, bool Penabled_);
 
         unsigned char partno; /**<if it's the Master's first part*/
@@ -149,6 +150,7 @@ class Part
         bool Plegatomode; // 0=normal, 1=legato
         bool Platchmode; // 0=normal, 1=latch
         unsigned char Pkeylimit; //how many keys are allowed to be played same time (0=off), the older will be released
+        unsigned char Pvoicelimit; //how many voices are allowed to be played same time (0=off), the older will be entombed
 
         char *Pname; //name of the instrument
         struct { //instrument additional information
@@ -194,6 +196,8 @@ class Part
         bool killallnotes;
 
         NotePool notePool;
+
+        void limit_voices(bool account_for_new_note);
 
         bool lastlegatomodevalid; // To keep track of previous legatomodevalid.
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -197,7 +197,7 @@ class Part
 
         NotePool notePool;
 
-        void limit_voices(bool account_for_new_note);
+        void limit_voices(int new_note);
 
         bool lastlegatomodevalid; // To keep track of previous legatomodevalid.
 

--- a/src/Tests/KitTest.cpp
+++ b/src/Tests/KitTest.cpp
@@ -35,7 +35,8 @@ enum PrivateNoteStatus {
     KEY_OFF                    = 0x00,
     KEY_PLAYING                = 0x01,
     KEY_RELEASED_AND_SUSTAINED = 0x02,
-    KEY_RELEASED               = 0x03
+    KEY_RELEASED               = 0x03,
+    KEY_ENTOMBED               = 0x04
 };
 
 
@@ -710,6 +711,8 @@ class KitTest
             part->NoteOn(67, 127, 0);
             part->NoteOn(68, 127, 0);
 
+            printf("Keylimit 3: After noteons:\n");
+            pool.dump();
             //Verify that notes are spawned as expected with limit
             TS_ASSERT_EQUAL_INT(pool.getRunningNotes(),  3);//2 entombed
             TS_ASSERT_EQUAL_INT(pool.usedNoteDesc(),     5);
@@ -747,7 +750,7 @@ class KitTest
             TS_ASSERT_EQUAL_INT(pool.ndesc[0].note, 64);
             TS_ASSERT_EQUAL_INT(pool.ndesc[1].note, 65);
             TS_ASSERT_EQUAL_INT(pool.ndesc[2].note, 66);
-            TS_ASSERT_EQUAL_INT(pool.ndesc[2].status, KEY_RELEASED);
+            TS_ASSERT_EQUAL_INT(pool.ndesc[2].status, KEY_ENTOMBED);
             TS_ASSERT_EQUAL_INT(pool.ndesc[3].note, 67);
 
             part->NoteOn(68, 127, 0);
@@ -759,9 +762,9 @@ class KitTest
             //Check that the result is {64, 68, 67}
             TS_ASSERT_EQUAL_INT(pool.ndesc[0].note, 64);
             TS_ASSERT_EQUAL_INT(pool.ndesc[1].note, 65);
-            TS_ASSERT_EQUAL_INT(pool.ndesc[1].status, KEY_RELEASED);
+            TS_ASSERT_EQUAL_INT(pool.ndesc[1].status, KEY_ENTOMBED);
             TS_ASSERT_EQUAL_INT(pool.ndesc[2].note, 66);
-            TS_ASSERT_EQUAL_INT(pool.ndesc[2].status, KEY_RELEASED);
+            TS_ASSERT_EQUAL_INT(pool.ndesc[2].status, KEY_ENTOMBED);
             TS_ASSERT_EQUAL_INT(pool.ndesc[3].note, 67);
             TS_ASSERT_EQUAL_INT(pool.ndesc[4].note, 68);
         }

--- a/src/Tests/guitar-adnote.xmz
+++ b/src/Tests/guitar-adnote.xmz
@@ -45,6 +45,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="poly_mode" value="yes" />
 <par name="legato_mode" value="0" />
 <par name="key_limit" value="15" />
+<par name="voice_limit" value="0" />
 <INSTRUMENT>
 <INFO>
 <string name="name">Dist Guitar 2</string>
@@ -1301,6 +1302,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="poly_mode" value="yes" />
 <par name="legato_mode" value="0" />
 <par name="key_limit" value="15" />
+<par name="voice_limit" value="0" />
 <INSTRUMENT>
 <INFO>
 <string name="name"></string>
@@ -1573,6 +1575,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="poly_mode" value="yes" />
 <par name="legato_mode" value="0" />
 <par name="key_limit" value="15" />
+<par name="voice_limit" value="0" />
 <INSTRUMENT>
 <INFO>
 <string name="name"></string>


### PR DESCRIPTION
Here's my attempt at adding a settable voice limit per part (Pvoicelimit), similar to Pkeylimit, except it really limits the number of voices sounding not just the number of notes actually being played. This way, sounds with long release times won't cause xruns when playing lots of notes. In effect, the part will behave like a classic synthesizer with a fixed number of voices.

Caveat: voices which are silenced are entombed rather than killed, meaning that for a brief period after stealing voices there will be more voices playing than the voice limit governs. I felt this was still preferable to killing the voices as that results in audible clicks, and the voice limit is not a hard DSP limit anyway.

Effort has been made to select the most appropriate note to steal every time