### PR TITLE
Pfilter fc ctl bypass

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -101,7 +101,8 @@ static const Ports voicePorts = {
         "FM Oscillator Phase"),
     rToggle(Pfilterbypass,   rShort("bypass"), rDefault(false),
         "Filter Bypass"),
-
+    rToggle(PfilterFcCtlBypass,   rShort("CtlBypass"), rDefault(false),
+        "Filter Fc Controll Bypass"),
     //Freq Stuff
     rToggle(Pfixedfreq,      rShort("fixed"),  rDefault(false),
         "If frequency is fixed"),
@@ -564,6 +565,7 @@ void ADnoteVoiceParam::defaults()
     POffsetHz     = 64;
     Presonance    = 1;
     Pfilterbypass = 0;
+    PfilterFcCtlBypass = 0;
     Pextoscil     = -1;
     PextFMoscil   = -1;
     Poscilphase   = 64;
@@ -771,6 +773,7 @@ void ADnoteVoiceParam::add2XML(XMLwrapper& xml, bool fmoscilused)
 
     xml.addparbool("filter_enabled", PFilterEnabled);
     xml.addparbool("filter_bypass", Pfilterbypass);
+    xml.addparbool("filter_fcctl_bypass", PfilterFcCtlBypass);
 
     xml.addpar("fm_enabled", (int)PFMEnabled);
 
@@ -1123,6 +1126,7 @@ void ADnoteVoiceParam::paste(ADnoteVoiceParam &a)
     copy(PFMoscilphase);
     copy(PFilterEnabled);
     copy(Pfilterbypass);
+    copy(PfilterFcCtlBypass);
     copy(PFMEnabled);
     copy(PFMFixedFreq);
 
@@ -1260,6 +1264,7 @@ void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
     PFMoscilphase  = xml.getpar127("oscil_fm_phase", PFMoscilphase);
     PFilterEnabled = xml.getparbool("filter_enabled", PFilterEnabled);
     Pfilterbypass  = xml.getparbool("filter_bypass", Pfilterbypass);
