### PR TITLE
new chorus mode - Roland Ensemble

### DIFF
--- a/doc/effects.txt
+++ b/doc/effects.txt
@@ -137,6 +137,10 @@ with very short LFO delay and little LFO depth. You can imagine a flanger as two
 copies of a sound playing at almost the same time. This leads to interference,
 which can be clearly heard. It is popular to apply flangers to guitars, giving
 them more "character".
+While in standard CHORUS and FLANGER mode there is only one additional voice, that 
+can be blended with the original one using the amount knob, the DUAL and TRIPLE 
+mode adds two/three voices with their LFOs each being phase shifted by 180 / 120 degrees.
+Those have been used by famous roland string synthesizers.
 
 Usage
 ^^^^^
@@ -153,6 +157,7 @@ the *D/W* knob, but we have not applied panning and subtraction yet.
 * Next, the signal can be negated. If the *Subtract* checkbox is activated,
 the amplitude is multiplied by -1.
 * Finally, *Pan* lets you apply panning.
+* *Mode* selector lets you choose between Chorus, Flanger, Dual- and Triple Chorus.
 
 Distortion
 ~~~~~~~~~~

--- a/doc/effects.txt
+++ b/doc/effects.txt
@@ -137,7 +137,7 @@ with very short LFO delay and little LFO depth. You can imagine a flanger as two
 copies of a sound playing at almost the same time. This leads to interference,
 which can be clearly heard. It is popular to apply flangers to guitars, giving
 them more "character".
-While in standard CHORUS and FLANGER mode there is only one additional voice, that
+While in standard CHORUS and FLANGER mode there is only one additional voice that
 can be blended with the original one using the amount knob, the DUAL and TRIPLE
 mode adds two/three voices with their LFOs each being phase shifted by 180 / 120 degrees.
 Those have been used by famous roland string synthesizers.

--- a/doc/effects.txt
+++ b/doc/effects.txt
@@ -137,8 +137,8 @@ with very short LFO delay and little LFO depth. You can imagine a flanger as two
 copies of a sound playing at almost the same time. This leads to interference,
 which can be clearly heard. It is popular to apply flangers to guitars, giving
 them more "character".
-While in standard CHORUS and FLANGER mode there is only one additional voice, that 
-can be blended with the original one using the amount knob, the DUAL and TRIPLE 
+While in standard CHORUS and FLANGER mode there is only one additional voice, that
+can be blended with the original one using the amount knob, the DUAL and TRIPLE
 mode adds two/three voices with their LFOs each being phase shifted by 180 / 120 degrees.
 Those have been used by famous roland string synthesizers.
 

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -144,7 +144,7 @@ void Chorus::out(const Stereo<float *> &input)
         // third member for ensemble mode
         dlHist240 = dlNew240;
         drHist240 = drNew240;
-        lfo.effectlfoout(&lfol, &lfor, 0.66666666f);
+        lfo.effectlfoout(&lfol, &lfor, 0.6f); // shifted to make it less regular
 
         dlNew240 = getdelay(lfol);
         drNew240 = getdelay(lfor);
@@ -322,6 +322,11 @@ void Chorus::changepar(int npar, unsigned char value)
             setlrcross(value);
             break;
         case 10:
+            if (Pflangemode == ENSEMBLE && value != ENSEMBLE) 
+                lfo.Pfreq *= 1.5f;
+            if (Pflangemode != ENSEMBLE && value == ENSEMBLE) 
+                lfo.Pfreq *= 0.66666666f;
+            lfo.updateparams();
             Pflangemode = (value > 2) ? 2 : value;
             break;
         case 11:

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -300,7 +300,7 @@ unsigned char Chorus::getpresetpar(unsigned char npreset, unsigned int npar)
         //Ensemble
         {127, 64, 68, 25, 1, 24, 35,  55, 64,  0,   TRIPLE, 0},
         //Dual
