### PR TITLE
Plugin: Also accept `-DZynFusionDir`

### DIFF
--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI-Zest.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX-UI-Zest.cpp
@@ -11,6 +11,12 @@
   of the License, or (at your option) any later version.
 */
 
+#if !defined(WIN32) && !defined(__APPLE__)
+#include <string>
+#include <unistd.h>
+#include "zyn-config.h"
+#endif
+
 // DPF includes
 #include "DistrhoUI.hpp"
 #ifdef WIN32
@@ -66,7 +72,18 @@ public:
         if(!handle) // VST
             handle = dlopen("@loader_path/../Resources/libzest.dylib", RTLD_LAZY);
 #else
-        handle = dlopen("./libzest.so", RTLD_LAZY);
+        if(zyn::fusion_dir && *zyn::fusion_dir)
+        {
+            std::string fusion = zyn::fusion_dir;
+            fusion += "/libzest.so";
+            if(access(fusion.c_str(), R_OK))
+                fputs("Warning: CMake's ZynFusionDir does not contain a"
+                      "\"libzest.so\" library - ignoring.", stderr);
+            else
+                handle = dlopen(fusion.c_str(), RTLD_LAZY);
+        }
+        if(!handle)
+            handle = dlopen("./libzest.so", RTLD_LAZY);
         if(!handle)
             handle = dlopen("/opt/zyn-fusion/libzest.so", RTLD_LAZY);
         if(!handle)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -717,6 +717,7 @@ int main(int argc, char *argv[])
         if(gui_pid == 0) {
             auto exec_fusion = [&addr](const char* path) {
                 execlp(path, "zyn-fusion", addr, "--builtin", "--no-hotload",  0); };
+#ifndef __APPLE__
             if(fusion_dir && *fusion_dir)
             {
                 std::string fusion = fusion_dir;
@@ -736,6 +737,7 @@ int main(int argc, char *argv[])
                     exec_fusion(fusion.c_str());
                 }
             }
+#endif
             exec_fusion("./zyn-fusion");
             exec_fusion("/opt/zyn-fusion/zyn-fusion");
             exec_fusion("zyn-fusion");


### PR DESCRIPTION
Also, this commit starts removing `-DZynFusionDir` from macOS - it could have never worked there, due to the `LD_LIBRARY_PATH` not existing there.