### PR TITLE
Fix delaying portamento bug (#304)

### DIFF
--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -275,8 +275,6 @@ int Controller::initportamento(float oldfreq_log2,
                                float newfreq_log2,
                                bool legatoflag)
 {
-    portamento.x = 0.0f;
-
     if(legatoflag) {  // Legato in progress
         if(portamento.portamento == 0)
             return 0;
@@ -311,6 +309,7 @@ int Controller::initportamento(float oldfreq_log2,
                                (64.0f - portamento.updowntimestretch) / 64.0f);
     }
 
+    portamento.x = 0.0f;
     portamento.dx = synth.buffersize_f / (portamentotime * synth.samplerate_f);
     portamento.origfreqdelta_log2 = deltafreq_log2;
 


### PR DESCRIPTION
Resetting portamento.x to 0 at the start of initportamento() causes
the actual portamento process to restart from zero every time a new note
is played - for the note that is currently exhibiting portamento
(there is only one per voice (or actually, per Controller)). The
result is that subsequently played note(s) will not have portamento
until the ongoing restarted portamento cycle has completed.

Fix this by simply not resetting portamento.x until such time that
initportamento() has decided to actually initate a portamento cycle.