-        {127, 64, 55, 25, 1, 24, 32,  55, 64,  0,   DUAL, 0}
+        {127, 64, 55, 25, 1, 24, 32,  55, 80,  0,   DUAL, 0}
     };
     if(npreset < NUM_PRESETS && npar < PRESET_SIZE) {
         return presets[npreset][npar];

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -133,7 +133,7 @@ void Chorus::out(const Stereo<float *> &input)
     // calculate new delay values
     dlNew = getdelay(lfol);
     drNew = getdelay(lfor);
-    
+    float fbComp = fb;
     if (Pflangemode == DUAL) // ensemble mode
     {
         // same for second member for ensemble mode with 120° phase offset
@@ -142,6 +142,7 @@ void Chorus::out(const Stereo<float *> &input)
         lfo.effectlfoout(&lfol, &lfor, 0.5f);
         dlNew2 = getdelay(lfol);
         drNew2 = getdelay(lfor);
+        fbComp /= 2.0f;
     }
     
     if (Pflangemode == TRIPLE) // ensemble mode
@@ -159,6 +160,7 @@ void Chorus::out(const Stereo<float *> &input)
         lfo.effectlfoout(&lfol, &lfor, 0.66666666f); 
         dlNew3 = getdelay(lfol);
         drNew3 = getdelay(lfor);
+        fbComp /= 3.0f;
     }
 
     for(int i = 0; i < buffersize; ++i) {
@@ -200,7 +202,7 @@ void Chorus::out(const Stereo<float *> &input)
                 break;
         }
         // store current input + feedback to delay line at writing position
-        delaySample.l[dlk] = inL + output * fb;
+        delaySample.l[dlk] = inL + output * fbComp;
         // write output to output interface
         efxoutl[i] = output;
 
@@ -231,7 +233,7 @@ void Chorus::out(const Stereo<float *> &input)
                 break;
         }
         
-        delaySample.r[drk] = inR + output * fb;
+        delaySample.r[drk] = inR + output * fbComp;
         efxoutr[i] = output;
     }
 

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -165,7 +165,7 @@ void Chorus::out(const Stereo<float *> &input)
         dlNew3 = getdelay(lfol);
         drNew3 = getdelay(lfor);
         // reduce amplitude to match single phase modes
-        // 0.85 * fbComp / 3 
+        // 0.85 * fbComp / 3
         fbComp /= 3.53f;
     }
 

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -20,7 +20,7 @@
 using namespace std;
 
 namespace zyn {
-    
+
 #define PHASE_120 0.33333333f
 #define PHASE_180 0.5f
 #define PHASE_240 0.66666666f
@@ -148,7 +148,7 @@ void Chorus::out(const Stereo<float *> &input)
         drNew2 = getdelay(lfor);
         fbComp /= 2.0f;
     }
-    
+
     if (Pflangemode == TRIPLE) // ensemble mode
     {
         // same for second member for ensemble mode with 120° phase offset
@@ -157,11 +157,11 @@ void Chorus::out(const Stereo<float *> &input)
         lfo.effectlfoout(&lfol, &lfor, PHASE_120);
         dlNew2 = getdelay(lfol);
         drNew2 = getdelay(lfor);
-        
+
         // same for third member for ensemble mode with 240° phase offset
         dlHist3 = dlNew3;
         drHist3 = drNew3;
-        lfo.effectlfoout(&lfol, &lfor, PHASE_240); 
+        lfo.effectlfoout(&lfol, &lfor, PHASE_240);
         dlNew3 = getdelay(lfol);
         drNew3 = getdelay(lfor);
         fbComp /= 3.0f;
@@ -236,7 +236,7 @@ void Chorus::out(const Stereo<float *> &input)
                 // nothing to do for standard chorus
                 break;
         }
-        
+
         delaySample.r[drk] = inR + output * fbComp;
         efxoutr[i] = output;
     }

