### PR TITLE
Fixup DynFilter presets after corruption in 2017

### DIFF
--- a/src/Effects/DynamicFilter.cpp
+++ b/src/Effects/DynamicFilter.cpp
@@ -188,34 +188,34 @@ void DynamicFilter::setfilterpreset(unsigned char npreset)
         case 0:
             filterpars->Pcategory = 0;
             filterpars->Ptype     = 2;
-            filterpars->Pfreq     = 45;
-            filterpars->Pq      = 64;
-            filterpars->Pstages = 1;
-            filterpars->Pgain   = 64;
+            filterpars->basefreq  = FilterParams::basefreqFromOldPreq(45);
+            filterpars->baseq     = FilterParams::baseqFromOldPq(64);
+            filterpars->Pstages   = 1;
+            filterpars->gain      = FilterParams::gainFromOldPgain(64);
             break;
         case 1:
             filterpars->Pcategory = 2;
             filterpars->Ptype     = 0;
-            filterpars->Pfreq     = 72;
-            filterpars->Pq      = 64;
-            filterpars->Pstages = 0;
-            filterpars->Pgain   = 64;
+            filterpars->basefreq  = FilterParams::basefreqFromOldPreq(72);
+            filterpars->baseq     = FilterParams::baseqFromOldPq(64);
+            filterpars->Pstages   = 0;
+            filterpars->gain      = FilterParams::gainFromOldPgain(64);
             break;
         case 2:
             filterpars->Pcategory = 0;
             filterpars->Ptype     = 4;
-            filterpars->Pfreq     = 64;
-            filterpars->Pq      = 64;
-            filterpars->Pstages = 2;
-            filterpars->Pgain   = 64;
+            filterpars->basefreq  = FilterParams::basefreqFromOldPreq(64);
+            filterpars->baseq     = FilterParams::baseqFromOldPq(64);
+            filterpars->Pstages   = 2;
+            filterpars->gain      = FilterParams::gainFromOldPgain(64);
             break;
         case 3:
             filterpars->Pcategory = 1;
             filterpars->Ptype     = 0;
-            filterpars->Pfreq     = 50;
-            filterpars->Pq      = 70;
-            filterpars->Pstages = 1;
-            filterpars->Pgain   = 64;
+            filterpars->basefreq  = FilterParams::basefreqFromOldPreq(50);
+            filterpars->baseq     = FilterParams::baseqFromOldPq(70);
+            filterpars->Pstages   = 1;
+            filterpars->gain      = FilterParams::gainFromOldPgain(64);
 
             filterpars->Psequencesize = 2;
             // "I"
@@ -242,10 +242,10 @@ void DynamicFilter::setfilterpreset(unsigned char npreset)
         case 4:
             filterpars->Pcategory = 1;
             filterpars->Ptype     = 0;
-            filterpars->Pfreq     = 64;
-            filterpars->Pq      = 70;
-            filterpars->Pstages = 1;
-            filterpars->Pgain   = 64;
+            filterpars->basefreq  = FilterParams::basefreqFromOldPreq(64);
+            filterpars->baseq     = FilterParams::baseqFromOldPq(70);
+            filterpars->Pstages   = 1;
+            filterpars->gain      = FilterParams::gainFromOldPgain(64);
 
             filterpars->Psequencesize   = 2;
             filterpars->Pnumformants    = 2;

--- a/src/Params/FilterParams.h
+++ b/src/Params/FilterParams.h
@@ -60,10 +60,9 @@ class FilterParams:public PresetsArray
         float    freqtracking; //!< Tracking of center frequency with note frequency (percentage)
         float    gain;         //!< filter's output gain (dB)
 
-        int Pq;         //dummy
-        int Pfreq;      //dummy
-        int Pfreqtrack; //dummy
-        int Pgain;      //dummy
+        static float baseqFromOldPq(int Pq);
+        static float gainFromOldPgain(int Pgain);
+        static float basefreqFromOldPreq(int Pfreq);
 
         //Formant filter parameters
         unsigned char Pnumformants; //how many formants are used


### PR DESCRIPTION
This is likely a fixup of b650636e306237397ef106b86fc2aaa35ec5182b, where those params have been turned into mostly unused dummy params, but the DynFilter code which uses them has been forgotten to adapt.

So this code fixes the DynFilter presets, so they sound like in 2017 again.

Additionally, this code also removes the dummy variables, which have no use as class variables since 2017.