### PR TITLE
Auto portamento mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 project(zynaddsubfx)
 set(VERSION_MAJOR "3")
 set(VERSION_MINOR "0")
-set(VERSION_REVISION "6")
+set(VERSION_REVISION "7")
 
 #Set data directory, if any
 if(DEFINED ZYN_DATADIR)

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1464,7 +1464,15 @@ void Part::getfromXML(XMLwrapper& xml)
     }
 
     if(xml.enterbranch("CONTROLLER")) {
+        const bool upgrade_3_0_7 = (xml.fileversion() < version_type(3,0,7));
+
         ctl.getfromXML(xml);
+        // Before version 3.0.7, mono and legato modes always had auto
+        // portamento (and poly mode never did, but in that case
+        // portamento.automode will default to off, so no need to do anything
+        // here).
+        if (upgrade_3_0_7 && !Ppolymode)
+            ctl.portamento.automode = 1;
         xml.exitbranch();
     }
 }

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -551,62 +551,59 @@ bool Part::NoteOnInternal(note_t note,
     // still held down or sustained for the Portamento to activate
     // (that's like Legato).
     PortamentoRealtime *portamento_realtime = NULL;
-    if(Ppolymode || isRunningNote) {
-        // If there is a currently ongoing glide, shift the starting point
-        // for any new portamento to where the current glide is right now
-        if (oldportamento && oldportamento->portamento.active)
-            oldportamentofreq_log2 += oldportamento->portamento.freqdelta_log2;
-        // Non-portamento settings and conditions say the note may have
-        // portamento, but it remains for Portamento.init to make the
-        // final decision depending on the portamento enable, threshold and
-        // other parameters.
-        Portamento portamento(ctl, synth, oldfreq_log2, oldportamentofreq_log2, note_log2_freq);
-        if(portamento.active) {
-            // We're good to go! Just need to figure out how.
-            // If we're doing legato and we already have a portamento structure,
-            // reuse it.
-            if (doingLegato && legatoportamento) {
-                portamento_realtime = legatoportamento;
-                portamento_realtime->portamento = portamento;
-            } else {
-                // Create new one if we don't already have one, or for each
-                // note in poly/mono mode
-                portamento_realtime = memory.alloc<PortamentoRealtime>
-                    (this,
-                     memory,
-                     // Cleanup function: Destroy any references we might
-                     // have to the current realtime pointer so that it
-                     // can not be (re)used, with disastrous results.
-                     [](PortamentoRealtime *realtime)
-                        {
-                            assert(realtime);
-                            Part *part = static_cast<Part *>(realtime->handle);
-                            assert(part);
-                            if (realtime == part->oldportamento) {
-                                // Since the last note is going away, capture
-                                // the portamento:ed pitch offset to our saved
-                                // previous note. This will be our starting
-                                // point for the next portamento glide.
-                                if (realtime->portamento.active)
-                                    part->oldportamentofreq_log2 +=
-                                        realtime->portamento.freqdelta_log2;
-                                part->oldportamento = NULL;
-                            }
-                            if (realtime == part->legatoportamento)
-                                part->legatoportamento = NULL;
-                        },
-                     portamento
-                    );
-                if (doingLegato)
-                    legatoportamento = portamento_realtime;
-            }
+    // If there is a currently ongoing glide, shift the starting point
+    // for any new portamento to where the current glide is right now
+    if (oldportamento && oldportamento->portamento.active)
+        oldportamentofreq_log2 += oldportamento->portamento.freqdelta_log2;
+    // Non-portamento settings and conditions say the note may have
+    // portamento, but it remains for Portamento.init to make the
+    // final decision depending on the portamento enable, threshold and
+    // other parameters.
+    Portamento portamento(ctl, synth, isRunningNote, oldfreq_log2, oldportamentofreq_log2, note_log2_freq);
+    if(portamento.active) {
+        // If we're doing legato and we already have a portamento structure,
+        // reuse it.
+        if (doingLegato && legatoportamento) {
+            portamento_realtime = legatoportamento;
+            portamento_realtime->portamento = portamento;
+        } else {
+            // Create new one if we don't already have one, or for each
+            // note in poly/mono mode
+            portamento_realtime = memory.alloc<PortamentoRealtime>
+                (this,
+                 memory,
+                 // Cleanup function: Destroy any references we might
+                 // have to the current realtime pointer so that it
+                 // can not be (re)used, with disastrous results.
+                 [](PortamentoRealtime *realtime)
+                    {
+                        assert(realtime);
+                        Part *part = static_cast<Part *>(realtime->handle);
+                        assert(part);
+                        if (realtime == part->oldportamento) {
+                            // Since the last note is going away, capture
+                            // the portamento:ed pitch offset to our saved
+                            // previous note. This will be our starting
+                            // point for the next portamento glide.
+                            if (realtime->portamento.active)
+                                part->oldportamentofreq_log2 +=
+                                    realtime->portamento.freqdelta_log2;
+                            part->oldportamento = NULL;
+                        }
+                        if (realtime == part->legatoportamento)
+                            part->legatoportamento = NULL;
+                    },
+                 portamento
+                );
+            if (doingLegato)
+                legatoportamento = portamento_realtime;
         }
     }
 
     // Create the portamento pointer that we distribute to the synth notes
-    Portamento *portamento = NULL;
+    Portamento *portamentoptr = NULL;
     if(portamento_realtime)
-        portamento = &portamento_realtime->portamento;
+        portamentoptr = &portamento_realtime->portamento;
 
     // Save note freq and pointer to portamento state for next note
     oldfreq_log2 = note_log2_freq;
@@ -615,7 +612,7 @@ bool Part::NoteOnInternal(note_t note,
 
     //Adjust Existing Notes
     if(doingLegato) {
-        LegatoParams pars = {vel, portamento, note_log2_freq, true, prng()};
+        LegatoParams pars = {vel, portamentoptr, note_log2_freq, true, prng()};
         notePool.applyLegato(note, pars, portamento_realtime);
         return true;
     }
@@ -639,7 +636,7 @@ bool Part::NoteOnInternal(note_t note,
             continue;
 
         SynthParams pars{memory, ctl, synth, time, vel,
-            portamento, note_log2_freq, false, prng()};
+            portamentoptr, note_log2_freq, false, prng()};
         const int sendto = Pkitmode ? item.sendto() : 0;
 
         // Enforce voice limit, before we trigger new note

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -62,6 +62,8 @@ const rtosc::Ports Controller::ports = {
         "Portamento MIDI Receive"),
     rToggle(portamento.portamento, rDefault(false),
         "Portamento Enable"),
+    rToggle(portamento.automode, rDefault(false),
+        "Portamento Auto mode"),
     rParamZyn(portamento.time,          rShort("time"), rDefault(64),
         "Portamento Length"),
     rToggle(portamento.proportional,    rShort("propt."), rDefault(false),
@@ -112,6 +114,7 @@ void Controller::defaults()
     NRPN.receive                 = 1;
 
     portamento.portamento        = 0;
+    portamento.automode          = 0;
     portamento.proportional      = 0;
     portamento.propRate          = 80;
     portamento.propDepth         = 90;
@@ -349,6 +352,7 @@ void Controller::add2XML(XMLwrapper& xml)
     xml.addpar("portamento_pitchthresh", portamento.pitchthresh);
     xml.addpar("portamento_pitchthreshtype", portamento.pitchthreshtype);
     xml.addpar("portamento_portamento", portamento.portamento);
+    xml.addparbool("portamento_auto", portamento.automode);
     xml.addpar("portamento_updowntimestretch", portamento.updowntimestretch);
     xml.addpar("portamento_proportional", portamento.proportional);
     xml.addpar("portamento_proprate", portamento.propRate);
@@ -390,6 +394,8 @@ void Controller::getfromXML(XMLwrapper& xml)
 
     portamento.receive = xml.getparbool("portamento_receive",
                                          portamento.receive);
+    portamento.automode = xml.getparbool("portamento_auto",
+                                         portamento.automode);
     portamento.time = xml.getpar127("portamento_time",
                                      portamento.time);
     portamento.pitchthresh = xml.getpar127("portamento_pitchthresh",

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -95,33 +95,34 @@ Controller::Controller(const SYNTH_T &synth_, const AbsTime *time_)
 
 void Controller::defaults()
 {
-    pitchwheel.bendrange = 200; //2 halftones
-    pitchwheel.bendrange_down = 0; //Unused by default
-    pitchwheel.is_split   = false;
-    expression.receive    = 1;
-    panning.depth         = 64;
-    filtercutoff.depth    = 64;
-    filterq.depth         = 64;
-    bandwidth.depth       = 64;
-    bandwidth.exponential = 0;
-    modwheel.depth        = 80;
-    modwheel.exponential  = 0;
-    fmamp.receive         = 1;
-    volume.receive        = 1;
-    sustain.receive       = 1;
-    NRPN.receive = 1;
+    pitchwheel.bendrange         = 200; //2 halftones
+    pitchwheel.bendrange_down    = 0; //Unused by default
+    pitchwheel.is_split          = false;
+    expression.receive           = 1;
+    panning.depth                = 64;
+    filtercutoff.depth           = 64;
+    filterq.depth                = 64;
+    bandwidth.depth              = 64;
+    bandwidth.exponential        = 0;
+    modwheel.depth               = 80;
+    modwheel.exponential         = 0;
+    fmamp.receive                = 1;
+    volume.receive               = 1;
+    sustain.receive              = 1;
+    NRPN.receive                 = 1;
 
-    portamento.portamento = 0;
-    portamento.proportional = 0;
-    portamento.propRate     = 80;
-    portamento.propDepth    = 90;
-    portamento.receive      = 1;
-    portamento.time = 64;
+    portamento.portamento        = 0;
+    portamento.proportional      = 0;
+    portamento.propRate          = 80;
+    portamento.propDepth         = 90;
+    portamento.receive           = 1;
+    portamento.time              = 64;
     portamento.updowntimestretch = 64;
-    portamento.pitchthresh     = 3;
-    portamento.pitchthreshtype = 1;
-    resonancecenter.depth    = 64;
-    resonancebandwidth.depth = 64;
+    portamento.pitchthresh       = 3;
+    portamento.pitchthreshtype   = 1;
+
+    resonancecenter.depth        = 64;
+    resonancebandwidth.depth     = 64;
 
     setportamento(0);
 }

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -124,6 +124,8 @@ class Controller
             unsigned char portamento;
             /**Whether the portamento midi events are received or not*/
             unsigned char receive;
+            /**Whether legato playing is needed to get portamento*/
+            unsigned char automode;
             /** The time that it takes for the portamento to complete
              *
              * Translates in an expontal fashion to 0 Seconds to 1.93f Seconds

--- a/src/Synth/Portamento.cpp
+++ b/src/Synth/Portamento.cpp
@@ -16,15 +16,17 @@ namespace zyn {
 
 Portamento::Portamento(const Controller &ctl,
                        const SYNTH_T &synth,
+                       bool is_running_note,
                        float oldfreq_log2,
                        float oldportamentofreq_log2,
                        float newfreq_log2)
 {
-    init(ctl, synth, oldfreq_log2, oldportamentofreq_log2, newfreq_log2);
+    init(ctl, synth, is_running_note, oldfreq_log2, oldportamentofreq_log2, newfreq_log2);
 }
 
 void Portamento::init(const Controller &ctl,
                       const SYNTH_T &synth,
+                      bool is_running_note,
                       float oldfreq_log2,
                       float oldportamentofreq_log2,
                       float newfreq_log2)
@@ -32,6 +34,9 @@ void Portamento::init(const Controller &ctl,
     active = false;
 
     if(ctl.portamento.portamento == 0)
+        return;
+
+    if(ctl.portamento.automode && !is_running_note)
         return;
 
     if(oldfreq_log2 == newfreq_log2)

--- a/src/Synth/Portamento.h
+++ b/src/Synth/Portamento.h
@@ -28,12 +28,14 @@ class Portamento {
          *
          * @param ctl The Controller which contains user patch parameters
          * @param synth The SYNTH_T from which to get sample rate and bufsize
+         * @param is_running_note True if at least one note is playing
          * @param oldfreq_log2 Pitch of previous note
          * @param oldportamentofreq_log2 Starting pitch of the portamento
          * @param newfreq_log2 Ending pitch of the portamento
          */
         Portamento(const Controller &ctl,
                    const SYNTH_T &synth,
+                   bool is_running_note,
                    float oldfreq_log2,
                    float oldportamentofreq_log2,
                    float newfreq_log2);
@@ -43,12 +45,14 @@ class Portamento {
          *
          * @param ctl The Controller which contains user patch parameters
          * @param synth The SYNTH_T from which to get sample rate and bufsize
+         * @param is_running_note True if at least one note is playing
          * @param oldfreq_log2 Pitch of previous note
          * @param oldportamentofreq_log2 Starting pitch of the portamento
          * @param newfreq_log2 Ending pitch of the portamento
          */
         void init(const Controller &ctl,
                   const SYNTH_T &synth,
+                  bool is_running_note,
                   float oldfreq_log2,
                   float oldportamentofreq_log2,
                   float newfreq_log2);

--- a/src/Tests/PortamentoTest.cpp
+++ b/src/Tests/PortamentoTest.cpp
@@ -48,7 +48,8 @@ class PortamentoTest
             //Initialize portamento
             ctl->setportamento(127);
             ctl->portamento.time = 127;
-            Portamento portamento(*ctl, *synth, log2f(40.0f), log2f(40.0f), log2f(400.0f));
+            ctl->portamento.automode = 0;
+            Portamento portamento(*ctl, *synth, false, log2f(40.0f), log2f(40.0f), log2f(400.0f));
             TS_ASSERT(portamento.active);
             //Bounds Check
             //We put a bound on number of loops executed, or we could be here
@@ -71,7 +72,8 @@ class PortamentoTest
         void testPortamentoValue() {
             ctl->setportamento(127);
             ctl->portamento.time = 127;
-            Portamento portamento(*ctl, *synth, log2f(40.0f), log2f(40.0f), log2f(400.0f));
+            ctl->portamento.automode = 0;
+            Portamento portamento(*ctl, *synth, false, log2f(40.0f), log2f(40.0f), log2f(400.0f));
             TS_ASSERT(portamento.active);
             int i;
             for(i = 0; i < 10; ++i)

--- a/src/Tests/guitar-adnote.xmz
+++ b/src/Tests/guitar-adnote.xmz
@@ -1280,6 +1280,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />
 <par name="portamento_portamento" value="0" />
+<par_bool name="portamento_auto" value="no" />
 <par name="portamento_updowntimestretch" value="64" />
 <par name="portamento_proportional" value="0" />
 <par name="portamento_proprate" value="80" />
@@ -1553,6 +1554,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />
 <par name="portamento_portamento" value="0" />
+<par_bool name="portamento_auto" value="no" />
 <par name="portamento_updowntimestretch" value="64" />
 <par name="portamento_proportional" value="0" />
 <par name="portamento_proprate" value="80" />
@@ -3931,6 +3933,7 @@ version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />
 <par name="portamento_portamento" value="0" />
+<par_bool name="portamento_auto" value="no" />
 <par name="portamento_updowntimestretch" value="64" />
 <par name="portamento_proportional" value="0" />
 <par name="portamento_proprate" value="80" />

--- a/src/Tests/guitar-adnote.xmz
+++ b/src/Tests/guitar-adnote.xmz
@@ -2,7 +2,7 @@
 <?xml version="1.0f" encoding="UTF-8"?>
 <!DOCTYPE ZynAddSubFX-data>
 <ZynAddSubFX-data version-major="3" version-minor="0"
-version-revision="6" ZynAddSubFX-author="Nasca Octavian Paul">
+version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <INFORMATION>
 <par_bool name="PADsynth_used" value="yes" />
 </INFORMATION>


### PR DESCRIPTION
Implement auto mode for portamento. This decouples the requirement to play legato to get portamento for the mono and legato modes from the mode itself, and allows activation of portamento in poly mode to be optionally controlled by legato playing, governed by a new portamento parameter.

I've let the automode member for the Controller.portamento struct be an unsigned char as all others are unsigned chars, and it didn't seem right to attempt to clean this up at this time.

In order to set auto portamento mode selectively when loading older patches, based on the key assign mode, I've bumped the revision version number. I don't know if this is an ok thing to do at this point.