### PR TITLE
globals.h: Increase smooth_float speed (#347)

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -368,7 +368,7 @@ public:
         next_value = curr_value = value;
     };
     operator float() {
-        const float delta = (next_value - curr_value) / 128.0f;
+        const float delta = (next_value - curr_value) / 32.0f;
         curr_value += delta;
         return (curr_value);
     };


### PR DESCRIPTION
Decrease the rate of smooth_float changes to make filter parameters
appear less sluggish. Otherwise it can take several seconds for
a parameter to reach the value set by a knob.

I don't know if this change has other consequences than the rate of parameter change when changing parameters in the UI, so this is more of a suggestion than a die hard fix.