### PR TITLE
Fixup of "Fix missing FL include" for NTK

### DIFF
--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -97,7 +97,7 @@ decl {\#if !defined(PLUGINVERSION) && HAS_X11
 \#endif} {private local
 }
 
-decl {\#if !defined(PLUGINVERSION) && HAS_X11
+decl {\#if !defined(PLUGINVERSION) && HAS_X11 && !defined(NTK_GUI)
 \#include <FL/platform.H>
 \#endif} {private local
 }


### PR DESCRIPTION
Fixup of 3d73a99acfec68dfcca79d0295576dead8a40479:

The mentioned commit added a `FL/platform.H`, but this header is neither present, nor necessary for NTK.