### PR TITLE
Misc/Part: Fix LR swap in multi mode (#330)

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1057,7 +1057,7 @@ void Master::setController(char chan, int type, note_t note, float value)
             part[npart]->SetController(type, note, value, keyshift);
 }
 
-void Master::vuUpdate(const float *outr, const float *outl)
+void Master::vuUpdate(const float *outl, const float *outr)
 {
     //Peak computation (for vumeters)
     vu.outpeakl = 1e-12;
@@ -1090,8 +1090,8 @@ void Master::vuUpdate(const float *outr, const float *outl)
         vuoutpeakpartl[npart] = 1.0e-12f;
         vuoutpeakpartr[npart] = 1.0e-12f;
         if(part[npart]->Penabled != 0) {
-            float *outr = part[npart]->partoutl,
-            *outl = part[npart]->partoutr;
+            float *outl = part[npart]->partoutl,
+            *outr = part[npart]->partoutr;
             for(int i = 0; i < synth.buffersize; ++i) {
                 if (fabsf(outl[i]) > vuoutpeakpartl[npart])
                     vuoutpeakpartl[npart] = fabsf(outl[i]);
@@ -1249,7 +1249,7 @@ bool Master::runOSC(float *outl, float *outr, bool offline,
 /*
  * Master audio out (the final sound)
  */
-bool Master::AudioOut(float *outr, float *outl)
+bool Master::AudioOut(float *outl, float *outr)
 {
     //Danger Limits
     if(memory->lowMemory(2,1024*1024))
@@ -1307,9 +1307,9 @@ bool Master::AudioOut(float *outr, float *outl)
 
         float pan = part[npart]->panning;
         if(pan < 0.5f)
-            newvol.l *= pan * 2.0f;
+            newvol.r *= pan * 2.0f;
         else
-            newvol.r *= (1.0f - pan) * 2.0f;
+            newvol.l *= (1.0f - pan) * 2.0f;
         //if(npart==0)
         //printf("[%d]vol = %f->%f\n", npart, oldvol.l, newvol.l);
 


### PR DESCRIPTION
Fix inverted LR panning in part outputs in multi mode. This was due
to LR being swapped in three places, in conjunction with the part
panning control being inverted:
- Mixer VU meter LR was swapped
- Part VU meters LR were swapped
- Audio mix output LR was swapped

A partial clue to the above (apart from the obviously inverted
LR part panning) was that panning in the parts effects (e.g. Echo)
was audibly ok in multi mode, but the VU meter indication was
swapped Left-Right. At the same time, the summed output from the
mixer exhibited inverted panning with regards to panning set in a
part effect.