### PR TITLE
Add -Werror support, CMake cleanup

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -27,7 +27,7 @@ jobs:
       run: mkdir build && cd build && cmake ..
     - name: configure-extensive
       if: (github.event_name == 'pull_request_review' && github.event.action == 'submitted') || ( github.ref == 'refs/heads/master' )
-      run: cd build && cmake -DCompileExtensiveTests=ON ..
+      run: cd build && cmake -DCompileExtensiveTests=ON -DRTOSC_WERROR=ON -DWerror=ON ..
     - name: make
       run: cd build && make
     - name: make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 project(zynaddsubfx)
 set(VERSION_MAJOR "3")
 set(VERSION_MINOR "0")
 set(VERSION_REVISION "7")
+cmake_policy(SET CMP0072 NEW)
 
 #Set data directory, if any
 if(DEFINED ZYN_DATADIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,9 @@ find_package(FLTK)
 find_package(OpenGL) #for FLTK
 find_package(ECM)
 list(APPEND CMAKE_MODULE_PATH ${ECM_FIND_MODULE_DIR})
-find_package(LibGit2)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+    find_package(LibGit2)
+endif()
 # lash
 if(PKG_CONFIG_FOUND AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Windows"))
     message("Looking For pkg config modules")
@@ -202,8 +204,19 @@ option (BuildForAMD_X86_64 "Build for AMD x86_64 system" OFF)
 option (BuildForCore2_X86_64 "Build for Intel Core2 x86_64 system" OFF)
 option (BuildForDebug "Include gdb debugging support" OFF)
 option (ExtendedWarnings "Enable all useful warnings" OFF)
+option (Werror "Treat all warnings as errors" ON)
 option (IncludeWhatYouUse "Check for useless includes" OFF)
 mark_as_advanced(IncludeWhatYouUse)
+
+if(Werror)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+        set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+    else()
+        if(NOT WIN32)  # For Windows, just allow warnings for now
+            add_definitions(-Werror)
+        endif()
+    endif()
+endif()
 
 set(CMAKE_BUILD_TYPE "Release")
 
@@ -281,17 +294,13 @@ set (BuildOptionsDebug
     CACHE STRING "Debug build flags")
 STRING(APPEND BuildOptionsDebug " ${BuildOptions_ExtendedWarnings}")
 
-if(${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(IwyuErr "disabled (cmake < 3.3.0)")
-else()
-    if(IncludeWhatYouUse)
-        find_program(IwyuPath NAMES include-what-you-use iwyu)
-        if(NOT IwyuPath)
-            set(IwyuErr "package NOT found")
-        endif()
-    else()
-        set(IwyuErr "disabled (IncludeWhatYouUse=OFF)")
+if(IncludeWhatYouUse)
+    find_program(IwyuPath NAMES include-what-you-use iwyu)
+    if(NOT IwyuPath)
+        set(IwyuErr "package NOT found")
     endif()
+else()
+    set(IwyuErr "disabled (IncludeWhatYouUse=OFF)")
 endif()
 
 ########### Settings dependent code ###########
@@ -367,9 +376,9 @@ endif()
 add_definitions(
 	 -Wall
 	 -Wextra
-	 )
+	 -Wno-stringop-truncation)  # https://stackoverflow.com/questions/50198319
 
-# macro similar to "check_cxx_compiler_flag_extra", however,
+# macro similar to "check_cxx_compiler_flag", however,
 # it also checks for warnings that are only output if other warnings are active
 macro (check_cxx_compiler_flag_extra _FLAG _FAILREGEX _RESULT)
     set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
@@ -388,12 +397,6 @@ check_cxx_compiler_flag_extra("-Wall -Wextra -Wno-inconsistent-missing-override"
     )
 if(COMPILER_SUPPORTS_NO_INCONSISTENT_MISSING_OVERRIDE)
     add_definitions(-Wno-inconsistent-missing-override)
-endif()
-
-check_cxx_compiler_flag("-Wall -Wextra -Werror --system-header-prefix='FL/'"
-    COMPILER_SUPPORTS_SYSTEM_HDR_PREFIX)
-if(COMPILER_SUPPORTS_SYSTEM_HDR_PREFIX)
-    add_definitions(--system-header-prefix="FL/")
 endif()
 
 if(HAVE_X86_FISTPL)
@@ -464,11 +467,9 @@ if(FltkGui)
 	add_definitions(-DFLTK_GUI)
 	message(STATUS "Will build FLTK gui")
 
-	include_directories(
-			${FLTK_INCLUDE_DIR}
-			"${CMAKE_CURRENT_SOURCE_DIR}/UI"
-			"${CMAKE_CURRENT_BINARY_DIR}/UI"
-			)
+	include_directories(SYSTEM ${FLTK_INCLUDE_DIR})
+	include_directories(	"${CMAKE_CURRENT_SOURCE_DIR}/UI"
+				"${CMAKE_CURRENT_BINARY_DIR}/UI")
 
 	add_subdirectory(UI)
 endif()
@@ -493,11 +494,9 @@ if(NtkGui)
 
 	message(STATUS "Will build NTK gui")
 
-	include_directories(BEFORE
-			${NTK_INCLUDE_DIRS}
-			"${CMAKE_CURRENT_SOURCE_DIR}/UI"
-			"${CMAKE_CURRENT_BINARY_DIR}/UI"
-			)
+	include_directories(BEFORE SYSTEM ${NTK_INCLUDE_DIRS})
+	include_directories(BEFORE	"${CMAKE_CURRENT_SOURCE_DIR}/UI"
+					"${CMAKE_CURRENT_BINARY_DIR}/UI")
 
 	add_subdirectory(UI)
 endif()

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -849,7 +849,9 @@ public:
                                 tmp1 << xml;
                                 tmp2 << xml2;
                             }
-                            system("diff tmp1.txt tmp2.txt");
+                            int sys_ret = system("diff tmp1.txt tmp2.txt");
+                            if(sys_ret)
+                                puts("FAILED to compare tmp1.txt and tmp2.txt. Please compare manually.");
                             res = -1;
                         }
 

--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -1582,7 +1582,7 @@ last_xmz->callback = [this](std::string filestr) {
     if (filename[0] != 0)
        strncpy(last_loaded, filename, XMZ_PATH_MAX-1);
     else if (loading_next[0] != 0) {
-       strncpy(last_loaded, loading_next, XMZ_PATH_MAX);
+       strncpy(last_loaded, loading_next, XMZ_PATH_MAX-1);
        loading_next[0] = 0;
     } else
        last_loaded[0] = 0;
@@ -1683,7 +1683,7 @@ microtonalui=new MicrotonalUI(osc, "/microtonal/");
   }
   Function {do_revert_changes_unconditional()} {return_type int
   } {
-    code {strncpy(loading_next, last_loaded, XMZ_PATH_MAX);
+    code {strncpy(loading_next, last_loaded, XMZ_PATH_MAX-1);
     osc->write("/load_xmz", "s", last_loaded);
     osc->write("/last_xmz");
     refresh_master_ui();
@@ -1701,7 +1701,7 @@ return 1;} {}
   }
   Function {do_load_master_unconditional(const char *filename, const char *display_name)} {return_type int
   } {
-    code {strncpy(loading_next, filename, XMZ_PATH_MAX);
+    code {strncpy(loading_next, filename, XMZ_PATH_MAX-1);
     osc->write("/load_xmz", "s", filename);
     osc->write("/last_xmz");
     refresh_master_ui();

--- a/src/UI/OscilGenUI.fl
+++ b/src/UI/OscilGenUI.fl
@@ -178,12 +178,12 @@ display->redraw();}
       Fl_Box {} {
         label 01
         xywh {0 210 20 15} labelfont 1 labelsize 9 align 20
-        code0 {char tmp[10];snprintf(tmp,10,"%d",n+1);o->label(strdup(tmp));}
+        code0 {char tmp[12];snprintf(tmp,sizeof(tmp),"%d",n+1);o->label(strdup(tmp));}
       }
       Fl_Box {} {
         label 01
         xywh {0 0 20 15} labelfont 1 labelsize 9 align 20
-        code0 {char tmp[10];snprintf(tmp,10,"%d",n+1);o->label(strdup(tmp));}
+        code0 {char tmp[12];snprintf(tmp,sizeof(tmp),"%d",n+1);o->label(strdup(tmp));}
       }
     }
   }

--- a/src/UI/PartUI.fl
+++ b/src/UI/PartUI.fl
@@ -67,7 +67,7 @@ class PartSysEffSend {open : {public Fl_Group}
         code0 {o->size(25,25);}
         code1 {o->alt_init("/","Psysefxvol"+to_s(neff)+"/part"+to_s(npart));}
         code2 {o->mark_dead();}
-        code3 {char tmp[10];snprintf(tmp,10,"%d",neff+1);o->copy_label(tmp);}
+        code3 {char tmp[12];snprintf(tmp,sizeof(tmp),"%d",neff+1);o->copy_label(tmp);}
         class Fl_Osc_Dial
       }
     }
@@ -227,7 +227,7 @@ else partkititemgroup->activate();
 o->redraw();
 partui->showparameters(n,-1);//use to delete the ui, if it is not to item 0}
         private xywh {30 0 20 15} down_box DOWN_BOX labeltype EMBOSSED_LABEL labelfont 1 labelsize 13 align 4
-        code0 {snprintf(label,10,"%d",n+1);o->label(label);}
+        code0 {snprintf(label,sizeof(label),"%d",n+1);o->label(label);}
         code1 {o->init("Penabled");}
         code2 {if (n==0) o->deactivate();}
         class Fl_Osc_Check
@@ -258,7 +258,7 @@ end();} {}
   }
   decl {int n;} {private local
   }