+    PfilterFcCtlBypass  = xml.getparbool("filter_fcctl_bypass", PfilterFcCtlBypass);
     PFMEnabled     = (FMTYPE)xml.getpar127("fm_enabled", (int)PFMEnabled);
 
     if(xml.enterbranch("OSCIL")) {

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -162,6 +162,7 @@ struct ADnoteVoiceParam {
 
     // filter bypass
     unsigned char Pfilterbypass;
+    unsigned char PfilterFcCtlBypass;
 
     /** Voice oscillator */
     OscilGen *OscilGn;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1128,7 +1128,7 @@ void ADnote::computecurrentparameters()
         /****************/
         auto *voiceFilter = NoteVoicePar[nvoice].Filter;
         if(voiceFilter) {
-            float voicerelfreq = NoteVoicePar[nvoice].filterFcCtlBypass == 0 ? relfreq : 0.0f;
+            const float voicerelfreq = NoteVoicePar[nvoice].filterFcCtlBypass == 0 ? relfreq : 0.0f;
             voiceFilter->update(voicerelfreq, ctl.filterq.relq);
         }
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -220,6 +220,7 @@ void ADnote::setupVoice(int nvoice)
     voice.FilterLfo      = NULL;
 
     voice.filterbypass = param.Pfilterbypass;
+    voice.filterFqCtlBypass = param.PfilterFcCtlBypass;
 
     setupVoiceMod(nvoice);
 
@@ -593,6 +594,8 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
         voice.filterbypass =
             pars.VoicePar[nvoice].Pfilterbypass;
+        voice.filterFqCtlBypass =
+            pars.VoicePar[nvoice].PfilterFcCtlBypass;
 
 
         voice.FMVoice = pars.VoicePar[nvoice].PFMVoice;
@@ -1125,7 +1128,8 @@ void ADnote::computecurrentparameters()
         /****************/
         auto *voiceFilter = NoteVoicePar[nvoice].Filter;
         if(voiceFilter) {
-            voiceFilter->update(relfreq, ctl.filterq.relq);
+            float voicerelfreq = NoteVoicePar[nvoice].filterFqCtlBypass == 0 ? relfreq : 0.0f;
+            voiceFilter->update(voicerelfreq, ctl.filterq.relq);
         }
 
         if(NoteVoicePar[nvoice].noisetype == 0) { //compute only if the voice isn't noise

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -220,7 +220,7 @@ void ADnote::setupVoice(int nvoice)
     voice.FilterLfo      = NULL;
 
     voice.filterbypass = param.Pfilterbypass;
-    voice.filterFqCtlBypass = param.PfilterFcCtlBypass;
+    voice.filterFcCtlBypass = param.PfilterFcCtlBypass;
 
     setupVoiceMod(nvoice);
 
@@ -594,7 +594,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
         voice.filterbypass =
             pars.VoicePar[nvoice].Pfilterbypass;
-        voice.filterFqCtlBypass =
+        voice.filterFcCtlBypass =
             pars.VoicePar[nvoice].PfilterFcCtlBypass;
 
 
@@ -1128,7 +1128,7 @@ void ADnote::computecurrentparameters()
         /****************/
         auto *voiceFilter = NoteVoicePar[nvoice].Filter;
         if(voiceFilter) {
-            float voicerelfreq = NoteVoicePar[nvoice].filterFqCtlBypass == 0 ? relfreq : 0.0f;
+            float voicerelfreq = NoteVoicePar[nvoice].filterFcCtlBypass == 0 ? relfreq : 0.0f;
             voiceFilter->update(voicerelfreq, ctl.filterq.relq);
         }
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -187,7 +187,7 @@ class ADnote:public SynthNote
             /* Filter Bypass */
             int filterbypass;
             /* Filter Fq Control Bypass */
-            int filterFqCtlBypass;
+            int filterFcCtlBypass;
 
             /* Delay (ticks) */
             int DelayTicks;

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -186,6 +186,8 @@ class ADnote:public SynthNote
 
             /* Filter Bypass */
             int filterbypass;
+            /* Filter Fq Control Bypass */
+            int filterFqCtlBypass;
 
             /* Delay (ticks) */
             int DelayTicks;

--- a/src/Tests/guitar-adnote.xmz
+++ b/src/Tests/guitar-adnote.xmz
@@ -213,6 +213,7 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="oscil_fm_phase" value="93" />
 <par_bool name="filter_enabled" value="yes" />
 <par_bool name="filter_bypass" value="no" />
+<par_bool name="filter_fcctl_bypass" value="no" />
 <par name="fm_enabled" value="1" />
 <OSCIL>
 <par name="harmonic_mag_type" value="0" />
@@ -485,6 +486,7 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="oscil_fm_phase" value="64" />
 <par_bool name="filter_enabled" value="no" />
 <par_bool name="filter_bypass" value="no" />
+<par_bool name="filter_fcctl_bypass" value="no" />
 <par name="fm_enabled" value="0" />
 <OSCIL>
 <par name="harmonic_mag_type" value="0" />
@@ -576,6 +578,7 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="oscil_fm_phase" value="64" />
 <par_bool name="filter_enabled" value="no" />
 <par_bool name="filter_bypass" value="no" />
+<par_bool name="filter_fcctl_bypass" value="no" />
 <par name="fm_enabled" value="0" />
 <OSCIL>
 <par name="harmonic_mag_type" value="0" />
@@ -667,6 +670,7 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par name="oscil_fm_phase" value="64" />
 <par_bool name="filter_enabled" value="no" />
 <par_bool name="filter_bypass" value="no" />
+<par_bool name="filter_fcctl_bypass" value="no" />
 <par name="fm_enabled" value="0" />
 <OSCIL>
 <par name="harmonic_mag_type" value="0" />


### PR DESCRIPTION
this commit makes it possible to disable the filter cutoff midi control (CC74) per voice. This is good for pitch tuned (comb) filters.