### PR TITLE
Fmaa multiscale

### DIFF
--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -42,6 +42,46 @@ bool isPlugin = false;
 
 prng_t prng_state = 0x1234;
 
+// Compute a Hann windowed sinc kernel
+//
+// Args:
+//   fc:    Cutoff frequency as a fraction of the sampling rate (in (0, 0.5))
+//   beta:  Kaiser window parameter
+//   h:     Output array
+//
+void windowedsinc(float fc, float gain, int N, float *h) {
+  
+  // Compute the sinc filter.
+  float s[N];
+  for (int n = 0; n < N; n++) {
+    s[n] = (n == (N-1)/2) ? 1 : sin(2 * M_PI * fc * (n - (N - 1) / 2)) / (2 * M_PI * fc * (n - (N - 1) / 2));
+  }
+
+  float w[N];
+  // Compute the Hann window.
+  for (int n = 0; n < N; n++) {
+    w[n] = 0.5 * (1 - cos(2 * M_PI * n / (N - 1)));
+  }
+
+  // Multiply the sinc filter by the window.
+  for (int n = 0; n < N; n++) {
+    h[n] = s[n] * w[n];
+  }
+
+  // summarize the kernel to get gain.
+  float sum = 0;
+  for (int n = 0; n < N; n++) {
+    sum += h[n];
+  }
+  
+  // divide by measured gain, multiply wanted gain.
+  for (int n = 0; n < N; n++) {
+    const float factor = gain/sum;
+    h[n] *= factor;
+  }
+}
+
+
 /*
  * Transform the velocity according the scaling parameter (velocity sensing)
  */

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -42,11 +42,25 @@ bool isPlugin = false;
 
 prng_t prng_state = 0x1234;
 
-// Compute a Hann windowed sinc kernel
+inline void BlackmanHarrisWindow(int N, float* w )
+{
+    const float a0      = 0.35875f;
+    const float a1      = 0.48829f;
+    const float a2      = 0.14128f;
+    const float a3      = 0.01168f;
+
+    for(auto i = 0; i < N; i++ )
+    {
+        w[i]   = a0 - (a1 * cosf( (2.0f * M_PI * i) / (N - 1) )) + (a2 * cosf( (4.0f * M_PI * i) / (N - 1) )) - (a3 * cosf( (6.0f * M_PI * i) / (N - 1) ));
+    }
+}
+
+
+// Compute a windowed sinc kernel
 //
 // Args:
 //   fc:    Cutoff frequency as a fraction of the sampling rate (in (0, 0.5))
-//   beta:  Kaiser window parameter
+//   gain:  gain factor of the kernel
 //   h:     Output array
 //
 void windowedsinc(float fc, float gain, int N, float *h) {
@@ -58,7 +72,8 @@ void windowedsinc(float fc, float gain, int N, float *h) {
   }
 
   float w[N];
-  // Compute the Hann window.
+  // Compute the Blackmann-Harris window.
+  //~ BlackmanHarrisWindow(N, w );
   for (int n = 0; n < N; n++) {
     w[n] = 0.5 * (1 - cos(2 * M_PI * n / (N - 1)));
   }

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -55,6 +55,22 @@ inline void BlackmanHarrisWindow(int N, float* w )
     }
 }
 
+inline float i0(float x) {
+  return 1 + x * x / 4;
+}
+
+// Compute the Kaiser window.
+inline void KaiserWindow(float beta, int N, float* w ) {
+    for (int n = 0; n < N; n++) {
+        w[n] = i0(beta * sqrt(1 - pow(2 * n / (N - 1) - 1, 2))) / i0(beta);
+    }
+}
+
+inline void HannWindow(int N, float* w ) {
+    for (int n = 0; n < N; n++) {
+        w[n] = 0.5 * (1 - cos(2 * M_PI * n / (N - 1)));
+    }
+}
 
 // Compute a windowed sinc kernel
 //
@@ -71,12 +87,12 @@ void windowedsinc(float fc, float gain, int N, float *h) {
     s[n] = (n == (N-1)/2) ? 1 : sin(2 * M_PI * fc * (n - (N - 1) / 2)) / (2 * M_PI * fc * (n - (N - 1) / 2));
   }
 
+  // Compute the window.
   float w[N];
