### PR TITLE
Effects: Get rid of compiler warnings

### DIFF
--- a/src/Effects/Alienwah.h
+++ b/src/Effects/Alienwah.h
@@ -23,7 +23,7 @@
 namespace zyn {
 
 /**"AlienWah" Effect*/
-class Alienwah:public Effect
+class Alienwah final:public Effect
 {
     public:
         Alienwah(EffectParams pars);

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -22,7 +22,7 @@
 namespace zyn {
 
 /**Chorus and Flange effects*/
-class Chorus:public Effect
+class Chorus final:public Effect
 {
     public:
         Chorus(EffectParams pars);

--- a/src/Effects/Distortion.h
+++ b/src/Effects/Distortion.h
@@ -19,7 +19,7 @@
 namespace zyn {
 
 /**Distortion Effect*/
-class Distortion:public Effect
+class Distortion final :public Effect
 {
     public:
         Distortion(EffectParams pars);

--- a/src/Effects/DynamicFilter.h
+++ b/src/Effects/DynamicFilter.h
@@ -20,7 +20,7 @@
 namespace zyn {
 
 /**DynamicFilter Effect*/
-class DynamicFilter:public Effect
+class DynamicFilter final:public Effect
 {
     public:
         DynamicFilter(EffectParams pars);

--- a/src/Effects/EQ.h
+++ b/src/Effects/EQ.h
@@ -19,7 +19,7 @@
 namespace zyn {
 
 /**EQ Effect*/
-class EQ:public Effect
+class EQ final:public Effect
 {
     public:
         EQ(EffectParams pars);

--- a/src/Effects/Echo.h
+++ b/src/Effects/Echo.h
@@ -20,7 +20,7 @@
 namespace zyn {
 
 /**Echo Effect*/
-class Echo:public Effect
+class Echo final:public Effect
 {
     public:
         Echo(EffectParams pars);

--- a/src/Effects/Phaser.h
+++ b/src/Effects/Phaser.h
@@ -25,7 +25,7 @@
 
 namespace zyn {
 
-class Phaser:public Effect
+class Phaser final:public Effect
 {
     public:
         Phaser(EffectParams pars);

--- a/src/Effects/Reverb.h
+++ b/src/Effects/Reverb.h
@@ -22,7 +22,7 @@
 namespace zyn {
 
 /**Creates Reverberation Effects*/
-class Reverb:public Effect
+class Reverb final:public Effect
 {
     public:
         Reverb(EffectParams pars);

--- a/src/Effects/Sympathetic.h
+++ b/src/Effects/Sympathetic.h
@@ -32,7 +32,7 @@ const unsigned int num_triple_strings = 48;
 // frequencies of a guitar in standard e tuning
 const float guitar_freqs[6] = {82.4f, 110.0f, 146.8f, 196.0f, 246.9f, 329.6f};
 
-class Sympathetic:public Effect
+class Sympathetic final:public Effect
 {
 
     public:


### PR DESCRIPTION
This fixes warnings like

```
Distortion.cpp:117:5: Call to virtual method 'Distortion::setpreset' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
```