### PR TITLE
src/CMakeLists.txt: use the target compiler during config tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,9 +59,10 @@ find_library(HAVE_LIBRT rt)
 set(CMAKE_REQUIRED_FLAGS "")
 
 
-execute_process(COMMAND echo fistpl 0
-                COMMAND as -
-                ERROR_VARIABLE AVOID_ASM)
+CHECK_CXX_SOURCE_COMPILES(
+    "int main(){
+    __asm__ __volatile__ (\"fistpl 0\");
+    return 0;}" HAVE_X86_FISTPL)
 
 ######### Settings ###########
 # NOTE: These cache variables should normally not be changed in this
@@ -384,8 +385,8 @@ if(COMPILER_SUPPORTS_SYSTEM_HDR_PREFIX)
     add_definitions(--system-header-prefix="FL/")
 endif()
 
-if(NOT AVOID_ASM)
-	message(STATUS "Compiling with x86 opcode support")
+if(HAVE_X86_FISTPL)
+    message(STATUS "Compiling with x86 opcode support")
     add_definitions(-DASM_F2I_YES)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ SET (NoNeonPlease False CACHE BOOL
 SET (PluginLibDir "lib" CACHE STRING
     "Install directory for plugin libraries PREFIX/PLUGIN_LIB_DIR/{lv2,vst}")
 SET (DemoMode FALSE CACHE BOOL "Enable 10 minute silence")
+SET (PluginEnable TRUE CACHE BOOL "Enable Plugins")
 SET (ZynFusionDir "" CACHE STRING "Developers only: zest binary's dir; useful if fusion is not system-installed.")
 mark_as_advanced(FORCE ZynFusionDir)
 
@@ -540,7 +541,9 @@ add_subdirectory(Effects)
 add_subdirectory(Params)
 add_subdirectory(DSP)
 add_subdirectory(Nio)
-add_subdirectory(Plugin)
+if (PluginEnable)
+    add_subdirectory(Plugin)
+endif()
 
 add_library(zynaddsubfx_core STATIC
     version.cpp


### PR DESCRIPTION
The availability of the "fistpl" x86 instruction was tested with a
direct call to the "as" command. In case the project is cross-compiled
to another architecture, the host compiler is tested instead the
target one. This was leading to compilation failures. This commit now
perform the test using the target compiler defined in CMake, which
fixes cross-compilation. This commit does not change the behavior
when doing a native compilation, as the host and target compiler are the
same.

Signed-off-by: Julien Olivain <ju.o@free.fr>