### PR TITLE
add feedback LPF/HPF to CombFilter

### DIFF
--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -13,9 +13,14 @@
 
 namespace zyn{
 
+
 CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
     unsigned int srate, int bufsize)
-    :Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), Plpf(127), Phpf(0), 
+    :CombFilter(alloc, Ftype, Ffreq, Fq, srate, bufsize, 127, 0){}
+
+CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
+    unsigned int srate, int bufsize, unsigned char Plpf_, unsigned char Phpf_)
+    :Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), Plpf(127), Phpf(0),
     lpf(nullptr), hpf(nullptr), memory(*alloc)
 {
     //worst case: looking back from smps[0] at 25Hz using higher order interpolation
@@ -27,6 +32,8 @@ CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float
 
     setfreq_and_q(Ffreq, q);
     settype(type);
+    setlpf(Plpf_);
+    sethpf(Phpf_);
 }
 
 CombFilter::~CombFilter(void)
@@ -34,12 +41,12 @@ CombFilter::~CombFilter(void)
     memory.dealloc(input);
     memory.dealloc(output);
 
-    if(Plpf != 127) { //LowPass
+
         memory.dealloc(lpf);
-    }
-    if(Phpf != 0) { //HighPass
+
+
         memory.dealloc(hpf);
-    }
+
 }
 
 

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -6,6 +6,7 @@
 #include "../Misc/Allocator.h"
 #include "../Misc/Util.h"
 #include "CombFilter.h"
+#include "AnalogFilter.h"
 
 // theory from `Introduction to Digital Filters with Audio Applications'', by Julius O. Smith III, (September 2007 Edition).
 // https://www.dsprelated.com/freebooks/filters/Analysis_Digital_Comb_Filter.html
@@ -14,7 +15,8 @@ namespace zyn{
 
 CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
     unsigned int srate, int bufsize)
-    :Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), memory(*alloc)
+    :Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), Plpf(127), Phpf(0), 
+    lpf(nullptr), hpf(nullptr), memory(*alloc)
 {
     //worst case: looking back from smps[0] at 25Hz using higher order interpolation
     mem_size = (int)ceilf((float)samplerate/25.0) + buffersize + 2; // 2178 at 48000Hz and 256Samples
@@ -31,6 +33,13 @@ CombFilter::~CombFilter(void)
 {
     memory.dealloc(input);
     memory.dealloc(output);
+
+    if(Plpf != 127) { //LowPass
+        memory.dealloc(lpf);
+    }
+    if(Phpf != 0) { //HighPass
+        memory.dealloc(hpf);
+    }
 }
 
 
@@ -55,10 +64,12 @@ void CombFilter::filterout(float *smp)
     memmove(&input[0], &input[buffersize], (mem_size-buffersize)*sizeof(float));
     // copy new input samples to the right end of the buffer
     memcpy(&input[mem_size-buffersize], smp, buffersize*sizeof(float));
+
     for (int i = 0; i < buffersize; i ++)
     {
         // calculate the feedback sample positions in the buffer
         float pos = float(mem_size-buffersize+i)-delay;
+
         // add the fwd and bwd feedback samples to current sample
         smp[i] = smp[i]*gain + tanhX(
             gainfwd * sampleLerp( input, pos) -
@@ -68,6 +79,16 @@ void CombFilter::filterout(float *smp)
         // apply output gain
         smp[i] *= outgain;
     }
+
+    float* outputbuf = &output[mem_size-buffersize];
+
+    if(lpf) {
+        lpf->filterout(outputbuf);
+    }
+    if(hpf) {
+        hpf->filterout(outputbuf);
+    }
+
     // shift the buffer content one buffersize to the left
     memmove(&output[0], &output[buffersize], (mem_size-buffersize)*sizeof(float));
 }
@@ -125,6 +146,36 @@ void CombFilter::settype(unsigned char type_)
             gainfwd = -q;
             gainbwd = -q;
             break;
+    }
+}
+
+void CombFilter::sethpf(unsigned char _Phpf)
+{
+    if(Phpf == _Phpf) return;
+    Phpf = _Phpf;
+    if(Phpf == 0) { //No HighPass
+        memory.dealloc(hpf);
+    } else {
+        const float fr = expf(sqrtf(Phpf / 127.0f) * logf(10000.0f)) + 20.0f;
+        if(hpf == NULL)
+            hpf = memory.alloc<AnalogFilter>(1, fr, 1, 0, samplerate, buffersize);
+        else
+            hpf->setfreq(fr);
+    }
+}
+
+void CombFilter::setlpf(unsigned char _Plpf)
+{
+    if(Plpf == _Plpf) return;
+    Plpf = _Plpf;
+    if(Plpf == 127) { //No LowPass
+        memory.dealloc(lpf);
+    } else {
+        const float fr = expf(sqrtf(Plpf / 127.0f) * logf(25000.0f)) + 40.0f;
+        if(!lpf)
+            lpf = memory.alloc<AnalogFilter>(0, fr, 1, 0, samplerate, buffersize);
+        else
+            lpf->setfreq(fr);
     }
 }
 

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -40,13 +40,8 @@ CombFilter::~CombFilter(void)
 {
     memory.dealloc(input);
     memory.dealloc(output);
-
-
-        memory.dealloc(lpf);
-
-
-        memory.dealloc(hpf);
-
+    memory.dealloc(lpf);
+    memory.dealloc(hpf);
 }
 
 