-  // Compute the Blackmann-Harris window.
-  //~ BlackmanHarrisWindow(N, w );
-  for (int n = 0; n < N; n++) {
-    w[n] = 0.5 * (1 - cos(2 * M_PI * n / (N - 1)));
-  }
+  //KaiserWindow(N, 8, w);  // nan audio
+  BlackmanHarrisWindow(N, w);
+  //~ HannWindow(N, w);
+
 
   // Multiply the sinc filter by the window.
   for (int n = 0; n < N; n++) {

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -23,7 +23,12 @@
 #include <rtosc/ports.h>
 #include <rtosc/port-sugar.h>
 
+#define DEBUGPRINTf(x) printf("DEBUG - " #x " = %f\n", x)
+#define DEBUGPRINTi(x) printf("DEBUG - " #x " = %d\n", x)
+
 namespace zyn {
+
+void windowedsinc(float fc, float gain, int N, float *h);
 
 extern bool isPlugin;
 bool fileexists(const char *filename);

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -494,6 +494,10 @@ ADnoteGlobalParam::ADnoteGlobalParam(const AbsTime *time_) :
     FilterEnvelope->init(ad_global_filter);
     FilterLfo = new LFOParams(ad_global_filter, time_);
     Reson     = new Resonance();
+    
+    wskernel = new float[WSKERNELSIZE];
+    windowedsinc(0.0125, 1.0f, WSKERNELSIZE, wskernel);
+    
 }
 
 void ADnoteParameters::defaults()
@@ -720,6 +724,7 @@ ADnoteGlobalParam::~ADnoteGlobalParam()
     delete FilterEnvelope;
     delete FilterLfo;
     delete Reson;
+    delete wskernel;
 }
 
 ADnoteParameters::~ADnoteParameters()

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -496,7 +496,7 @@ ADnoteGlobalParam::ADnoteGlobalParam(const AbsTime *time_) :
     Reson     = new Resonance();
     
     wskernel = new float[WSKERNELSIZE];
-    windowedsinc(0.0125, 1.0f, WSKERNELSIZE, wskernel);
+    windowedsinc(0.00625, 1.0f, WSKERNELSIZE, wskernel);
     
 }
 

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -20,6 +20,12 @@
 
 namespace zyn {
 
+/**
+ * The size of the windowes sinc kernel
+ * This must be an odd number
+ */
+#define WSKERNELSIZE 161
+
 enum class FMTYPE {
     NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD
 };
@@ -40,8 +46,10 @@ struct ADnoteGlobalParam {
     Stereo=1, Mono=0. */
 
     unsigned char PStereo;
-
-
+    
+    // float array for windowed sinc kernel
+    float_t* wskernel;
+    
     /******************************************
     *     FREQUENCY GLOBAL PARAMETERS        *
     ******************************************/

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1543,11 +1543,15 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
         // variable to accumulate the output to
         float out = 0;
         for(int i = 0; i < synth.buffersize; ++i) {
-            // accumulate the freq to get a pos
+            float fmpos;
+            // FM: accumulate tw to transform freq to pos
+            // PM: use tw as pos
             fmold += tw[i];
+            if(FMmode == FMTYPE::FREQ_MOD) fmpos=fmold; 
+            else fmpos = tw[i];
             int FMmodposhi = 0;
-            F2I(fmold, FMmodposhi);
-            int FMmodposlo = ((fmold-FMmodposhi) * (1<<24));//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
+            F2I(fmpos, FMmodposhi);
+            int FMmodposlo = ((fmpos-FMmodposhi) * (1<<24));//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
             // make the rounding error symmetric
             if(FMmodposlo < 0)
                 FMmodposlo++;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1582,11 +1582,15 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                 ovsmpposhi &= synth.oscilsize - 1;
                 //for resampling factor up to 40 we reduce the kernel step size down to 1.
                 // -> lower cut off frequency
-                const int stpsize = rsmpfactor>40 ? 1 : 40/rsmpfactor;
+                
+                #define minstep 8 // <-----      this factor reduces the needed multiplications  <----------------
+                                 // it's best to use integer factors of 40
+                
+                const int stpsize = rsmpfactor>40/minstep ? minstep : 40/rsmpfactor;
                 // for resampling factor above 40 start scipping oscillator samples
-                const int ovsmpfreqhi = rsmpfactor<40 ? 1 : rsmpfactor/40;
+                const int ovsmpfreqhi = rsmpfactor<minstep ? 1 : rsmpfactor/minstep;
                 // first kernel sample to be used
-                const int startposhi = (carposlo*stpsize*ovsmpfreqhi)>>24;                
+                const int startposhi = (carposlo*stpsize)>>24;                
                 // reset output value
                 float out = 0;
                 for (int l = startposhi; l<(WSKERNELSIZE-2); l+=stpsize) { 


### PR DESCRIPTION
this commit adds a function to calculate a windows sinc kernel.
this is used as antialiasing filter in addsynth for the standard oscillator if the AA button in voice list
it effectively reduces audible antialiasing which otherwise occurs if a note is bent to higher frequencies by ENV, LFO or pitchbend.

In FM it is always active because there is such frequency bending the standard use case.