### PR TITLE
Lazily expand `ZYN_DATADIR`

### DIFF
--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -301,7 +301,6 @@ int Bank::newbank(string newbankdirname)
     bankdir = config->cfg.bankRootDirList[0];
 
     expanddirname(bankdir);
-    normalizedirsuffix(bankdir);
 
     bankdir += newbankdirname;
 #ifdef _WIN32
@@ -458,21 +457,13 @@ void Bank::scanrootdir(string rootdir)
         return;
 
     bankstruct bank;
-
-    const char *separator = "/";
-    if(rootdir.size()) {
-        char tmp = rootdir[rootdir.size() - 1];
-        if((tmp == '/') || (tmp == '\\'))
-            separator = "";
-    }
-
     struct dirent *fn;
     while((fn = readdir(dir))) {
         const char *dirname = fn->d_name;
         if(dirname[0] == '.')
             continue;
 
-        bank.dir  = rootdir + separator + dirname + '/';
+        bank.dir  = rootdir + dirname + '/';
         bank.name = dirname;
         //find out if the directory contains at least 1 instrument
         bool isbank = false;
@@ -572,25 +563,5 @@ void Bank::deletefrombank(int pos)
 Bank::ins_t::ins_t()
     :name(""), filename("")
 {}
-
-void Bank::expanddirname(std::string &dirname) {
-    if (dirname.empty())
-        return;
-
-    // if the directory name starts with a ~ and the $HOME variable is
-    // defined in the environment, replace ~ by the content of $HOME
-    if (dirname.at(0) == '~') {
-        char *home_dirname = getenv("HOME");
-        if (home_dirname != NULL) {
-            dirname = std::string(home_dirname) + dirname.substr(1);
-        }
-    }
-}
-
-void Bank::normalizedirsuffix(string &dirname) const {
-    if(((dirname[dirname.size() - 1]) != '/')
-       && ((dirname[dirname.size() - 1]) != '\\'))
-        dirname += "/";
-}
 
 }

--- a/src/Misc/Bank.h
+++ b/src/Misc/Bank.h
@@ -98,13 +98,6 @@ class Bank
 
         void scanrootdir(std::string rootdir); //scans a root dir for banks
 
-        /** Expends ~ prefix in dirname, if any */
-        void expanddirname(std::string &dirname);
-
-        /** Ensure that the directory name is suffixed by a
-         * directory separator */
-        void normalizedirsuffix(std::string &dirname) const;
-
         Config* const config;
         class BankDb *db;
 

--- a/src/Misc/Config.cpp
+++ b/src/Misc/Config.cpp
@@ -245,7 +245,7 @@ void Config::init()
 #endif
         cfg.bankRootDirList[3] = "banks";
 #ifdef ZYN_DATADIR
-        cfg.bankRootDirList[4] = ZYN_DATADIR "/banks";
+        cfg.bankRootDirList[4] = "$ZYN_DATADIR/banks";
 #else
         cfg.bankRootDirList[4] = "/usr/share/zynaddsubfx/banks";
         cfg.bankRootDirList[5] = "/usr/local/share/zynaddsubfx/banks";
@@ -262,7 +262,7 @@ void Config::init()
 #endif
         cfg.presetsDirList[2] = "presets";
 #ifdef ZYN_DATADIR
-        cfg.presetsDirList[3] = ZYN_DATADIR "/presets";
+        cfg.presetsDirList[3] = "$ZYN_DATADIR/presets";
 #else
         cfg.presetsDirList[3] = "/usr/share/zynaddsubfx/presets";
         cfg.presetsDirList[4] = "/usr/local/share/zynaddsubfx/presets";

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -255,4 +255,36 @@ char *rtosc_splat(const char *path, std::set<std::string> v)
     return buf;
 }
 