--- a/src/DSP/CombFilter.h
+++ b/src/DSP/CombFilter.h
@@ -23,6 +23,8 @@ class CombFilter:public Filter
         //! @param Fq resonance, range [0.1,1000], logscale
         CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
                 unsigned int srate, int bufsize);
+        CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
+                unsigned int srate, int bufsize, unsigned char Plpf_, unsigned char Phpf_);
         ~CombFilter() override;
         void filterout(float *smp) override;
         void setfreq(float freq) override;
@@ -40,7 +42,7 @@ class CombFilter:public Filter
         float gain;
         float q;
         unsigned char type;
-        
+
         unsigned char Plpf;
         unsigned char Phpf;
 
@@ -53,7 +55,7 @@ class CombFilter:public Filter
         float gainfwd;
         float gainbwd;
         float delay;
-        
+
         class AnalogFilter *lpf, *hpf; //filters
 
         Allocator &memory;

--- a/src/DSP/CombFilter.h
+++ b/src/DSP/CombFilter.h
@@ -30,6 +30,8 @@ class CombFilter:public Filter
         void setq(float q) override;
         void setgain(float dBgain) override;
         void settype(unsigned char type);
+        void sethpf(unsigned char _Phpf);
+        void setlpf(unsigned char _Plpf);
 
     private:
 
@@ -38,15 +40,21 @@ class CombFilter:public Filter
         float gain;
         float q;
         unsigned char type;
+        
+        unsigned char Plpf;
+        unsigned char Phpf;
 
         float step(float x);
 
         float tanhX(const float x);
         float sampleLerp(float *smp, float pos);
 
+
         float gainfwd;
         float gainbwd;
         float delay;
+        
+        class AnalogFilter *lpf, *hpf; //filters
 
         Allocator &memory;
         int mem_size;

