### PR TITLE
MiddleWare: Handle queued up messages during doReadOnlyOp

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -2073,7 +2073,7 @@ void MiddleWareImpl::doReadOnlyOp(std::function<void()> read_only_fn)
     //Now to resume normal operations
     uToB->write("/thaw_state","");
     for(auto x:fico) {
-        uToB->raw_write(x);
+        bToUhandle(x);
         delete [] x;
     }
 }
@@ -2180,7 +2180,7 @@ bool MiddleWareImpl::doReadOnlyOpNormal(std::function<void()> read_only_fn, bool
         //Now to resume normal operations
         uToB->write("/thaw_state","");
         for(auto x:fico) {
-            uToB->raw_write(x);
+            bToUhandle(x);
             delete [] x;
         }
         return false;
@@ -2196,7 +2196,7 @@ bool MiddleWareImpl::doReadOnlyOpNormal(std::function<void()> read_only_fn, bool
     //Now to resume normal operations
     uToB->write("/thaw_state","");
     for(auto x:fico) {
-        uToB->raw_write(x);
+        bToUhandle(x);
         delete [] x;
     }
     return true;


### PR DESCRIPTION
Correctly handle messages that have been queued up from the backend
while performing a doReadOnlyOp, rather than sending them
back to backend.

This gets rid of messages like the following when doing a write
operation from the UI:

    Unknown address<BACKEND:online> /vu-meter:ffffffffffffffffffffffffffffffffffffff
    Unknown address<BACKEND:online> /broadcast:
    Unknown address<BACKEND:online> /active_keys:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF