### PR TITLE
AnalogFilter: Update coeffs when Q changed using setfreq_and_q()

### DIFF
--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -301,8 +301,12 @@ void AnalogFilter::setfreq(float frequency)
 
 void AnalogFilter::setfreq_and_q(float frequency, float q_)
 {
-    q = q_;
-    setfreq(frequency);
+    if (q == q_)
+        setfreq(frequency);
+    else {
+        q = q_;
+        computefiltercoefs(frequency,q);
+    }
 }
 
 void AnalogFilter::setq(float q_)


### PR DESCRIPTION
For the Analog filter (only), only the frequency was updated when
the setfreq_and_q() method was called. The consequence of this was
that updating the Q would only have an effect if for some reason
the frequency was being updated at the same time, for instance
because it was being swept by the envelope.

This also fixes the problem that changing MIDI CC#71 (filter Q)
would not have any effect until MIDI CC#74 (filter freq) was also
changed.

Fix by recomputing the coefficients if Q was changed, and just
updating the frequency if it was not.