### PR TITLE
MasterUI.fl: Fix `fl_open_display`/`HAS_X11`

### DIFF
--- a/src/UI/MasterUI.fl
+++ b/src/UI/MasterUI.fl
@@ -97,7 +97,7 @@ decl {\#if !defined(PLUGINVERSION) && HAS_X11
 \#endif} {private local
 }
 
-decl {\#if !defined(PLUGINVERSION) && HAS_X11 && !defined(NTK_GUI)
+decl {\#if !defined(PLUGINVERSION) && !defined(NTK_GUI)
 \#include <FL/platform.H>
 \#endif} {private local
 }
@@ -1615,14 +1615,22 @@ bankui=new BankUI(&npart, osc);
 configui=new ConfigUI(osc);
 
 make_window();
-fl_open_display();
 
-\#if !defined(PLUGINVERSION) && defined(FLTK_GUI)
+/*
+  Call fl_open_display. On Windows, it's not available before 1.4.
+  Note that the documentation says that this function is being called automatically,
+  and only required if the display is not open yet.
+*/
+\#if ! defined(WIN32) || (FL_MAJOR_VERSION == 1 && FL_MINOR_VERSION >= 4) || (FL_MAJOR_VERSION > 1)
+fl_open_display();
+\#endif
+
+\#if !defined(PLUGINVERSION) && defined(FLTK_GUI) && HAS_X11
 Fl_Pixmap *pixmap = new Fl_Pixmap(zynaddsubfx_xpm);
 Fl_RGB_Image *p = new Fl_RGB_Image(pixmap, FL_GRAY);
 masterwindow->icon(p);
 \#endif
-\#if !defined(PLUGINVERSION) && defined(NTK_GUI)
+\#if !defined(PLUGINVERSION) && defined(NTK_GUI) && HAS_X11
 Pixmap p, mask;
 XCreatePixmapFromData(fl_display, DefaultRootWindow(fl_display),
                       (char**)zynaddsubfx_xpm, &p, &mask, NULL);


### PR DESCRIPTION
This fixes multiple issues:

* fl_open_display on Windows is not available before FL 1.4.0 (this can be verified by looking at FLTK's sources: `src/Fl_win32.cxx`)
* Since `fl_open_display` is not called if `HAS_X11` is set, the `FL/platform.H` should not have the `HAS_X11` restriction either
* Since X11/xpm.h does require `HAS_X11`, do require it for the pixmap handling code, too

Fixup of
* e9a1b628b0fdcf2c1f2c88a8d3e9c964fb3bb607
* 3d73a99acfec68dfcca79d0295576dead8a40479