### PR TITLE
Fix sympathetic effect multiplier

### DIFF
--- a/src/Effects/Sympathetic.cpp
+++ b/src/Effects/Sympathetic.cpp
@@ -284,7 +284,7 @@ unsigned char Sympathetic::getpresetpar(unsigned char npreset, unsigned int npar
     if(npreset < NUM_PRESETS && npar < PRESET_SIZE) {
         if(npar == 0 && insertion == 0) {
             /* lower the volume if this is system effect */
-            return (3 * presets[npreset][npar]) / 2;
+            return (2 * presets[npreset][npar]) / 3;
         }
         return presets[npreset][npar];
     }


### PR DESCRIPTION
Analogous implementation to
4e0b22f267f4254ad9deed74856d9155aef55848, but this time, for the Sympathetic effect.