--- a/src/DSP/Filter.cpp
+++ b/src/DSP/Filter.cpp
@@ -59,8 +59,13 @@ Filter *Filter::generate(Allocator &memory, const FilterParams *pars,
             filter->setgain(pars->getgain());
             break;
         case 4:
-            filter = memory.alloc<CombFilter>(&memory, Ftype, 1000.0f, pars->getq(), srate, bufsize);
-            filter->setgain(pars->getgain());
+            {
+            CombFilter* comb = memory.alloc<CombFilter>(&memory, Ftype, 1000.0f, pars->getq(), srate, bufsize);
+            comb->setgain(pars->getgain());
+            comb->sethpf(pars->Phpf);
+            comb->setlpf(pars->Plpf);
+            filter = comb;
+            }
             break;
         default:
             filter = memory.alloc<AnalogFilter>(Ftype, 1000.0f, pars->getq(), Fstages, srate, bufsize);

--- a/src/DSP/Filter.cpp
+++ b/src/DSP/Filter.cpp
@@ -60,11 +60,8 @@ Filter *Filter::generate(Allocator &memory, const FilterParams *pars,
             break;
         case 4:
             {
-            CombFilter* comb = memory.alloc<CombFilter>(&memory, Ftype, 1000.0f, pars->getq(), srate, bufsize);
-            comb->setgain(pars->getgain());
-            comb->sethpf(pars->Phpf);
-            comb->setlpf(pars->Plpf);
-            filter = comb;
+            filter = memory.alloc<CombFilter>(&memory, Ftype, 1000.0f, pars->getq(), srate, bufsize, pars->Phpf, pars->Plpf);
+            filter->setgain(pars->getgain());
             }
             break;
         default:

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -141,7 +141,10 @@ const rtosc::Ports FilterParams::ports = {
             "Center Freq (formant)"),
     rParamZyn(Poctavesfreq,     rShort("octaves"), rDefault(64),
             "Number of octaves for formant"),
-
+    rParamZyn(Phpf, rShort("hpl"), rDefault(0),
+            "Waveguide HighPass"),
+    rParamZyn(Plpf, rShort("lpf"), rDefault(127),
+            "Waveguide LowPass"),
     rParamI(Psequencesize,    rShort("seq.size"),
             rLinear(0, FF_MAX_SEQUENCE),
             rDefault(3), rDefaultDepends(loc),
@@ -456,6 +459,8 @@ void FilterParams::defaults()
     Pcenterfreq     = 64; //1 kHz
     Poctavesfreq    = 64;
     Pvowelclearness = 64;
+    Phpf    = 0;
+    Plpf    = 127;
 }
 
 void FilterParams::defaults(int n)

--- a/src/Params/FilterParams.cpp
+++ b/src/Params/FilterParams.cpp
@@ -141,7 +141,7 @@ const rtosc::Ports FilterParams::ports = {
             "Center Freq (formant)"),
     rParamZyn(Poctavesfreq,     rShort("octaves"), rDefault(64),
             "Number of octaves for formant"),
-    rParamZyn(Phpf, rShort("hpl"), rDefault(0),
+    rParamZyn(Phpf, rShort("hpf"), rDefault(0),
             "Waveguide HighPass"),
     rParamZyn(Plpf, rShort("lpf"), rDefault(127),
             "Waveguide LowPass"),

--- a/src/Params/FilterParams.h
+++ b/src/Params/FilterParams.h
@@ -70,6 +70,9 @@ class FilterParams:public PresetsArray
         unsigned char Pformantslowness; //how slow varies the formants
         unsigned char Pvowelclearness; //how vowels are kept clean (how much try to avoid "mixed" vowels)
         unsigned char Pcenterfreq, Poctavesfreq; //the center frequency of the res. func., and the number of octaves
+        
+        //Comb filter parameter
+        unsigned char Phpf, Plpf; //the center frequency of the res. func., and the number of octaves
 
         struct Pvowels_t {
             struct formants_t {

--- a/src/Params/FilterParams.h
+++ b/src/Params/FilterParams.h
@@ -70,7 +70,7 @@ class FilterParams:public PresetsArray
         unsigned char Pformantslowness; //how slow varies the formants
         unsigned char Pvowelclearness; //how vowels are kept clean (how much try to avoid "mixed" vowels)
         unsigned char Pcenterfreq, Poctavesfreq; //the center frequency of the res. func., and the number of octaves
-        
+
         //Comb filter parameter
         unsigned char Phpf, Plpf; //the center frequency of the res. func., and the number of octaves
 

--- a/src/Synth/ModFilter.cpp
+++ b/src/Synth/ModFilter.cpp
@@ -77,7 +77,7 @@ void ModFilter::update(float relfreq, float relq)
         baseFreq = pars.getfreq();
         baseQ    = pars.getq();
         tracking = pars.getfreqtracking(noteFreq);
-        
+
     }
 
     //Controller Free Center Frequency

--- a/src/Synth/ModFilter.cpp
+++ b/src/Synth/ModFilter.cpp
@@ -77,6 +77,7 @@ void ModFilter::update(float relfreq, float relq)
         baseFreq = pars.getfreq();
         baseQ    = pars.getq();
         tracking = pars.getfreqtracking(noteFreq);
+        
     }
 
     //Controller Free Center Frequency
@@ -181,5 +182,7 @@ void ModFilter::cbParamUpdate(CombFilter &cb)
 {
     cb.settype(pars.Ptype);
     cb.setgain(pars.getgain());
+    cb.sethpf(pars.Phpf);
+    cb.setlpf(pars.Plpf);
 }
 }


### PR DESCRIPTION
add HPF and LPF to the feedback path of the CombFilter
[comb.xiz.txt](https://github.com/user-attachments/files/19043083/comb.xiz.txt)

This makes it possible to create a full Karplus-Strong aka Digital Waveguide synthesis.

[https://en.wikipedia.org/wiki/Karplus%E2%80%93Strong_string_synthesis](https://en.wikipedia.org/wiki/Karplus%E2%80%93Strong_string_synthesis)

Use it like in this Videos:
https://youtu.be/2OnzblGvRDk

https://youtu.be/PU5awXvGM0Q

GUI PR: mruby-zest/mruby-zest-build#121