-  decl {char label[10];} {private local
+  decl {char label[12];} {private local
   }
   decl {class PartUI *partui;} {private local
   }

--- a/src/UI/SUBnoteUI.fl
+++ b/src/UI/SUBnoteUI.fl
@@ -88,12 +88,12 @@ class SUBnoteharmonic {: {public Fl_Osc_Group}
       Fl_Box {} {
         label 01
         xywh {0 288 10 15} labelfont 1 labelsize 9 align 20
-        code0 {char tmp[10];snprintf(tmp,10,"%d",n+1);o->label(strdup(tmp));}
+        code0 {char tmp[12];snprintf(tmp,sizeof(tmp),"%d",n+1);o->label(strdup(tmp));}
       }
       Fl_Box {} {
         label 01
         xywh {0 0 10 15} labelfont 1 labelsize 9 align 20
-        code0 {char tmp[10];snprintf(tmp,10,"%d",n+1);o->label(strdup(tmp));}
+        code0 {char tmp[12];snprintf(tmp,sizeof(tmp),"%d",n+1);o->label(strdup(tmp));}
       }
     }
   }


### PR DESCRIPTION
* Add Werror option and use it in CI
* Add -Wno-stringop-truncation because it cannot be fixed with code
* Don't show warnings in NTK headers
* Fix warnings in code
* Raise CMake minimum version to 3.5 (due to deprecation warnings)
* Update RTOSC correspondingly