### PR TITLE
Fix distortion effect multiplier

### DIFF
--- a/src/Effects/Distortion.cpp
+++ b/src/Effects/Distortion.cpp
@@ -240,7 +240,7 @@ unsigned char Distortion::getpresetpar(unsigned char npreset, unsigned int npar)
     if(npreset < NUM_PRESETS && npar < PRESET_SIZE) {
         if(npar == 0 && insertion == 0) {
             /* lower the volume if this is system effect */
-            return (3 * presets[npreset][npar]) / 2;
+            return (2 * presets[npreset][npar]) / 3;
         }
         return presets[npreset][npar];
     }


### PR DESCRIPTION
This fixes a bug introduced in 85ed5029787cbbc3b4ea50bc18b9182526d923eb. That commit accidentally multiplied the preset value for volume by 3/2, instead of by dividing it ("lowering") by 3/2.

This fixes knobs displaying values like "190" and presets being too loud.