### PR TITLE
Switch some ports so apropos() works for them

### DIFF
--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -447,11 +447,13 @@ static const Ports adPorts = {//XXX 16 should not be hard coded
     rSelf(ADnoteParameters),
     rPasteRt,
     rArrayPasteRt,
-    rRecurs(VoicePar, NUM_VOICES),
     {"VoicePar#" STRINGIFY(NUM_VOICES) "/Enabled::T:F",
      rProp(parameter) rShort("enable") rDoc("Voice Enable")
      rDefault([true false false ...]),
      NULL, rArrayTCbMember(VoicePar, Enabled)},
+    // this must come after "VoicePar#.../..." ports, so rtosc::apropos finds
+    // the more exact path first (bug in apropos)
+    rRecurs(VoicePar, NUM_VOICES),
     rRecur(GlobalPar, "Adnote Parameters"),
 };
 #undef rChangeCb


### PR DESCRIPTION
This is due to a bug, which is documented in rtosc tests.