### PR TITLE
OscilGen: Skip no-ops for custom base funcs

### DIFF
--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -622,9 +622,14 @@ void OscilGen::oscilfilter(fft_t *freqs) const
 void OscilGen::changebasefunction(OscilGenBuffers& bfrs) const
 {
     if(Pcurrentbasefunc != 0) {
-        getbasefunction(bfrs, bfrs.tmpsmps);
-        if(fft)
-            fft->smps2freqs_noconst_input(bfrs.tmpsmps, bfrs.basefuncFFTfreqs);
+        if(Pcurrentbasefunc == 127 && !Pbasefuncmodulation) {
+            // this would be a no-op, skip it
+        }
+        else {
+            getbasefunction(bfrs, bfrs.tmpsmps);
+            if(fft)
+                fft->smps2freqs_noconst_input(bfrs.tmpsmps, bfrs.basefuncFFTfreqs);
+        }
         clearDC(bfrs.basefuncFFTfreqs.data);
     }
     else //in this case bfrs.basefuncFFTfreqs are not used


### PR DESCRIPTION
This skips an unnecessary re-computation of OscilGen's `basefuncFFTfreqs`.

Before this patch, not only runtime is wasted, but the redundant FFT can slightly modify the base func FFT freqs, which can cause issues when comparing savefiles.