### PR TITLE
SVFilter.cpp: Avoid clicks when UI updates freq, Q or gain (#348)

### DIFF
--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -151,9 +151,11 @@ void SVFilter::setstages(int stages_)
 {
     if(stages_ >= MAX_FILTER_STAGES)
         stages_ = MAX_FILTER_STAGES - 1;
-    stages = stages_;
-    cleanup();
-    computefiltercoefs();
+    if (stages != stages_) {
+        stages = stages_;
+        cleanup();
+        computefiltercoefs();
+    }
 }
 
 float *SVFilter::getfilteroutfortype(SVFilter::fstage &x) {


### PR DESCRIPTION
In the setstages() method, only call cleanup() when needed,
i.e. when the number of stages is actually changed (same as
in AnalogFilter.cpp).

(The reason this is a problem is because setstages() is
called whenever the frequency, Q, filter tracking or gain
is changed in the UI).