### PR TITLE
Fixed compilation of zynaddsubfx-ext-gui on MacOS

### DIFF
--- a/cmake/FindHOMEBREW.cmake
+++ b/cmake/FindHOMEBREW.cmake
@@ -1,0 +1,10 @@
+#Find Homebrew
+
+if ("Darwin" STREQUAL ${CMAKE_SYSTEM_NAME})
+  if(DEFINED ENV{HOMEBREW_PREFIX}) 
+    set(HOMEBREW_LIB_DIR "$ENV{HOMEBREW_PREFIX}/lib")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(HOMEBREW DEFAULT_MSG HOMEBREW_LIB_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Alsa)
 find_package(Sndio)
 find_package(FLTK)
 find_package(OpenGL) #for FLTK
+find_package(HOMEBREW)  #for libpng and libjpeg (for fltk on MacOS)
 # lash
 if(PKG_CONFIG_FOUND AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Windows"))
     message("Looking For pkg config modules")
@@ -461,10 +462,10 @@ if(FltkGui)
 		string(STRIP "${FLTK_LDFLAGS}" FLTK_LIBRARIES)
 	endif()
 
-	message(STATUS ${FLTK_LDFLAGS})
+	message(STATUS "Link flags: ${FLTK_LDFLAGS}")
 
 
-	set(GUI_LIBRARIES zynaddsubfx_gui ${FLTK_LIBRARIES} ${FLTK_LIBRARIES} ${OPENGL_LIBRARIES})
+	set(GUI_LIBRARIES zynaddsubfx_gui ${FLTK_LIBRARIES} ${OPENGL_LIBRARIES})
 
 	add_definitions(-DFLTK_GUI)
 	message(STATUS "Will build FLTK gui")
@@ -524,7 +525,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zyn-version.h.in
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zyn-config.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/zyn-config.h)
 
-link_directories(${AUDIO_LIBRARY_DIRS} ${ZLIB_LIBRARY_DIRS} ${FFTW3F_LIBRARY_DIRS} ${MXML_LIBRARY_DIRS} ${FLTK_LIBRARY_DIRS} ${NTK_LIBRARY_DIRS} ${X11_LIBRARY_DIRS})
+link_directories(${AUDIO_LIBRARY_DIRS} ${ZLIB_LIBRARY_DIRS} ${FFTW3F_LIBRARY_DIRS} ${MXML_LIBRARY_DIRS} ${FLTK_LIBRARY_DIRS} ${NTK_LIBRARY_DIRS} ${X11_LIBRARY_DIRS} ${HOMEBREW_LIB_DIR})
 
 include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}
@@ -689,6 +690,7 @@ package_status(ZLIB_FOUND       "zlib     " "found"   ${Red})
 package_status(MXML_FOUND       "mxml     " "found"   ${Red})
 package_status(FFTW3F_FOUND     "fftw3f   " "found"   ${Red})
 package_status(LIBLO_FOUND      "liblo    " "found"   ${Red})
+package_status(HOMEBREW_FOUND   "Homebrew " "found"   ${Yellow})
 package_status(X11_FOUND        "x11      " "found"   ${Yellow})
 package_status(X11_Xpm_FOUND    "xpm      " "found"   ${Yellow})
 package_status(FLTK_FOUND       "fltk     " "found"   ${Yellow})

--- a/src/UI/CMakeLists.txt
+++ b/src/UI/CMakeLists.txt
@@ -29,9 +29,15 @@ if(NtkGui)
 endif()
 
 if(FltkGui)
+    link_directories(${HOMEBREW_LIB_DIR})  # This is necessary for fltk to find libpng and other libraries on MacOS.
     add_executable(zynaddsubfx-ext-gui guimain.cpp)
-    target_link_libraries(zynaddsubfx-ext-gui zynaddsubfx_gui ${FLTK_LIBRARIES}
-        ${FLTK_LIBRARIES} ${OPENGL_LIBRARIES} ${LIBLO_LIBRARIES} rtosc rtosc-cpp)
+    target_link_libraries(zynaddsubfx-ext-gui
+        zynaddsubfx_gui
+        ${FLTK_LIBRARIES}
+        ${OPENGL_LIBRARIES}
+        ${LIBLO_LIBRARIES}
+        rtosc
+        rtosc-cpp)
     if(X11_FOUND AND X11_Xpm_FOUND)
         add_definitions(-DHAS_X11=1)
         target_link_libraries(zynaddsubfx-ext-gui ${X11_LIBRARIES} -lXpm)


### PR DESCRIPTION
Original issue: `make zynaddsubfx-ext-gui` failed to compile because it couldn't find the png library. The -lpng flag is generated by fltk-config, which apparently assumes that it's installed system-wide and doesn't require a -L flag. This assumption is incorrect when libpng has been installed through Homebrew.

The fix here is to pass the homebrew lib/ directory to the linker, when homebrew is installed.

Test system: Macbook Air M2 (arm64) running MacOS Ventura 13.3.1, using Homebrew to install the required dependencies. Compilation is using Apple's Clang from XCode command-line tools. 

With this commit, the **FLTK standalone version** compiles and runs (using jack as a backend, though I haven't been able to hear any sound yet). 

**Plugin versions of Zyn don't compile**, apparently because of a function not yet implemented in DPF. Once https://github.com/zynaddsubfx/zynaddsubfx/pull/221 is merged I'll take another stab at it.
