### PR TITLE
Fix gcc warnings

### DIFF
--- a/src/Misc/Microtonal.cpp
+++ b/src/Misc/Microtonal.cpp
@@ -637,10 +637,10 @@ int Microtonal::loadscl(SclInfo &scl, const char *filename)
         if(tmp[i] < 32)
             tmp[i] = 0;
 
-    strncpy(scl.Pname,    tmp, MICROTONAL_MAX_NAME_LEN);
-    strncpy(scl.Pcomment, tmp, MICROTONAL_MAX_NAME_LEN);
-    scl.Pname[MICROTONAL_MAX_NAME_LEN-1] = 0;
-    scl.Pcomment[MICROTONAL_MAX_NAME_LEN-1] = 0;
+    strncpy(scl.Pname,    tmp, MICROTONAL_MAX_NAME_LEN-1);
+    scl.Pname[MICROTONAL_MAX_NAME_LEN-1] = '\0';
+    strncpy(scl.Pcomment, tmp, MICROTONAL_MAX_NAME_LEN-1);
+    scl.Pcomment[MICROTONAL_MAX_NAME_LEN-1] = '\0';
 
     //loads the number of the notes
     if(loadline(file, &tmp[0]) != 0)

--- a/src/Nio/Nio.cpp
+++ b/src/Nio/Nio.cpp
@@ -143,7 +143,7 @@ void Nio::preferredSampleRate(unsigned &rate)
     while(fgets(buffer, sizeof(buffer), ps))
         if(strstr(buffer, "jack"))
             break;
-    fclose(ps);
+    pclose(ps);
 
     if(!strstr(buffer, "jack"))
         return;

--- a/src/Synth/WatchPoint.cpp
+++ b/src/Synth/WatchPoint.cpp
@@ -33,7 +33,7 @@ WatchPoint::WatchPoint(WatchManager *ref, const char *prefix, const char *id)
     if(prefix)
         fast_strcpy(identity, prefix, sizeof(identity));
     if(id)
-        strncat(identity, id, sizeof(identity));
+        strncat(identity, id, sizeof(identity)-1);
 }
 
 bool WatchPoint::is_active(void)


### PR DESCRIPTION
This pull request fixes few compiler warnings reported by gcc 11 on Linux.
Those changes are mostly cosmetic and are not changing the behavior.