### PR TITLE
Don't load invalid values from XML savefiles

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1470,7 +1470,8 @@ void Part::getfromXML(XMLwrapper& xml)
     Plegatomode = xml.getparbool("legato_mode", Plegatomode); //older versions
     if(!Plegatomode)
         Plegatomode = xml.getpar127("legato_mode", Plegatomode);
-    Pkeylimit = xml.getpar127("key_limit", Pkeylimit);
+    int keylimit_max = std::atoi(ports["Pkeylimit"]->meta()["max"]);
+    Pkeylimit = std::min(keylimit_max, xml.getpar127("key_limit", Pkeylimit));
     Pvoicelimit = xml.getpar127("voice_limit", Pvoicelimit);
 
 

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1242,7 +1242,10 @@ void ADnoteGlobalParam::paste(ADnoteGlobalParam &a)
 void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
 {
     Enabled     = xml.getparbool("enabled", 0);
-    Unison_size = xml.getpar127("unison_size", Unison_size);
+    unsigned char unison_in_file = xml.getpar127("unison_size", Unison_size);
+    unsigned char unison_min = std::atoi(ports["Unison_size"]->meta()["min"]);
+    unsigned char unison_max = std::atoi(ports["Unison_size"]->meta()["max"]);
+    Unison_size = std::min(std::max(unison_in_file, unison_min), unison_max);
     Unison_frequency_spread = xml.getpar127("unison_frequency_spread",
                                              Unison_frequency_spread);
     Unison_stereo_spread = xml.getpar127("unison_stereo_spread",

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -661,6 +661,8 @@ void FilterParams::getfromXML(XMLwrapper& xml)
         gain         = xml.getparreal("gain",       0);
         freqtracking = xml.getparreal("freq_tracking", 0);
     }
+    float basefreq_min = std::atof(ports["basefreq"]->meta()["min"]);
+    basefreq = std::max(basefreq, basefreq_min);
 
     //formant filter parameters
     if(xml.enterbranch("FORMANT_FILTER")) {

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -415,7 +415,6 @@ if (event==FL_RIGHT_MOUSE){
           tooltip {Key Limit} xywh {215 155 50 20} labelsize 10 align 8 textfont 1 textsize 10
           code0 {o->init("Pkeylimit",'i');}
           code1 {o->step(1.0,10.0);}
-          code2 {o->range(0,127);}
           class Fl_Osc_Counter
         }
         Fl_Choice {} {


### PR DESCRIPTION
* Part.cpp: keylimit is 100 in some old savefiles
* ADnoteParameters.cpp: unison size was 0 or >50 while developing the zest UI
* FilterParams.cpp: basefreq was sometimes slightly lower than "min" (rounding errors)