### PR TITLE
Removing buffers from FFTwrapper

### DIFF
--- a/src/DSP/FFTwrapper.h
+++ b/src/DSP/FFTwrapper.h
@@ -19,7 +19,52 @@
 
 namespace zyn {
 
-/**A wrapper for the FFTW library (Fast Fourier Transforms)*/
+//! Struct to make sure FFT sizes fit. *Not* an RAII class
+struct FFTfreqBuffer
+{
+    friend class FFTwrapper;
+
+    const int fftsize;
+    fft_t* data;
+
+    // comfort functions
+    fft_t& operator[](std::size_t idx) { return data[idx]; }
+    const fft_t& operator[](std::size_t idx) const { return data[idx]; }
+    //! Allocation size. For users of this class, `fftsize/2` would be enough,
+    //! But fftw needs `fftsize+1` freqs to operate on
+    int allocSize() const { return fftsize + 1; }
+
+private:
+    FFTfreqBuffer(int fftsize, fft_t* ptr = nullptr) : // called by FFTwrapper
+        fftsize(fftsize),
+        data(ptr ? ptr : new fft_t[allocSize()])
+    {}
+};
+
+//! Struct to make sure FFT sizes fit. *Not* an RAII class
+struct FFTsampleBuffer
+{
+    friend class FFTwrapper;
+
+    const int fftsize;
+    float* data;
+
+    // comfort functions
+    float& operator[](std::size_t idx) { return data[idx]; }
+    const float& operator[](std::size_t idx) const { return data[idx]; }
+    int allocSize() const { return fftsize; }
+
+private:
+    FFTsampleBuffer(int fftsize, float* ptr = nullptr) : // called by FFTwrapper
+        fftsize(fftsize),
+        data(ptr ? ptr : new float[allocSize()])
+    {}
+};
+
+/**
+    A wrapper for the FFTW library (Fast Fourier Transforms)
+    All methods (except CTOR/DTOR) are static/const. This class is thread-safe.
+*/
 class FFTwrapper
 {
     public:
@@ -31,14 +76,26 @@ class FFTwrapper
         /**Convert Samples to Frequencies using Fourier Transform
          * @param smps Pointer to Samples to be converted; has length fftsize_
          * @param freqs Structure FFTFREQS which stores the frequencies*/
-        void smps2freqs(const float *smps, fft_t *freqs);
-        void freqs2smps(const fft_t *freqs, float *smps);
+        void smps2freqs(const FFTsampleBuffer smps, FFTfreqBuffer freqs, FFTsampleBuffer scratch) const;
+        void freqs2smps(const FFTfreqBuffer freqs, FFTsampleBuffer smps, FFTfreqBuffer scratch) const;
+        void smps2freqs_noconst_input(FFTsampleBuffer smps, FFTfreqBuffer freqs) const;
+        void freqs2smps_noconst_input(FFTfreqBuffer freqs, FFTsampleBuffer smps) const;
+
+        // Whenever you need one of the FFT*Buffers, you take them from here
+        // The methods make sure that the FFT*Buffers match the fftsize
+        FFTfreqBuffer allocFreqBuf(fft_t* ptr = nullptr) const { return FFTfreqBuffer(m_fftsize, ptr); }
+        FFTsampleBuffer allocSampleBuf(float* ptr = nullptr) const { return FFTsampleBuffer(m_fftsize, ptr); }
+        // These should only be used exceptionally if you need to alloc those buffers,
+        // buf never run any FFT/IFFT on them
+        static FFTfreqBuffer riskAllocFreqBufWithSize(int othersize) { return FFTfreqBuffer(othersize); }
+        static FFTsampleBuffer riskAllocSampleBufWithSize(int othersize) { return FFTsampleBuffer(othersize); }
 
         int fftsize() const { return m_fftsize; }
+
     private:
-        int m_fftsize;
-        fftwf_real     *time;
-        fftwf_complex *fft;
+        const int     m_fftsize;
+        fftwf_real    *time; // only used when creating plan
+        fftwf_complex *fft;  // only used when creating plan
         fftwf_plan    planfftw, planfftw_inv;
 };
 


### PR DESCRIPTION
Reason for PR: parallelize `FFTwrapper` => remove its buffers.
Solution: run directly on input/output buffers => ensure that these are big enough, using new classes `FFTsampleBuffer` and `FFTfreqBuffer`.
Alternative solution (not realized): pass temporary buffers to `FFTwrapper` for every FFT/IFFT (probably more complicated, would take more memcpys)

