### PR TITLE
Part, NotePool: Use correct method to release keys (#346)

### DIFF
--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -465,6 +465,17 @@ void NotePool::releasePlayingNotes(void)
     }
 }
 
+void NotePool::releaseSustainingNotes(void)
+{
+    for(auto &d:activeDesc()) {
+        if(d.sustained()) {
+            d.setStatus(KEY_RELEASED);
+            for(auto s:activeNotes(d))
+                s.note->releasekey();
+        }
+    }
+}
+
 void NotePool::release(NoteDescriptor &d)
 {
     d.setStatus(KEY_RELEASED);

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -146,6 +146,7 @@ class NotePool
         void limitVoice(int preferred_note);
 
         void releasePlayingNotes(void);
+        void releaseSustainingNotes(void);
         void releaseNote(note_t note);
         void release(NoteDescriptor &d);
         void latch(NoteDescriptor &d);

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -873,10 +873,7 @@ void Part::ReleaseSustainedKeys()
         if(monomemBack() != lastnote) // Sustain controller manipulation would cause repeated same note respawn without this check.
             MonoMemRenote();  // To play most recent still held note.
 
-    for(auto &d:notePool.activeDesc())
-        if(d.sustained())
-            for(auto &s:notePool.activeNotes(d))
-                s.note->releasekey();
+    notePool.releaseSustainingNotes();
 }
 
 /*
@@ -885,10 +882,7 @@ void Part::ReleaseSustainedKeys()
 
 void Part::ReleaseAllKeys()
 {
-    for(auto &d:notePool.activeDesc())
-        if(!d.released())
-            for(auto &s:notePool.activeNotes(d))
-                s.note->releasekey();
+    notePool.releasePlayingNotes();
 }
 
 // Call NoteOn(...) with the most recent still held key as new note

--- a/src/Tests/KitTest.cpp
+++ b/src/Tests/KitTest.cpp
@@ -113,6 +113,44 @@ class KitTest
                     .status=0,
                     .legatoMirror=false,
                     .portamentoRealtime=NULL}));
+
+            //clear sustain
+            part->ctl.setsustain(0); // strictly speaking not necessary
+                                     // for the test, but it's what would
+                                     // trigger the release of sustained notes.
+            part->notePool.releaseSustainingNotes();
+
+            //both are now in the released state
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[0],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=64,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED|SUSTAIN_BIT,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=64,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=0,
+                    .sendto=0,
+                    .size=0,
+                    .status=0,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
         }
 
         void testSustainCase2() {
@@ -188,6 +226,78 @@ class KitTest
                     .sendto=0,
                     .size=1,
                     .status=KEY_PLAYING,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=0,
+                    .sendto=0,
+                    .size=0,
+                    .status=0,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            part->NoteOff(65);
+
+            //first note is still in release state
+            //second note has moved to sustaining state
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[0],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=64,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=65,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED_AND_SUSTAINED,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=0,
+                    .sendto=0,
+                    .size=0,
+                    .status=0,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            //clear sustain
+            part->ctl.setsustain(0); // strictly speaking not necessary
+                                     // for the test, but it's what would
+                                     // trigger the release of sustained notes.
+            part->notePool.releaseSustainingNotes();
+
+            //now both notes are released
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[0],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=64,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED,
+                    .legatoMirror=false,
+                    .portamentoRealtime=NULL}));
+
+            TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
+                    (NotePool::NoteDescriptor{
+                    .age=0,
+                    .note=65,
+                    .sendto=0,
+                    .size=1,
+                    .status=KEY_RELEASED,
                     .legatoMirror=false,
                     .portamentoRealtime=NULL}));
 


### PR DESCRIPTION
Use the correct NotePool method to release keys, which set the
released keys in the RELEASED state, rather than bypassing the
note pool and directly calling the releasekey() method for the
engine(s).