### PR TITLE
Rename variables hiding others

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1102,13 +1102,13 @@ void Master::vuUpdate(const float *outl, const float *outr)
         vuoutpeakpartl[npart] = 1.0e-12f;
         vuoutpeakpartr[npart] = 1.0e-12f;
         if(part[npart]->Penabled != 0) {
-            float *outl = part[npart]->partoutl,
-            *outr = part[npart]->partoutr;
+            float *outl2 = part[npart]->partoutl,
+                  *outr2 = part[npart]->partoutr;
             for(int i = 0; i < synth.buffersize; ++i) {
-                if (fabsf(outl[i]) > vuoutpeakpartl[npart])
-                    vuoutpeakpartl[npart] = fabsf(outl[i]);
-                if (fabsf(outr[i]) > vuoutpeakpartr[npart])
-                    vuoutpeakpartr[npart] = fabsf(outr[i]);
+                if (fabsf(outl2[i]) > vuoutpeakpartl[npart])
+                    vuoutpeakpartl[npart] = fabsf(outl2[i]);
+                if (fabsf(outr2[i]) > vuoutpeakpartr[npart])
+                    vuoutpeakpartr[npart] = fabsf(outr2[i]);
             }
         }
         else

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -781,10 +781,10 @@ public:
                         std::cerr << savefile << std::endl;
                         std::cerr << "first entry that could not be parsed:" << std::endl;
 
-                        for(int i = -res + 1; savefile[i]; ++i)
-                        if(savefile[i] == '\n')
+                        for(int j = -res + 1; savefile[j]; ++j)
+                        if(savefile[j] == '\n')
                         {
-                            savefile.resize(i);
+                            savefile.resize(j);
                             break;
                         }
                         std::cerr << (savefile.c_str() - res) << std::endl;
@@ -1216,15 +1216,15 @@ const rtosc::Ports bankPorts = {
             impl.loadbank(impl.banks[0].dir);
 
             //Reload bank slots
-            for(int i=0; i<BANK_SIZE; ++i) {
+            for(int j=0; j<BANK_SIZE; ++j) {
                 d.reply("/bankview", "iss",
-                    i, impl.ins[i].name.c_str(),
-                    impl.ins[i].filename.c_str());
+                    j, impl.ins[j].name.c_str(),
+                    impl.ins[j].filename.c_str());
             }
         } else {
             //Clear all bank slots
-            for(int i=0; i<BANK_SIZE; ++i) {
-                d.reply("/bankview", "iss", i, "", "");
+            for(int j=0; j<BANK_SIZE; ++j) {
+                d.reply("/bankview", "iss", j, "", "");
             }
         }
         d.broadcast("/damage", "s", "/bank/");


### PR DESCRIPTION
This helps with an MSVC warning and makes the code more clear.


Note: If this PR feels wrong, I can also disable the warning in MSVC, let me know what you prefer.

After this PR, all other PRs depend on the C++17 PR, which is next.