### PR TITLE
Remove unused variable in demo version silencing code

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1442,7 +1442,6 @@ bool Master::AudioOut(float *outl, float *outr)
     if(seconds > 10*60) {//10 minute trial
         shutup = true;
         for(int i = 0; i < synth.buffersize; ++i) {
-            float tmp = (synth.buffersize_f - i) / synth.buffersize_f;
             outl[i] *= 0.0f;
             outr[i] *= 0.0f;
         }


### PR DESCRIPTION
This `tmp` var doesn't appear to be doing anything, and is throwing a compiler warning. Can it be removed?