### PR TITLE
Fix missing FL include

### DIFF
--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -98,6 +98,11 @@ decl {\#if !defined(PLUGINVERSION) && HAS_X11
 }
 
 decl {\#if !defined(PLUGINVERSION) && HAS_X11
+\#include <FL/platform.H>
+\#endif} {private local
+}
+
+decl {\#if !defined(PLUGINVERSION) && HAS_X11
 \#include <FL/Enumerations.H>
 \#endif} {private local
 }

--- a/src/UI/MicrotonalUI.fl
+++ b/src/UI/MicrotonalUI.fl
@@ -15,6 +15,9 @@ decl {\#include <stdio.h>} {public
 decl {\#include <string.h>} {public
 } 
 
+decl {\#include <FL/Enumerations.H>} {public
+} 
+
 decl {\#include <FL/Fl_File_Chooser.H>} {public
 } 
 
@@ -122,7 +125,11 @@ if (true) {
        updateTuningsInput();
        nameinput->update();
        commentinput->update();
+\#if FL_API_VERSION >= 10404
+       tuningsinput->insert_position(0);
+\#else
        tuningsinput->position(0);
+\#endif
        octavesizeoutput->update();
      }
      }
@@ -180,7 +187,11 @@ if (filename==NULL) return;
 osc->write("/load_kbm", "s", filename);
 if (true) {
        updateMappingInput();
+\#if FL_API_VERSION >= 10404
+       mappinginput->insert_position(0);
+\#else
        mappinginput->position(0);
+\#endif
        mapsizeoutput->update();
        firstnotecounter->update();
        lastnotecounter->update();


### PR DESCRIPTION
This fixes the following error which seems to be due to newer FL versions:

```
  src/UI/MasterUI.cxx:2381:3: error: 'fl_open_display' was not declared in this scope
```

This also fixes 2 deprecation warnings.