### PR TITLE
Fix no analog filter q update

### DIFF
--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -35,6 +35,7 @@ AnalogFilter::AnalogFilter(unsigned char Ftype,
       stages(Fstages),
       freq(Ffreq),
       q(Fq),
+      newq(Fq),
      gain(1.0),
      recompute(true),
      freqbufsize(bufsize/8)
@@ -292,6 +293,8 @@ void AnalogFilter::setfreq(float frequency)
         freq = frequency;
         recompute = true;
     }
+    if (recompute)
+        q = newq;
     
     if (beforeFirstTick) {
         freq_smoothing.reset( freq );
@@ -301,22 +304,21 @@ void AnalogFilter::setfreq(float frequency)
 
 void AnalogFilter::setfreq_and_q(float frequency, float q_)
 {
+    newq = q_;
     /*
      * Only recompute based on Q change if change is more than 10%
      * from current value (or the old or new Q is 0, which normally
      * won't occur, but better to handle it than potentially
      * fail on division by zero or assert).
      */
-    if (q == 0.0 || q_ == 0.0 || ((q > q_ ? q / q_ : q_ / q) > 1.1)) {
-        q = q_;
+    if (q == 0.0 || q_ == 0.0 || ((q > q_ ? q / q_ : q_ / q) > 1.1))
         recompute = true;
-    }
     setfreq(frequency);
 }
 
 void AnalogFilter::setq(float q_)
 {
-    q = q_;
+    newq = q = q_;
     computefiltercoefs(freq,q);
 }
 

--- a/src/DSP/AnalogFilter.h
+++ b/src/DSP/AnalogFilter.h
@@ -69,6 +69,7 @@ class AnalogFilter:public Filter
         int   stages; //how many times the filter is applied (0->1,1->2,etc.)
         float freq;   //Frequency given in Hz
         float q;      //Q factor (resonance or Q factor)
+        float newq;   //New target Q
         float gain;   //the gain of the filter (if are shelf/peak) filters
         bool recompute; // need to recompute coeff.
         int order; //the order of the filter (number of poles)


### PR DESCRIPTION
This fixes a problem with the Q for the Analog Filter not being updated unless the filter frequency is updated simultaneously, be it manually via the UI or MIDI CC, or via a sweeping envelope. The first commit fixes the problem in a rudimentary way, whereas the second one takes its cue from the setfreq method and attempts to only update the Q if it has changed significantly. I've chosen 10% as the limit, i.e. changes smaller than that will not be perpetrated. The final commit takes advantage of those situations when the coefficients are recalculated anyway (because the filter frequency is changed), and the latest set Q value is then taken regardless of if it's outside the 10% limit or not.