### PR TITLE
Hardcode system installed banks & presets

### DIFF
--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -380,6 +380,12 @@ void Bank::rescanforbanks()
     for(int i = 0; i < MAX_BANK_ROOT_DIRS; ++i)
         if(!config->cfg.bankRootDirList[i].empty())
             scanrootdir(config->cfg.bankRootDirList[i]);
+#ifdef ZYN_DATADIR
+    scanrootdir(ZYN_DATADIR "/banks");
+#else
+    scanrootdir("/usr/share/zynaddsubfx/banks");
+    scanrootdir("/usr/local/share/zynaddsubfx/banks");
+#endif
 #ifdef WIN32
     {
         //Search the VST Directory for banks/preset/etc

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -244,12 +244,6 @@ void Config::init()
         cfg.bankRootDirList[2] = "../banks";
 #endif
         cfg.bankRootDirList[3] = "banks";
-#ifdef ZYN_DATADIR
-        cfg.bankRootDirList[4] = ZYN_DATADIR "/banks";
-#else
-        cfg.bankRootDirList[4] = "/usr/share/zynaddsubfx/banks";
-        cfg.bankRootDirList[5] = "/usr/local/share/zynaddsubfx/banks";
-#endif
     }
 
     if(cfg.presetsDirList[0].empty()) {
@@ -261,12 +255,6 @@ void Config::init()
         cfg.presetsDirList[1] = "../presets";
 #endif
         cfg.presetsDirList[2] = "presets";
-#ifdef ZYN_DATADIR
-        cfg.presetsDirList[3] = ZYN_DATADIR "/presets";
-#else
-        cfg.presetsDirList[3] = "/usr/share/zynaddsubfx/presets";
-        cfg.presetsDirList[4] = "/usr/local/share/zynaddsubfx/presets";
-#endif
     }
     cfg.LinuxALSAaudioDev = "default";
     cfg.nameTag = "";

--- a/src/Params/PresetsStore.h
+++ b/src/Params/PresetsStore.h
@@ -54,6 +54,10 @@ class PresetsStore
         } clipboard;
 
         void clearpresets();
+
+    private:
+
+        void scanrootdir(std::string rootdir);
 };
 
 //extern PresetsStore presetsstore;


### PR DESCRIPTION
Hi! Right now when using zynaddsubfx on NixOS, the built-in instruments get wiped out on each update: https://github.com/NixOS/nixpkgs/issues/143324. 

The way NixOS is designed to install files to a "content-adressable" store (technically input-addressable, but that's not really relevant for this PR), the hash in `ZYN_DATADIR` will change each time the package is updated. Eg. `/nix/store/2w3a6jhxm3y6kb4a0fnbxsh2isc4fbf6-zynaddsubfx-3.0.6/share/zynaddsubfx`.

The problem is that `.zynaddsubfxXML.cfg` keeps around a reference to the directory it found the first time it was launched. So when NixOS removes the old directory, zynaddsubfx will fail to scan it.

This PR modifies bank & preset scanning so the system path will always be loaded, and not saved in `~/.zynaddsubfxXML.cfg`, just like how the VST directory is already hardcoded for windows & macOS.