--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -20,6 +20,10 @@
 using namespace std;
 
 namespace zyn {
+    
+#define PHASE_120 0.33333333f
+#define PHASE_180 0.5f
+#define PHASE_240 0.66666666f
 
 #define rObject Chorus
 #define rBegin [](const char *msg, rtosc::RtData &d) {
@@ -139,7 +143,7 @@ void Chorus::out(const Stereo<float *> &input)
         // same for second member for ensemble mode with 120° phase offset
         dlHist2 = dlNew2;
         drHist2 = drNew2;
-        lfo.effectlfoout(&lfol, &lfor, 0.5f);
+        lfo.effectlfoout(&lfol, &lfor, PHASE_180);
         dlNew2 = getdelay(lfol);
         drNew2 = getdelay(lfor);
         fbComp /= 2.0f;
@@ -150,14 +154,14 @@ void Chorus::out(const Stereo<float *> &input)
         // same for second member for ensemble mode with 120° phase offset
         dlHist2 = dlNew2;
         drHist2 = drNew2;
-        lfo.effectlfoout(&lfol, &lfor, 0.33333333f);
+        lfo.effectlfoout(&lfol, &lfor, PHASE_120);
         dlNew2 = getdelay(lfol);
         drNew2 = getdelay(lfor);
         
         // same for third member for ensemble mode with 240° phase offset
         dlHist3 = dlNew3;
         drHist3 = drNew3;
-        lfo.effectlfoout(&lfol, &lfor, 0.66666666f); 
+        lfo.effectlfoout(&lfol, &lfor, PHASE_240); 
         dlNew3 = getdelay(lfol);
         drNew3 = getdelay(lfor);
         fbComp /= 3.0f;

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -17,9 +17,22 @@
 #include "EffectLFO.h"
 #include "../Misc/Stereo.h"
 
-#define MAX_CHORUS_DELAY 250.0f //ms
+
+
+
 
 namespace zyn {
+
+#define MAX_CHORUS_DELAY 250.0f //ms
+
+#define CHORUS_MODES \
+    CHORUS,\
+    FLANGE,\
+    ENSEMBLE\
+
+enum {
+    CHORUS_MODES
+};
 
 /**Chorus and Flange effects*/
 class Chorus final:public Effect
@@ -73,6 +86,8 @@ class Chorus final:public Effect
 
         static rtosc::Ports ports;
     private:
+        inline float getSample(float* delayline, float mdel, int dk);
+        
         //Chorus Parameters
         unsigned char Pvolume;
         unsigned char Pdepth;      //the depth of the Chorus(ms)
@@ -91,11 +106,18 @@ class Chorus final:public Effect
 
         //Internal Values
         float depth, delay, fb;
-        float dl1, dl2, dr1, dr2, lfol, lfor;
+        float dlHist, dlNew, lfol;
+        float drHist, drNew, lfor;
+        float dlHist120, dlNew120;
+        float drHist120, drNew120;
+        float dlHist240, dlNew240;
+        float drHist240, drNew240;
         int   maxdelay;
         Stereo<float *> delaySample;
-        int dlk, drk, dlhi;
+        int dlk, drk;
         float getdelay(float xlfo);
+        
+        float output;
 };
 
 }

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -28,7 +28,8 @@ namespace zyn {
 #define CHORUS_MODES \
     CHORUS,\
     FLANGE,\
-    ENSEMBLE\
+    TRIPLE,\
+    DUAL\
 
 enum {
     CHORUS_MODES
@@ -108,10 +109,10 @@ class Chorus final:public Effect
         float depth, delay, fb;
         float dlHist, dlNew, lfol;
         float drHist, drNew, lfor;
-        float dlHist120, dlNew120;
-        float drHist120, drNew120;
-        float dlHist240, dlNew240;
-        float drHist240, drNew240;
+        float dlHist2, dlNew2;
+        float drHist2, drNew2;
+        float dlHist3, dlNew3;
+        float drHist3, drNew3;
         int   maxdelay;
         Stereo<float *> delaySample;
         int dlk, drk;

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -25,11 +25,17 @@ namespace zyn {
 
 #define MAX_CHORUS_DELAY 250.0f //ms
 
+// Chorus modes
+// CHORUS default chorus mode
+// FLANGE flanger mode (very short delays)
+// TRIPLE 120° triple phase chorus
+// DUAL   180° dual phase chorus
+
 #define CHORUS_MODES \
-    CHORUS,\ // default chorus mode
-    FLANGE,\ // flanger mode (very short delays)
-    TRIPLE,\ // 120° triple phase chorus
-    DUAL\    // 180° dual phase chorus
+    CHORUS,\
+    FLANGE,\
+    TRIPLE,\
+    DUAL
 
 enum {
     CHORUS_MODES

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -94,7 +94,7 @@ class Chorus final:public Effect
         static rtosc::Ports ports;
     private:
         inline float getSample(float* delayline, float mdel, int dk);
-        
+
         //Chorus Parameters
         unsigned char Pvolume;
         unsigned char Pdepth;      //the depth of the Chorus(ms)
@@ -123,7 +123,7 @@ class Chorus final:public Effect
         Stereo<float *> delaySample;
         int dlk, drk;
         float getdelay(float xlfo);
-        
+
         float output;
 };
 

--- a/src/Effects/Chorus.h
+++ b/src/Effects/Chorus.h
@@ -26,10 +26,10 @@ namespace zyn {
 #define MAX_CHORUS_DELAY 250.0f //ms
 
 #define CHORUS_MODES \
-    CHORUS,\
-    FLANGE,\
-    TRIPLE,\
-    DUAL\
+    CHORUS,\ // default chorus mode
+    FLANGE,\ // flanger mode (very short delays)
+    TRIPLE,\ // 120° triple phase chorus
+    DUAL\    // 180° dual phase chorus
 
 enum {
     CHORUS_MODES
@@ -94,7 +94,7 @@ class Chorus final:public Effect
         unsigned char Pdepth;      //the depth of the Chorus(ms)
         unsigned char Pdelay;      //the delay (ms)
         unsigned char Pfb;         //feedback
-        unsigned char Pflangemode; //how the LFO is scaled, to result chorus or flange
+        unsigned char Pflangemode; //mode as described above in CHORUS_MODES
         unsigned char Poutsub;     //if I wish to subtract the output instead of the adding it
         EffectLFO     lfo;         //lfo-ul chorus
 

--- a/src/Effects/EffectLFO.cpp
+++ b/src/Effects/EffectLFO.cpp
@@ -82,15 +82,15 @@ float EffectLFO::getlfoshape(float x)
 }
 
 //LFO output
-void EffectLFO::effectlfoout(float *outl, float *outr, unsigned char phaseOffset)
+void EffectLFO::effectlfoout(float *outl, float *outr, float phaseOffset)
 {
     float out;
-
+    // left stereo signal
     out = getlfoshape(xl+phaseOffset);
     if((lfotype == 0) || (lfotype == 1))
         out *= (ampl1 + xl * (ampl2 - ampl1));
     *outl = (out + 1.0f) * 0.5f;
-    // update left phase for master
+    // update left phase for master lfo
     if(phaseOffset==0.0f) {
         xl += incx;
         if(xl > 1.0f) {
@@ -100,12 +100,13 @@ void EffectLFO::effectlfoout(float *outl, float *outr, unsigned char phaseOffset
         }
     }
 
+    // right stereo signal
     out = getlfoshape(xr+phaseOffset);
     if((lfotype == 0) || (lfotype == 1))
         out *= (ampr1 + xr * (ampr2 - ampr1));
     *outr = (out + 1.0f) * 0.5f;
     
-    // update right phase for master
+    // update right phase for master lfo
     if(phaseOffset==0.0f) {
         xr += incx;
         if(xr > 1.0f) {

--- a/src/Effects/EffectLFO.cpp
+++ b/src/Effects/EffectLFO.cpp
@@ -62,6 +62,7 @@ void EffectLFO::updateparams(void)
 //Compute the shape of the LFO
 float EffectLFO::getlfoshape(float x)
 {
+    x = fmodf(x, 1.0f);
     float out;
     switch(lfotype) {
         case 1: //EffectLFO_TRIANGLE
@@ -81,31 +82,39 @@ float EffectLFO::getlfoshape(float x)
 }
 
 //LFO output
-void EffectLFO::effectlfoout(float *outl, float *outr)
+void EffectLFO::effectlfoout(float *outl, float *outr, unsigned char phaseOffset)
 {
     float out;
 
-    out = getlfoshape(xl);
+    out = getlfoshape(xl+phaseOffset);
     if((lfotype == 0) || (lfotype == 1))
         out *= (ampl1 + xl * (ampl2 - ampl1));
-    xl += incx;
-    if(xl > 1.0f) {
-        xl   -= 1.0f;
-        ampl1 = ampl2;
-        ampl2 = (1.0f - lfornd) + lfornd * RND;
-    }
     *outl = (out + 1.0f) * 0.5f;
+    // update left phase for master
+    if(phaseOffset==0.0f) {
+        xl += incx;
+        if(xl > 1.0f) {
+            xl   -= 1.0f;
+            ampl1 = ampl2;
+            ampl2 = (1.0f - lfornd) + lfornd * RND;
+        }
+    }
 
-    out = getlfoshape(xr);
+    out = getlfoshape(xr+phaseOffset);
     if((lfotype == 0) || (lfotype == 1))
         out *= (ampr1 + xr * (ampr2 - ampr1));
-    xr += incx;
-    if(xr > 1.0f) {
-        xr   -= 1.0f;
-        ampr1 = ampr2;
-        ampr2 = (1.0f - lfornd) + lfornd * RND;
-    }
     *outr = (out + 1.0f) * 0.5f;
+    
+    // update right phase for master
+    if(phaseOffset==0.0f) {
+        xr += incx;
+        if(xr > 1.0f) {
+            xr   -= 1.0f;
+            ampr1 = ampr2;
+            ampr2 = (1.0f - lfornd) + lfornd * RND;
+        }
+    }
+    
 }
 
 }

--- a/src/Effects/EffectLFO.cpp
+++ b/src/Effects/EffectLFO.cpp
@@ -105,7 +105,7 @@ void EffectLFO::effectlfoout(float *outl, float *outr, float phaseOffset)
     if((lfotype == 0) || (lfotype == 1))
         out *= (ampr1 + xr * (ampr2 - ampr1));
     *outr = (out + 1.0f) * 0.5f;
-    
+
     // update right phase for master lfo
     if(phaseOffset==0.0f) {
         xr += incx;
@@ -115,7 +115,7 @@ void EffectLFO::effectlfoout(float *outl, float *outr, float phaseOffset)
             ampr2 = (1.0f - lfornd) + lfornd * RND;
         }
     }
-    
+
 }
 
 }

--- a/src/Effects/EffectLFO.h
+++ b/src/Effects/EffectLFO.h
@@ -30,20 +30,20 @@ class EffectLFO
      * @param bufsize_f Buffer size.
      * @param time Pointer to an AbsTime object (optional).
      */
-    EffectLFO(float srate_f, float bufsize_f);
+    EffectLFO(float srate_f, float bufsize_f, const AbsTime *time = nullptr);
 
     /**
      * Destructs the EffectLFO object.
      */
     ~EffectLFO();
 
+    // if phaseOffset!=0 we don't want to update the phase but get a phased shifted output of the last one.
     /**
-     * Processes the LFO and outputs the result to the provided pointers.
-     *
+     * calculate the output of the effect LFO for two signals (stereo)
      * @param outl Pointer to the left output channel.
      * @param outr Pointer to the right output channel.
-     * @param phaseOffset phaseoffset 
-     * if phaseOffset is not 0 we don't want to update the phase 
+     * @param phaseOffset phaseoffset
+     * if phaseOffset is not 0 we don't want to update the phase
      * but get the phased shifted output of the last one.
      */
     void effectlfoout(float *outl, float *outr, float phaseOffset = 0.0f);

--- a/src/Effects/EffectLFO.h
+++ b/src/Effects/EffectLFO.h
@@ -43,7 +43,7 @@ class EffectLFO
      * @param outl Pointer to the left output channel.
      * @param outr Pointer to the right output channel.
      */
-    void effectlfoout(float *outl, float *outr, unsigned char phaseOffset = 0);
+    void effectlfoout(float *outl, float *outr, float phaseOffset = 0);
 
     /**
      * Updates the LFO parameters based on the current settings.

--- a/src/Effects/EffectLFO.h
+++ b/src/Effects/EffectLFO.h
@@ -30,7 +30,7 @@ class EffectLFO
      * @param bufsize_f Buffer size.
      * @param time Pointer to an AbsTime object (optional).
      */
-    EffectLFO(float srate_f, float bufsize_f, const AbsTime *time = nullptr);
+    EffectLFO(float srate_f, float bufsize_f);
 
     /**
      * Destructs the EffectLFO object.
@@ -42,8 +42,11 @@ class EffectLFO
      *
      * @param outl Pointer to the left output channel.
      * @param outr Pointer to the right output channel.
+     * @param phaseOffset phaseoffset 
+     * if phaseOffset is not 0 we don't want to update the phase 
+     * but get the phased shifted output of the last one.
      */
-    void effectlfoout(float *outl, float *outr, float phaseOffset = 0);
+    void effectlfoout(float *outl, float *outr, float phaseOffset = 0.0f);
 
     /**
      * Updates the LFO parameters based on the current settings.

--- a/src/Effects/EffectLFO.h
+++ b/src/Effects/EffectLFO.h
@@ -43,7 +43,7 @@ class EffectLFO
      * @param outl Pointer to the left output channel.
      * @param outr Pointer to the right output channel.
      */
-    void effectlfoout(float *outl, float *outr);
+    void effectlfoout(float *outl, float *outr, unsigned char phaseOffset = 0);
 
     /**
      * Updates the LFO parameters based on the current settings.

--- a/src/UI/EffUI.fl
+++ b/src/UI/EffUI.fl
@@ -442,12 +442,6 @@ if (filterwindow!=NULL){
         code0 {o->init("parameter9");}
         class Fl_Osc_Dial
       }
-      Fl_Check_Button {} {
-        label Flange
-        xywh {120 10 55 20} box THIN_UP_BOX down_box DOWN_BOX color 230 labelfont 1 labelsize 10 hide deactivate
-        code0 {o->init("parameter10");}
-        class Fl_Osc_Check
-      }
       Fl_Check_Button chorusp11 {
         label Subtract
         tooltip {inverts the output} xywh {185 10 70 20} box THIN_UP_BOX down_box DOWN_BOX color 51 labelsize 10
@@ -469,6 +463,29 @@ if (filterwindow!=NULL){
           xywh {25 25 100 20} labelfont 1 labelsize 10
         }
       }
+      Fl_Choice chorusp10 {
+        label {Mode}
+        tooltip {LFO function} xywh {270 15 80 15} box UP_BOX down_box BORDER_BOX labelfont 1 labelsize 10 align 5 textsize 8
+        code0 {o->init("parameter10");}
+        class Fl_Osc_Choice
+      } {
+        MenuItem {} {
+          label CHORUS
+          xywh {15 15 100 20} labelfont 1 labelsize 10
+        }
+        MenuItem {} {
+          label FLANGE
+          xywh {25 25 100 20} labelfont 1 labelsize 10
+        }
+        MenuItem {} {
+          label TRIPLE
+          xywh {35 35 100 20} labelfont 1 labelsize 10
+        }
+        MenuItem {} {
+          label DUAL
+          xywh {45 45 100 20} labelfont 1 labelsize 10
+        }
+      }    
     }
   }
   Function {make_phaser_window()} {} {


### PR DESCRIPTION
this adds a new chorus mode ensemble, that attempts to realize the three-phase chorus 
once established by the Roland RS202 string synthesizer
https://www.soundonsound.com/reviews/roland-rs202-multivox-mx202-retrozone
https://www.florian-anwander.de/roland_string_choruses/

more info about 3 phase choruses:
http://jhaible.com/legacy/triple_chorus/triple_chorus.html

gui at: https://github.com/mruby-zest/mruby-zest-build/pull/113

# Description

(Write your PR description here)

# Checks

## Human checks (please check those!):

- [x] 01. Could parts of this PR be split into another PR (while keeping the PRs "atomic")?
- [x] 02. Does this PR depend on another PR or does it block another PR?
- [ ] 03. Does this PR solve a known issue?
- [x] 04. Is there sufficient user documentation in the `doc/` folder?
- [x] 05. Is the code realtime safe? (e.g. no `new`/`delete`, no other syscalls like `sleep`/file handling/mutexes, no prints in non-error code pathways, ...)
- [x] 06. Is aliasing avoided?
- [x] 07. Are clicks/pops/discontinuities avoided?
- [x] 08. Are any new parameters well mapped over their provided range?
- [x] 09. Is divide by zero impossible?
- [x] 10. Does the code define all magic numbers at a common place (e.g. on top of the file, or for constants which are used in several places, inside `src/globals.h`)?
- [ ] 11. Are nontrivial formulae or constants explained and the source is referenced?
- [ ] 12. Do nontrivial class variables have a doxygen comment?
- [x] 13. Code: Are grammar and spelling correct? (Note: spell checks are only done for `doc/`)
- [ ] 14. Documentation: Is the grammar correct? (Note: spell checks are done by CI)
- [x] 15. Are all function parameters `const` - if possible?
- [x] 16. Are all class members `const` - if possible?
- [x] 17. Is `memmove` avoided where a ringbuffer would be faster?
- [x] 18. Is a unit test needed for this functionality?

## CI checks:

- No trailing whitespace?
- Are all included headers necessary?
- No compiler warnings?
- No spell errors in documentation? (new words must be appended to `doc/wordlist.txt`)