### PR TITLE
Make tests independent of config

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -721,10 +721,13 @@ public:
             // after the savefile will have been saved, it will be loaded into this
             // dummy master, and then the two masters will be compared
             zyn::Config config;
+            config.cfg.SaveFullXml = master->SaveFullXml;
+
             zyn::SYNTH_T* synth = new zyn::SYNTH_T;
             synth->buffersize = master->synth.buffersize;
             synth->samplerate = master->synth.samplerate;
             synth->alias();
+
             zyn::Master master2(*synth, &config);
             master->copyMasterCbTo(&master2);
             master2.frozenState = true;

--- a/src/Tests/PluginTest.cpp
+++ b/src/Tests/PluginTest.cpp
@@ -167,6 +167,8 @@ class PluginTest
     public:
         Config config;
         void setUp() {
+            config.cfg.SaveFullXml = false;
+
             synth = new SYNTH_T;
             synth->buffersize = 256;
             synth->samplerate = 48000;

--- a/src/Tests/SaveOSC.cpp
+++ b/src/Tests/SaveOSC.cpp
@@ -43,6 +43,10 @@ class SaveOSCTest
         }
 
         void setUp() {
+            // this might be set to true in the future
+            // when saving will work better
+            config.cfg.SaveFullXml = false;
+
             synth = new zyn::SYNTH_T;
             synth->buffersize = 256;
             synth->samplerate = 48000;


### PR DESCRIPTION
This uses a fixed config in tests, instead of relying on the user
config.

For `MiddleWare::saveParams`, the second master (which controls the
saving) must have the same config values for `SaveFullXml` as the first
master (the original one). Otherwise, they dump different XMLs which can
not be compared.