### PR TITLE
Chorus: Ensemble: reduce triple mode amplitude on left channel 

### DIFF
--- a/src/Effects/Chorus.cpp
+++ b/src/Effects/Chorus.cpp
@@ -202,6 +202,8 @@ void Chorus::out(const Stereo<float *> &input)
             // same for third ensemble member
             dl = (dlHist3 * (buffersize - i) + dlNew3 * i) / buffersize_f;
             output += getSample(delaySample.l, dl, dlk);
+            // reduce amplitude to match single phase modes
+            output *= 0.85f;
                 break;
             default:
                 // nothing to do for standard chorus


### PR DESCRIPTION
In triple mode, the right channel has an amplitude reduction,
but the left has not.

Apply the same 0.85 multiplier to it.