### PR TITLE
Fix individual synth panning direction (#376)

### DIFF
--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1837,9 +1837,9 @@ int ADnote::noteout(float *outl, float *outr)
             if(stereo)
                 for(int i = 0; i < synth.buffersize; ++i) { //stereo
                     outl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume
-                               * NoteVoicePar[nvoice].Panning * 2.0f;
-                    outr[i] += tmpwaver[i] * NoteVoicePar[nvoice].Volume
                                * (1.0f - NoteVoicePar[nvoice].Panning) * 2.0f;
+                    outr[i] += tmpwaver[i] * NoteVoicePar[nvoice].Volume
+                               * NoteVoicePar[nvoice].Panning * 2.0f;
                 }
             else
                 for(int i = 0; i < synth.buffersize; ++i) //mono
@@ -1849,10 +1849,10 @@ int ADnote::noteout(float *outl, float *outr)
             if(stereo)
                 for(int i = 0; i < synth.buffersize; ++i) { //stereo
                     bypassl[i] += tmpwavel[i] * NoteVoicePar[nvoice].Volume
-                                  * NoteVoicePar[nvoice].Panning * 2.0f;
-                    bypassr[i] += tmpwaver[i] * NoteVoicePar[nvoice].Volume
                                   * (1.0f
                                      - NoteVoicePar[nvoice].Panning) * 2.0f;
+                    bypassr[i] += tmpwaver[i] * NoteVoicePar[nvoice].Volume
+                                  * NoteVoicePar[nvoice].Panning * 2.0f;
                 }
             else
                 for(int i = 0; i < synth.buffersize; ++i) //mono
@@ -1885,13 +1885,13 @@ int ADnote::noteout(float *outl, float *outr)
                                                  globalnewamplitude,
                                                  i,
                                                  synth.buffersize);
-            outl[i] *= tmpvol * NoteGlobalPar.Panning;
-            outr[i] *= tmpvol * (1.0f - NoteGlobalPar.Panning);
+            outl[i] *= tmpvol * (1.0f - NoteGlobalPar.Panning);
+            outr[i] *= tmpvol * NoteGlobalPar.Panning;
         }
     else
         for(int i = 0; i < synth.buffersize; ++i) {
-            outl[i] *= globalnewamplitude * NoteGlobalPar.Panning;
-            outr[i] *= globalnewamplitude * (1.0f - NoteGlobalPar.Panning);
+            outl[i] *= globalnewamplitude * (1.0f - NoteGlobalPar.Panning);
+            outr[i] *= globalnewamplitude * NoteGlobalPar.Panning;
         }
 
     //Apply the punch

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -417,13 +417,13 @@ int PADnote::noteout(float *outl, float *outr)
                                                  globalnewamplitude,
                                                  i,
                                                  synth.buffersize);
-            outl[i] *= tmpvol * NoteGlobalPar.Panning;
-            outr[i] *= tmpvol * (1.0f - NoteGlobalPar.Panning);
+            outl[i] *= tmpvol * (1.0f - NoteGlobalPar.Panning);
+            outr[i] *= tmpvol * NoteGlobalPar.Panning;
         }
     else
         for(int i = 0; i < synth.buffersize; ++i) {
-            outl[i] *= globalnewamplitude * NoteGlobalPar.Panning;
-            outr[i] *= globalnewamplitude * (1.0f - NoteGlobalPar.Panning);
+            outl[i] *= globalnewamplitude * (1.0f - NoteGlobalPar.Panning);
+            outr[i] *= globalnewamplitude * NoteGlobalPar.Panning;
         }
 
     watch_amp_int(outl,synth.buffersize);

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -587,13 +587,13 @@ int SUBnote::noteout(float *outl, float *outr)
                                                  newamplitude,
                                                  i,
                                                  synth.buffersize);
-            outl[i] *= tmpvol * panning;
-            outr[i] *= tmpvol * (1.0f - panning);
+            outl[i] *= tmpvol * (1.0f - panning);
+            outr[i] *= tmpvol * panning;
         }
     else
         for(int i = 0; i < synth.buffersize; ++i) {
-            outl[i] *= newamplitude * panning;
-            outr[i] *= newamplitude * (1.0f - panning);
+            outl[i] *= newamplitude * (1.0f - panning);
+            outr[i] *= newamplitude * panning;
         }
     watch_amp_int(outl,synth.buffersize);
     oldamplitude = newamplitude;

--- a/src/Tests/AdNoteTest.cpp
+++ b/src/Tests/AdNoteTest.cpp
@@ -170,33 +170,33 @@ class AdNoteTest
             note->noteout(outL, outR);
 #ifdef WRITE_OUTPUT
             for(int i = 0; i < synth->buffersize; ++i)
-                file << outL[i] << std::endl;
+                file << outR[i] << std::endl;
 
 #endif
             sampleCount += synth->buffersize;
-            TS_ASSERT_DELTA(outL[255], 0.25552f, 0.0001f);
+            TS_ASSERT_DELTA(outR[255], 0.25552f, 0.0001f);
             note->releasekey();
 
             TS_ASSERT(!tr->hasNext());
             w->add_watch("noteout/be4_mix");
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;
-            TS_ASSERT_DELTA(outL[255], -0.46883f, 0.0001f);
+            TS_ASSERT_DELTA(outR[255], -0.46883f, 0.0001f);
             w->tick();
             TS_ASSERT(tr->hasNext());
 
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;
             w->tick();
-            TS_ASSERT_DELTA(outL[255], 0.06695f, 0.0001f);
+            TS_ASSERT_DELTA(outR[255], 0.06695f, 0.0001f);
 
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;
-            TS_ASSERT_DELTA(outL[255], 0.11621f, 0.0001f);
+            TS_ASSERT_DELTA(outR[255], 0.11621f, 0.0001f);
             w->tick();
             note->noteout(outL, outR);
             sampleCount += synth->buffersize;
-            TS_ASSERT_DELTA(outL[255], -0.1169f, 0.0001f);
+            TS_ASSERT_DELTA(outR[255], -0.1169f, 0.0001f);
             w->tick();
 
             TS_ASSERT(tr->hasNext());


### PR DESCRIPTION
Fix panning direction for the individual synths as noted in the issue.

Also fix the ADnote test which actually is panning dependent. Simple fix, just use the R channel from the synth output instead of the L channel (this also ensures a certain amount of backwards traceability rather than extracting new values to compare with in the applicable tests).