### PR TITLE
Don't write invalid values to XML savefiles

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1246,7 +1246,8 @@ void Part::add2XML(XMLwrapper& xml)
     xml.addparbool("note_on", Pnoteon);
     xml.addparbool("poly_mode", Ppolymode);
     xml.addpar("legato_mode", Plegatomode);
-    xml.addpar("key_limit", Pkeylimit);
+    unsigned char keylimit_max = std::atoi(ports["Pkeylimit"]->meta()["max"]);
+    xml.addpar("key_limit", std::min(Pkeylimit, keylimit_max));
     xml.addpar("voice_limit", Pvoicelimit);
 
     xml.beginbranch("INSTRUMENT");

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -753,7 +753,10 @@ void ADnoteVoiceParam::add2XML(XMLwrapper& xml, bool fmoscilused)
 {
     xml.addpar("type", Type);
 
-    xml.addpar("unison_size", Unison_size);
+    unsigned char unison_min = std::atoi(ports["Unison_size"]->meta()["min"]);
+    unsigned char unison_max = std::atoi(ports["Unison_size"]->meta()["max"]);
+    unsigned char unison_to_save = std::min(std::max(Unison_size, unison_min), unison_max);
+    xml.addpar("unison_size", unison_to_save);
     xml.addpar("unison_frequency_spread",
                 Unison_frequency_spread);
     xml.addpar("unison_stereo_spread", Unison_stereo_spread);

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -585,7 +585,8 @@ void FilterParams::add2XML(XMLwrapper& xml)
     //filter parameters
     xml.addpar("category", Pcategory);
     xml.addpar("type", Ptype);
-    xml.addparreal("basefreq", basefreq);
+    float basefreq_min = std::atof(ports["basefreq"]->meta()["min"]);
+    xml.addparreal("basefreq", std::max(basefreq_min, basefreq));
     xml.addparreal("baseq", baseq);
     xml.addpar("stages", Pstages);
     xml.addparreal("freq_tracking", freqtracking);

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -415,7 +415,6 @@ if (event==FL_RIGHT_MOUSE){
           tooltip {Key Limit} xywh {215 155 50 20} labelsize 10 align 8 textfont 1 textsize 10
           code0 {o->init("Pkeylimit",'i');}
           code1 {o->step(1.0,10.0);}
-          code2 {o->range(0,127);}
           class Fl_Osc_Counter
         }
         Fl_Choice {} {


### PR DESCRIPTION
* Part.cpp: keylimit is 100 in some old savefiles
* ADnoteParameters.cpp: unison size was 0 or >50 while developing the zest UI
* FilterParams.cpp: basefreq was sometimes slightly lower than "min" (rounding errors)