### PR TITLE
Elliminate VLAs for Windows

### DIFF
--- a/src/DSP/AnalogFilter.cpp
+++ b/src/DSP/AnalogFilter.cpp
@@ -424,7 +424,7 @@ void AnalogFilter::singlefilterout(float *smp, fstage &hist, float f, unsigned i
 
 void AnalogFilter::filterout(float *smp)
 {
-    float freqbuf[freqbufsize];
+    STACKALLOC(float, freqbuf, freqbufsize);
 
     if ( freq_smoothing.apply( freqbuf, freqbufsize, freq ) )
     {

--- a/src/DSP/FormantFilter.cpp
+++ b/src/DSP/FormantFilter.cpp
@@ -196,16 +196,16 @@ void FormantFilter::setfreq_and_q(float frequency, float q_)
 
 void FormantFilter::filterout(float *smp)
 {
-    float inbuffer[buffersize];
+    STACKALLOC(float, inbuffer, buffersize);
 
     memcpy(inbuffer, smp, bufferbytes);
     memset(smp, 0, bufferbytes);
 
-    float formantbuf[buffersize];
+    STACKALLOC(float, formantbuf, buffersize);
 
     for(int j = 0; j < numformants; ++j) {
 
-        float tmpbuf[buffersize];
+        STACKALLOC(float, tmpbuf, buffersize);
 
         for(int i = 0; i < buffersize; ++i)
             tmpbuf[i] = inbuffer[i] * outgain;

--- a/src/DSP/SVFilter.cpp
+++ b/src/DSP/SVFilter.cpp
@@ -209,7 +209,7 @@ void SVFilter::filterout(float *smp)
 {
     assert((buffersize % 8) == 0);
 
-    float freqbuf[buffersize];
+    STACKALLOC(float, freqbuf, buffersize);
 
     if ( freq_smoothing.apply( freqbuf, buffersize, freq ) )
     {

--- a/src/Effects/CombFilterBank.cpp
+++ b/src/Effects/CombFilterBank.cpp
@@ -96,7 +96,7 @@ namespace zyn {
         // this should prevent popping noise when controlled binary with 0 / 127
         // new control rate = samplerate / 16
         const unsigned int gainbufsize = buffersize / 16;
-        float gainbuf[gainbufsize]; // buffer for value smoothing filter
+        STACKALLOC(float, gainbuf, gainbufsize); // buffer for value smoothing filter
         if (!gain_smoothing.apply( gainbuf, gainbufsize, gainbwd ) ) // interpolate the gain value
             std::fill(gainbuf, gainbuf+gainbufsize, gainbwd); // if nothing to interpolate (constant value)
 

--- a/src/Effects/Reverb.cpp
+++ b/src/Effects/Reverb.cpp
@@ -200,7 +200,7 @@ void Reverb::out(const Stereo<float *> &smp)
     if(!Pvolume && insertion)
         return;
 
-    float inputbuf[buffersize];
+    STACKALLOC(float, inputbuf, buffersize);
     for(int i = 0; i < buffersize; ++i)
         inputbuf[i] = (smp.l[i] + smp.r[i]) / 2.0f;
 

--- a/src/Misc/Allocator.cpp
+++ b/src/Misc/Allocator.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include "../../tlsf/tlsf.h"
 #include "Allocator.h"
+#include "Util.h"
 
 namespace zyn {
 
@@ -89,7 +90,7 @@ void AllocatorClass::dealloc_mem(void *memory)
 bool AllocatorClass::lowMemory(unsigned n, size_t chunk_size) const
 {
     //This should stay on the stack
-    void *buf[n];
+    STACKALLOC(void*, buf, n);
     for(unsigned i=0; i<n; ++i)
         buf[i] = tlsf_malloc(impl->tlsf, chunk_size);
     bool outOfMem = false;

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1312,7 +1312,7 @@ bool Master::AudioOut(float *outl, float *outr)
                                   part[efxpart]->partoutr);
         }
 
-    float gainbuf[synth.buffersize];
+    STACKALLOC(float, gainbuf, synth.buffersize);
 
     //Apply the part volumes and pannings (after insertion effects)
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
@@ -1363,8 +1363,8 @@ bool Master::AudioOut(float *outl, float *outr)
         if(sysefx[nefx]->geteffect() == 0)
             continue;  //the effect is disabled
 
-        float tmpmixl[synth.buffersize];
-        float tmpmixr[synth.buffersize];
+        STACKALLOC(float, tmpmixl, synth.buffersize);
+        STACKALLOC(float, tmpmixr, synth.buffersize);
         //Clean up the samples used by the system effects
         memset(tmpmixl, 0, synth.bufferbytes);
         memset(tmpmixr, 0, synth.bufferbytes);

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1061,8 +1061,8 @@ void Part::ComputePartSmps()
     for(auto &d:notePool.activeDesc()) {
         d.age++;
         for(auto &s:notePool.activeNotes(d)) {
-            float tmpoutr[synth.buffersize];
-            float tmpoutl[synth.buffersize];
+            STACKALLOC(float, tmpoutr, synth.buffersize);
+            STACKALLOC(float, tmpoutl, synth.buffersize);
             auto &note = *s.note;
             note.noteout(&tmpoutl[0], &tmpoutr[0]);
 

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -243,8 +243,8 @@ float cinterpolate(const float *data, size_t len, float pos)
 
 char *rtosc_splat(const char *path, std::set<std::string> v)
 {
-    char argT[v.size()+1];
-    rtosc_arg_t arg[v.size()];
+    STACKALLOC(char, argT, v.size()+1);
+    STACKALLOC(rtosc_arg_t, arg, v.size());
     unsigned i=0;
     for(auto &vv : v) {
         argT[i]  = 's';

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -25,6 +25,12 @@
 
 namespace zyn {
 
+#ifdef _MSC_VER
+#define STACKALLOC(type, name, size) type *name = (type*)(_alloca((size)*sizeof(type)))
+#else
+#define STACKALLOC(type, name, size) type name[size]
+#endif
+
 extern bool isPlugin;
 bool fileexists(const char *filename);
 

--- a/src/Params/PADnoteParameters.cpp
+++ b/src/Params/PADnoteParameters.cpp
@@ -728,7 +728,7 @@ void PADnoteParameters::generatespectrum_bandwidthMode(float *spectrum,
                                                        int profilesize,
                                                        float bwadjust) const
 {
-    float harmonics[synth.oscilsize];
+    STACKALLOC(float, harmonics, synth.oscilsize);
     memset(spectrum, 0, sizeof(float) * size);
     memset(harmonics, 0, sizeof(float) * synth.oscilsize);
 
@@ -803,7 +803,7 @@ void PADnoteParameters::generatespectrum_otherModes(float *spectrum,
                                                     int size,
                                                     float basefreq) const
 {
-    float harmonics[synth.oscilsize];
+    STACKALLOC(float, harmonics, synth.oscilsize);
     memset(spectrum,  0, sizeof(float) * size);
     memset(harmonics, 0, sizeof(float) * synth.oscilsize);
 
@@ -917,7 +917,7 @@ int PADnoteParameters::sampleGenerator(PADnoteParameters::callback cb,
         samplemax = PAD_MAX_SAMPLES;
 
     //this is used to compute frequency relation to the base frequency
-    float adj[samplemax];
+    STACKALLOC(float, adj, samplemax);
     for(int nsample = 0; nsample < samplemax; ++nsample)
         adj[nsample] = (Pquality.oct + 1.0f) * (float)nsample / samplemax;
     // QtCreator can't capture VLAs (QTCREATORBUG-23722), so this is

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -285,7 +285,7 @@ int ADnote::setupVoiceUnison(int nvoice)
             break;
         default: //unison for more than 2 subvoices
         {
-            float unison_values[true_unison];
+            STACKALLOC(float, unison_values, true_unison);
             float min = -1e-6f, max = 1e-6f;
             for(int k = 0; k < true_unison; ++k) {
                 const float step = (k / (float) (true_unison - 1)) * 2.0f - 1.0f; //this makes the unison spread more uniform

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -519,8 +519,8 @@ void SUBnote::computeallfiltercoefs(bpfilter *filters, float envfreq,
 
 void SUBnote::chanOutput(float *out, bpfilter *bp, int buffer_size)
 {
-    float tmprnd[buffer_size];
-    float tmpsmp[buffer_size];
+    STACKALLOC(float, tmprnd, buffer_size);
+    STACKALLOC(float, tmpsmp, buffer_size);
 
     //Initialize Random Input
     for(int i = 0; i < buffer_size; ++i)

--- a/src/Tests/PadNoteTest.cpp
+++ b/src/Tests/PadNoteTest.cpp
@@ -239,7 +239,7 @@ class PadNoteTest
 
 
             //Verify Harmonic Input
-            float harmonics[synth->oscilsize];
+            STACKALLOC(float, harmonics, synth->oscilsize);
             memset(harmonics, 0, sizeof(float) * synth->oscilsize);
 
             pars->oscilgen->get(harmonics, 440.0f, false);

--- a/src/Tests/common.h
+++ b/src/Tests/common.h
@@ -214,7 +214,12 @@ int assert_hex_eq(const char *a, const char *b, size_t size_a, size_t size_b,
         //create difference mask
         const int longer  = size_a > size_b ? size_a : size_b;
         const int shorter = size_a < size_b ? size_a : size_b;
+
+#ifdef _MSC_VER
+        char* mask = (char*)(_alloca(longer*sizeof(char)));
+#else
         char mask[longer];
+#endif
         memset(mask, 0, longer);
         for(int i=0; i<shorter; ++i)
             if(a[i] != b[i])

--- a/src/UI/Osc_SimpleListModel.h
+++ b/src/UI/Osc_SimpleListModel.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <vector>
 #include <rtosc/rtosc.h>
+#include "../Misc/Util.h"
 
 class Osc_SimpleListModel:public Fl_Osc_Widget
 {
@@ -43,12 +44,12 @@ class Osc_SimpleListModel:public Fl_Osc_Widget
             if(list.size() == 0) {
                 oscWrite("", "I");
             }
-            char         types[list.size()+1];
-            rtosc_arg_t  args[list.size()];
+            STACKALLOC(char,        types, list.size()+1);
+            STACKALLOC(rtosc_arg_t, args,  list.size());
 
             //zero out data
-            memset(types, 0, sizeof(types));
-            memset(args,  0, sizeof(args));
+            memset(types, 0, (list.size()+1) * sizeof(*types));
+            memset(args,  0, (list.size())   * sizeof(*args));
 
             for(int i=0; i<(int)list.size(); ++i) {
                 types[i]  = 's';


### PR DESCRIPTION
This replaces VLAs by workarounds.

This fixes a possible bug in `Osc_SimpleListModel`, where the OSC buffers were not properly zero initialized. This *might* fix a known bug.

Testing info: I did a quick test on all changed Filters and Reverb, no issues.