+void expanddirname(std::string &dirname) {
+    if (dirname.empty())
+        return;
+
+    // if the directory name starts with a ~ and the $HOME variable is
+    // defined in the environment, replace ~ by the content of $HOME
+    if (dirname.at(0) == '~') {
+        char *home_dirname = getenv("HOME");
+        if (home_dirname != NULL) {
+            dirname = std::string(home_dirname) + dirname.substr(1);
+        }
+    }
+
+#ifdef ZYN_DATADIR
+    {
+        std::string var = "$ZYN_DATADIR";
+        size_t pos = dirname.find(var);
+        if (pos != std::string::npos) {
+            dirname.replace(pos, var.length(), ZYN_DATADIR);
+        }
+    }
+#endif
+
+    normalizedirsuffix(dirname);
+}
+
+void normalizedirsuffix(std::string &dirname) {
+    if(((dirname[dirname.size() - 1]) != '/')
+       && ((dirname[dirname.size() - 1]) != '\\'))
+        dirname += "/";
+}
+
 }

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -159,6 +159,13 @@ static inline void arrayNullify(T &t) {delete [] t; t = NULL; }
 
 char *rtosc_splat(const char *path, std::set<std::string>);
 
+/** Expands ~ prefix & ZYN_DATADIR in dirname */
+void expanddirname(std::string &dirname);
+
+/** Ensure that the directory name is suffixed by a
+ * directory separator */
+void normalizedirsuffix(std::string &dirname);
+
 /**
  * Port macros - these produce easy and regular port definitions for common
  * types

--- a/src/Params/PresetsStore.cpp
+++ b/src/Params/PresetsStore.cpp
@@ -87,6 +87,7 @@ void PresetsStore::scanforpresets()
 
         //open directory
         string dirname = config.cfg.presetsDirList[i];
+        expanddirname(dirname);
         DIR   *dir     = opendir(dirname.c_str());
         if(dir == NULL)
             continue;
@@ -98,15 +99,7 @@ void PresetsStore::scanforpresets()
             if(filename.find(ftype) == string::npos)
                 continue;
 
-            //ensure proper path is formed
-            char tmpc = dirname[dirname.size() - 1];
-            const char *tmps;
-            if((tmpc == '/') || (tmpc == '\\'))
-                tmps = "";
-            else
-                tmps = "/";
-
-            string location = "" + dirname + tmps + filename;
+            string location = dirname + filename;
 
             //trim file type off of name
             string name_type = filename.substr(0, filename.find(ftype));
@@ -138,15 +131,10 @@ void PresetsStore::copypreset(XMLwrapper &xml, char *type, string name)
     name = legalizeFilename(name);
 
     //make path legal
-    const string dirname = config.cfg.presetsDirList[0];
-    char tmpc = dirname[dirname.size() - 1];
-    const char *tmps;
-    if((tmpc == '/') || (tmpc == '\\'))
-        tmps = "";
-    else
-        tmps = "/";
+    string dirname = config.cfg.presetsDirList[0];
+    expanddirname(dirname);
 
-    string filename("" + dirname + tmps + name + "." + &type[1] + ".xpz");
+    string filename("" + dirname + name + "." + &type[1] + ".xpz");
 
     xml.saveXMLfile(filename, config.cfg.GzipCompression);
 }


### PR DESCRIPTION
Alternative to #295 to fix loading builtin banks if `ZYN_DATADIR` changes.

#### Before `.zynaddsubfxXML.cfg`:
```xml
...
<BANKROOT id="4">
<string name="bank_root">/nix/store/2w3a6jhxm3y6kb4a0fnbxsh2isc4fbf6-zynaddsubfx-3.0.6/share/zynaddsubfx/banks</string>
</BANKROOT>
<PRESETSROOT id="3">
<string name="presets_root">/nix/store/2w3a6jhxm3y6kb4a0fnbxsh2isc4fbf6-zynaddsubfx-3.0.6/share/zynaddsubfx/presets</string>
</PRESETSROOT>
...
```

#### After `.zynaddsubfxXML.cfg`:
```xml
...
<BANKROOT id="4">
<string name="bank_root">$ZYN_DATADIR/banks</string>
</BANKROOT>
<PRESETSROOT id="3">
<string name="presets_root">$ZYN_DATADIR/presets</string>
</PRESETSROOT>
...
```