### PR TITLE
Fix issue with ADDsynth part going silent in Zynthian when Resonance enabled

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -847,8 +847,13 @@ void Part::SetController(unsigned int type, int par)
             break;
         case C_resonance_bandwidth:
             ctl.setresonancebw(par);
-            kit[0].adpars->GlobalPar.Reson->
-            sendcontroller(C_resonance_bandwidth, ctl.resonancebandwidth.relbw);
+            for(int item = 0; item < NUM_KIT_ITEMS; ++item) {
+                if(kit[item].adpars == NULL)
+                    continue;
+                kit[item].adpars->GlobalPar.Reson->
+                sendcontroller(C_resonance_bandwidth,
+                               ctl.resonancebandwidth.relbw);
+            }
             break;
     }
 }

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -379,6 +379,7 @@ void Controller::setresonancecenter(void)
 void Controller::setresonancebw(int value)
 {
     resonancebandwidth.data  = value;
+    setresonancebw();
 }
 
 void Controller::setresonancebw(void)


### PR DESCRIPTION
This probably wouldn't show up on any other platform, as it is based on something sending CC#78 (Resonance Bandwidth) to Zynaddsubfx (without updating Resonance Bandwidth Depth first), but Zynthian does, and when it happens it triggers a bug which I believe causes disruption of the audio when Resonance is enabled due to the relbw struct member being uninitialized. I didn't debug it further than this, basically just copying the code from the way Resonance Center is handled. Testing adjusting Resonance Center and Resonance Bandwidth using the Zynthian built-in GUI now behaves in a sane manner so it seems to be the correct fix.

While debugging I also found a discrepancy in the way incoming CC messages for Resonance Center and Resonance Bandwidth are handled, again, essentially copying code from one method to the other. I haven't seen any ill effects, it just looked like both should be handled the same way. Since it's not the same issue, I've submitted it as a separate commit.