### PR TITLE
Replace POSIX API use by STL use

### DIFF
--- a/src/Effects/EffectMgr.h
+++ b/src/Effects/EffectMgr.h
@@ -14,8 +14,6 @@
 #ifndef EFFECTMGR_H
 #define EFFECTMGR_H
 
-#include <pthread.h>
-
 #include "../Params/FilterParams.h"
 #include "../Params/Presets.h"
 #include "../globals.h"

--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -248,7 +248,7 @@ int Bank::loadbank(string bankdirname)
         const std::string filename{fn.path().filename().string()};
 
         //check for extension
-        if(filename.find("INSTRUMENT_EXTENSION") == std::string::npos)
+        if(filename.find(INSTRUMENT_EXTENSION) == std::string::npos)
             continue;
 
         //verify if the name is like this NNNN-name (where N is a digit)
@@ -463,7 +463,7 @@ void Bank::scanrootdir(string rootdir)
         bool isbank = false;
         if(!fs::is_directory(bank.dir))
             continue;
-        for(const auto& subentry : fs::directory_iterator{rootdirpath})
+        for(const auto& subentry : fs::directory_iterator{bank.dir})
         {
             if(subentry.is_directory())
                 continue;

--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -296,16 +296,20 @@ int Bank::newbank(string newbankdirname)
 
     namespace fs = std::filesystem;
     try {
-        if (!fs::exists(bankdir))
+        if (fs::exists(bankdir))
+        {
+            if (!fs::is_directory(bankdir))
+                return -1;
+        }
+        else
             fs::create_directory(bankdir);
     } catch (...) {
         return -1;
     }
 
     const string tmpfilename = bankdir + '/' + FORCE_BANK_DIR_FILE;
-
-    FILE *tmpfile = fopen(tmpfilename.c_str(), "w+");
-    fclose(tmpfile);
+    if(FILE *tmpfile = fopen(tmpfilename.c_str(), "w+"))
+        fclose(tmpfile);
 
     return loadbank(bankdir);
 }

--- a/src/Misc/Bank.cpp
+++ b/src/Misc/Bank.cpp
@@ -256,9 +256,6 @@ int Bank::loadbank(string bankdirname)
         unsigned int startname = 0;
 
         for(unsigned int i = 0; i < 4 && i < filename.size(); ++i) {
-            if(filename.length() <= i)
-                break;
-
             if((filename[i] >= '0') && (filename[i] <= '9')) {
                 no = no * 10 + (filename[i] - '0');
                 startname++;

--- a/src/Misc/LASHClient.h
+++ b/src/Misc/LASHClient.h
@@ -14,7 +14,6 @@
 #define LASHClient_h
 
 #include <string>
-#include <pthread.h>
 #include <lash/lash.h>
 
 namespace zyn {

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -39,7 +39,6 @@
 #include <algorithm>
 #include <cmath>
 #include <atomic>
-#include <unistd.h>
 
 using namespace std;
 using namespace rtosc;

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -2450,7 +2450,7 @@ int MiddleWare::checkAutoSave(void) const
         const char *prefix = "zynaddsubfx-";
 
         //check for mandatory prefix
-        if(filename.rfind(prefix, 0) == 0)
+        if(entry.is_directory() || filename.rfind(prefix, 0) != 0)
             continue;
 
         int id = atoi(filename.c_str()+strlen(prefix));

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -16,9 +16,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <dirent.h>
 #include <sys/stat.h>
 #include <mutex>
+#include <thread>
 
 #include <rtosc/undo-history.h>
 #include <rtosc/thread-link.h>
@@ -30,9 +30,6 @@
 
 #include "../UI/Connection.h"
 #include "../UI/Fl_Osc_Interface.h"
-
-#include <map>
-#include <queue>
 
 #include "Util.h"
 #include "CallbackRepeater.h"
@@ -54,10 +51,13 @@
 #include "../Synth/OscilGen.h"
 #include "../Nio/Nio.h"
 
-#include <string>
-#include <future>
 #include <atomic>
+#include <filesystem>
+#include <future>
 #include <list>
+#include <map>
+#include <queue>
+#include <chrono>
 
 #define errx(...) {}
 #define warnx(...) {}
@@ -70,25 +70,7 @@ namespace zyn {
 using std::string;
 int Pexitprogram = 0;
 
-#ifdef __APPLE__
-#include <mach/clock.h>
-#include <mach/mach.h>
-#endif
 
-/* work around missing clock_gettime on OSX */
-static void monotonic_clock_gettime(struct timespec *ts) {
-#ifdef __APPLE__
-    clock_serv_t cclock;
-    mach_timespec_t mts;
-    host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-    clock_get_time(cclock, &mts);
-    mach_port_deallocate(mach_task_self(), cclock);
-    ts->tv_sec = mts.tv_sec;
-    ts->tv_nsec = mts.tv_nsec;
-#else
-    clock_gettime(CLOCK_MONOTONIC, ts);
-#endif
-}
 
 /******************************************************************************
  *                        LIBLO And Reflection Code                           *
@@ -547,8 +529,7 @@ public:
 
     //Check offline vs online mode in plugins
     void heartBeat(Master *m);
-    int64_t start_time_sec;
-    int64_t start_time_nsec;
+    std::chrono::steady_clock::time_point start_time;
     bool offline;
 
     //Apply function while parameters are write locked
@@ -746,6 +727,7 @@ public:
 
                 doReadOnlyOp([this,filename,&dispatcher,&master2,&savefile,&res,&alreadyWritten]()
                 {
+                    using namespace std::literals::chrono_literals;
                     savefile = master->saveOSC(savefile, alreadyWritten);
 #if 1
                     // load the savefile string into another master to compare the results
@@ -753,7 +735,7 @@ public:
                     // this requires a temporary master switch
                     Master* old_master = master;
                     dispatcher.updateMaster(&master2);
-                    while(old_master->isMasterSwitchUpcoming()) { os_usleep(50000); }
+                    while(old_master->isMasterSwitchUpcoming()) { std::this_thread::sleep_for(50ms); }
 
                     res = master2.loadOSCFromStr(savefile.c_str(), &dispatcher);
                     // TODO: compare MiddleWare, too?
@@ -763,7 +745,7 @@ public:
                     // We need to wait until savefile has been loaded into master2
                     int i;
                     for(i = 0; i < 20 && master2.uToB->hasNext(); ++i)
-                        os_usleep(50000);
+                        std::this_thread::sleep_for(50ms);
                     if(i >= 20) // >= 1 second?
                     {
                         // Master failed to fetch its messages
@@ -772,7 +754,7 @@ public:
                     printf("Saved in less than %d ms.\n", 50*i);
 
                     dispatcher.updateMaster(old_master);
-                    while(master2.isMasterSwitchUpcoming()) { os_usleep(50000); }
+                    while(master2.isMasterSwitchUpcoming()) { std::this_thread::sleep_for(50ms); }
 #endif
                     if(res < 0)
                     {
@@ -1121,49 +1103,23 @@ class MwDataObj:public rtosc::RtData
 
 static std::vector<std::string> getFiles(const char *folder, bool finddir)
 {
-    DIR *dir = opendir(folder);
+    namespace fs = std::filesystem;
 
-    if(dir == NULL) {
-        return {};
-    }
-
-    struct dirent *fn;
     std::vector<string> files;
-    bool has_updir = false;
+    std::error_code ec;
 
-    while((fn = readdir(dir))) {
-#ifndef WIN32
-        bool is_dir = fn->d_type == DT_DIR;
-        //it could still be a symbolic link
-        if(!is_dir) {
-            string path = string(folder) + "/" + fn->d_name;
-            struct stat buf;
-            memset((void*)&buf, 0, sizeof(buf));
-            int err = stat(path.c_str(), &buf);
-            if(err)
-                printf("[Zyn:Error] stat cannot handle <%s>:%d\n", path.c_str(), err);
-            if(S_ISDIR(buf.st_mode)) {
-                is_dir = true;
-            }
-        }
-#else
-        std::string darn_windows = folder + std::string("/") + std::string(fn->d_name);
-        //printf("attr on <%s> => %x\n", darn_windows.c_str(), GetFileAttributes(darn_windows.c_str()));
-        //printf("desired mask =  %x\n", mask);
-        //printf("error = %x\n", INVALID_FILE_ATTRIBUTES);
-        bool is_dir = GetFileAttributes(darn_windows.c_str()) & FILE_ATTRIBUTE_DIRECTORY;
-#endif
-        if(finddir == is_dir && strcmp(".", fn->d_name))
-            files.push_back(fn->d_name);
+    for(const auto& entry : fs::directory_iterator(folder, ec))
+    {
+        if(ec) { return{}; }
 
-        if(!strcmp("..", fn->d_name))
-            has_updir = true;
+        // note: is_directory is also true for symlinks to dirs
+        if(finddir == entry.is_directory())
+            files.push_back(entry.path().filename().string());
     }
 
-    if(finddir == true && has_updir == false)
+    if(finddir == true) // std::directory_iterator does not return ".."
         files.push_back("..");
 
-    closedir(dir);
     std::sort(begin(files), end(files));
     return files;
 }
@@ -1995,11 +1951,7 @@ MiddleWareImpl::MiddleWareImpl(MiddleWare *mw, SYNTH_T synth_,
             handleMsg(buf);
             });
 
-    //Setup starting time
-    struct timespec time;
-    monotonic_clock_gettime(&time);
-    start_time_sec  = time.tv_sec;
-    start_time_nsec = time.tv_nsec;
+    start_time = std::chrono::steady_clock::now();
 
     offline = false;
 }
@@ -2065,7 +2017,8 @@ void MiddleWareImpl::doReadOnlyOp(std::function<void()> read_only_fn)
     int tries = 0;
     while(tries++ < 10000) {
         if(!bToU->hasNextLookahead()) {
-            os_usleep(500);
+            using namespace std::literals::chrono_literals;
+            std::this_thread::sleep_for(500us);
             continue;
         }
         const char *msg = bToU->read_lookahead();
@@ -2099,10 +2052,9 @@ void MiddleWareImpl::heartBeat(Master *master)
     //Last acknowledged beat
     //Current offline status
 
-    struct timespec time;
-    monotonic_clock_gettime(&time);
-    uint32_t now = (time.tv_sec-start_time_sec)*100 +
-                   (time.tv_nsec-start_time_nsec)*1e-9*100;
+    auto duration = start_time - std::chrono::steady_clock::now();
+    using tick_t = std::chrono::duration<uint32_t, std::ratio<1, 100>>;  // 10 ms
+    uint32_t now = std::chrono::duration_cast<tick_t>(duration).count();
     int32_t last_ack   = master->last_ack;
     int32_t last_beat  = master->last_beat;
 
@@ -2169,7 +2121,8 @@ bool MiddleWareImpl::doReadOnlyOpNormal(std::function<void()> read_only_fn, bool
     int tries = 0;
     while(tries++ < 2000) {
         if(!bToU->hasNextLookahead()) {
-            os_usleep(500);
+            using namespace std::literals::chrono_literals;
+            std::this_thread::sleep_for(500us);
             continue;
         }
         const char *msg = bToU->read_lookahead();
@@ -2479,27 +2432,28 @@ void MiddleWare::enableAutoSave(int interval_sec)
 
 int MiddleWare::checkAutoSave(void) const
 {
+    namespace fs = std::filesystem;
+
     //save spec zynaddsubfx-PID-autosave.xmz
     const std::string home     = getenv("HOME");
     const std::string save_dir = home+"/.local/";
 
-    DIR *dir = opendir(save_dir.c_str());
-
-    if(dir == NULL)
-        return -1;
-
-    struct dirent *fn;
     int    reload_save = -1;
 
-    while((fn = readdir(dir))) {
-        const char *filename = fn->d_name;
+    std::error_code ec;
+
+    for(const auto& entry : fs::directory_iterator(save_dir, ec))
+    {
+        if(ec) { return{}; }
+
+        const std::string filename = entry.path().filename().string();
         const char *prefix = "zynaddsubfx-";
 
-        //check for manditory prefix
-        if(strstr(filename, prefix) != filename)
+        //check for mandatory prefix
+        if(filename.rfind(prefix, 0) == 0)
             continue;
 
-        int id = atoi(filename+strlen(prefix));
+        int id = atoi(filename.c_str()+strlen(prefix));
 
         bool in_use = false;
 
@@ -2516,8 +2470,6 @@ int MiddleWare::checkAutoSave(void) const
             break;
         }
     }
-
-    closedir(dir);
 
     return reload_save;
 }

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -1115,8 +1115,8 @@ static std::vector<std::string> getFiles(const char *folder, bool finddir)
             if(finddir == entry.is_directory())
                 files.push_back(entry.path().filename().string());
         }
-    } catch {
-        return {}
+    } catch(...) {
+        return {};
     }
 
     if(finddir) // std::directory_iterator does not return ".."

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -1106,18 +1106,20 @@ static std::vector<std::string> getFiles(const char *folder, bool finddir)
     namespace fs = std::filesystem;
 
     std::vector<string> files;
-    std::error_code ec;
 
-    for(const auto& entry : fs::directory_iterator(folder, ec))
+    try
     {
-        if(ec) { return{}; }
-
-        // note: is_directory is also true for symlinks to dirs
-        if(finddir == entry.is_directory())
-            files.push_back(entry.path().filename().string());
+        for(const auto& entry : fs::directory_iterator(folder))
+        {
+            // note: is_directory is also true for symlinks to dirs
+            if(finddir == entry.is_directory())
+                files.push_back(entry.path().filename().string());
+        }
+    } catch {
+        return {}
     }
 
-    if(finddir == true) // std::directory_iterator does not return ".."
+    if(finddir) // std::directory_iterator does not return ".."
         files.push_back("..");
 
     std::sort(begin(files), end(files));
@@ -2052,7 +2054,7 @@ void MiddleWareImpl::heartBeat(Master *master)
     //Last acknowledged beat
     //Current offline status
 
-    auto duration = start_time - std::chrono::steady_clock::now();
+    auto duration = std::chrono::steady_clock::now() - start_time;
     using tick_t = std::chrono::duration<uint32_t, std::ratio<1, 100>>;  // 10 ms
     uint32_t now = std::chrono::duration_cast<tick_t>(duration).count();
     int32_t last_ack   = master->last_ack;
@@ -2450,7 +2452,7 @@ int MiddleWare::checkAutoSave(void) const
         const char *prefix = "zynaddsubfx-";
 
         //check for mandatory prefix
-        if(entry.is_directory() || filename.rfind(prefix, 0) != 0)
+        if(entry.is_directory(ec) || filename.rfind(prefix, 0) != 0)
             continue;
 
         int id = atoi(filename.c_str()+strlen(prefix));

--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -2446,7 +2446,7 @@ int MiddleWare::checkAutoSave(void) const
 
     for(const auto& entry : fs::directory_iterator(save_dir, ec))
     {
-        if(ec) { return{}; }
+        if(ec) continue;
 
         const std::string filename = entry.path().filename().string();
         const char *prefix = "zynaddsubfx-";

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -22,11 +22,13 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
 #include <string.h>
 #ifdef HAVE_SCHEDULER
 #include <sched.h>
+#endif
+#ifndef _MSC_VER
+#include <unistd.h>
 #endif
 
 #define errx(...) {}

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -50,7 +50,7 @@ AlsaEngine::~AlsaEngine()
 void AlsaEngine::AudioThread()
 {
     set_realtime();
-    return processAudio();
+    processAudio();
 }
 
 bool AlsaEngine::Start()
@@ -225,7 +225,6 @@ void AlsaEngine::MidiThread(void)
         }
         snd_seq_free_event(event);
     }
-    return NULL;
 }
 
 bool AlsaEngine::openMidi()
@@ -401,7 +400,7 @@ void AlsaEngine::stopAudio()
              << endl;
 }
 
-void *AlsaEngine::processAudio()
+void AlsaEngine::processAudio()
 {
     while(audio.handle) {
         audio.buffer = interleave(getNext());
@@ -420,7 +419,6 @@ void *AlsaEngine::processAudio()
              throw "Could not recover ALSA connection";
         }
     }
-    return NULL;
 }
 
 }

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -382,9 +382,9 @@ void AlsaEngine::stopAudio()
 {
     if(!getAudioEn())
         return;
-    audio.running.clear();
 
     snd_pcm_t *handle = audio.handle;
+    audio.running.clear();
     audio.thread.join();
     snd_pcm_drain(handle);
     if(snd_pcm_close(handle))

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -34,10 +34,8 @@ AlsaEngine::AlsaEngine(const SYNTH_T &synth)
 {
     audio.buffer = new short[synth.buffersize * 2];
     name = "ALSA";
-    audio.handle = NULL;
     audio.peaks[0] = 0;
 
-    midi.handle  = NULL;
     midi.alsaId  = -1;
 }
 
@@ -269,14 +267,12 @@ void AlsaEngine::stopMidi()
         return;
 
     snd_seq_t *handle = midi.handle;
-    if(midi.handle && midi.running.test()) {
+    if(midi.running.test()) {
         midi.running.clear();
         if(midi.thread.joinable())
             midi.thread.join();
     }
-    midi.handle = NULL;
-    if(handle)
-        snd_seq_close(handle);
+    snd_seq_close(handle);
 }
 
 short *AlsaEngine::interleave(const Stereo<float *> &smps)
@@ -392,7 +388,6 @@ void AlsaEngine::stopAudio()
     audio.running.clear();
 
     snd_pcm_t *handle = audio.handle;
-    audio.handle = NULL;
     if(audio.thread.joinable())
         audio.thread.join();
     snd_pcm_drain(handle);

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -77,7 +77,7 @@ void AlsaEngine::setMidiEn(bool nval)
 
 bool AlsaEngine::getMidiEn() const
 {
-    return midi.handle;
+    return midi.running.test();
 }
 
 void AlsaEngine::setAudioEn(bool nval)
@@ -229,7 +229,7 @@ void AlsaEngine::MidiThread(void)
 
 bool AlsaEngine::openMidi()
 {
-    if(getMidiEn())
+    if(midi.running.test_and_set())
         return true;
 
     int alsaport;

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -47,7 +47,7 @@ AlsaEngine::~AlsaEngine()
     delete[] audio.buffer;
 }
 
-void *AlsaEngine::AudioThread()
+void AlsaEngine::AudioThread()
 {
     set_realtime();
     return processAudio();
@@ -94,7 +94,7 @@ bool AlsaEngine::getAudioEn() const
 }
 
 
-void *AlsaEngine::MidiThread(void)
+void AlsaEngine::MidiThread(void)
 {
     snd_seq_event_t *event;
     MidiEvent ev = {};

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -90,7 +90,7 @@ void AlsaEngine::setAudioEn(bool nval)
 
 bool AlsaEngine::getAudioEn() const
 {
-    return audio.handle;
+    return audio.running.test();
 }
 
 
@@ -258,8 +258,6 @@ bool AlsaEngine::openMidi()
     if(alsaport < 0)
         return false;
 
-    midi.running.test_and_set();
-
     midi.thread = std::thread(&AlsaEngine::MidiThread, this);
 
     return true;
@@ -304,7 +302,7 @@ short *AlsaEngine::interleave(const Stereo<float *> &smps)
 
 bool AlsaEngine::openAudio()
 {
-    if(getAudioEn())
+    if(audio.running.test_and_set())
         return true;
 
     int rc = 0;
@@ -391,10 +389,12 @@ void AlsaEngine::stopAudio()
 {
     if(!getAudioEn())
         return;
+    audio.running.clear();
 
     snd_pcm_t *handle = audio.handle;
     audio.handle = NULL;
-    audio.thread.join();
+    if(audio.thread.joinable())
+        audio.thread.join();
     snd_pcm_drain(handle);
     if(snd_pcm_close(handle))
         cout << "Error: in snd_pcm_close " << __LINE__ << ' ' << __FILE__
@@ -403,7 +403,7 @@ void AlsaEngine::stopAudio()
 
 void AlsaEngine::processAudio()
 {
-    while(audio.handle) {
+    while(audio.running.test()) {
         audio.buffer = interleave(getNext());
         snd_pcm_t *handle = audio.handle;
         int rc = snd_pcm_writei(handle, audio.buffer, synth.buffersize);

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -267,10 +267,8 @@ void AlsaEngine::stopMidi()
         return;
 
     snd_seq_t *handle = midi.handle;
-    if(midi.running.test()) {
-        midi.running.clear();
-        midi.thread.join();
-    }
+    midi.running.clear();
+    midi.thread.join();
     snd_seq_close(handle);
 }
 

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -102,8 +102,8 @@ void AlsaEngine::MidiThread(void)
     int error;
 
     set_realtime();
-    while(1) {
-        if(midi.exiting)
+    while(true) {
+        if(!midi.running.test())
             break;
         error = snd_seq_event_input(midi.handle, &event);
         if (error < 0) {
@@ -258,7 +258,7 @@ bool AlsaEngine::openMidi()
     if(alsaport < 0)
         return false;
 
-    midi.exiting = false;
+    midi.running.test_and_set();
 
     midi.thread = std::thread(&AlsaEngine::MidiThread, this);
 
@@ -271,9 +271,10 @@ void AlsaEngine::stopMidi()
         return;
 
     snd_seq_t *handle = midi.handle;
-    if(midi.handle && midi.thread.joinable()) {
-        midi.exiting = true;
-        midi.thread.join();
+    if(midi.handle && midi.running.test()) {
+        midi.running.clear();
+        if(midi.thread.joinable())
+            midi.thread.join();
     }
     midi.handle = NULL;
     if(handle)

--- a/src/Nio/AlsaEngine.cpp
+++ b/src/Nio/AlsaEngine.cpp
@@ -269,8 +269,7 @@ void AlsaEngine::stopMidi()
     snd_seq_t *handle = midi.handle;
     if(midi.running.test()) {
         midi.running.clear();
-        if(midi.thread.joinable())
-            midi.thread.join();
+        midi.thread.join();
     }
     snd_seq_close(handle);
 }
@@ -388,8 +387,7 @@ void AlsaEngine::stopAudio()
     audio.running.clear();
 
     snd_pcm_t *handle = audio.handle;
-    if(audio.thread.joinable())
-        audio.thread.join();
+    audio.thread.join();
     snd_pcm_drain(handle);
     if(snd_pcm_close(handle))
         cout << "Error: in snd_pcm_close " << __LINE__ << ' ' << __FILE__

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -14,7 +14,7 @@
 #ifndef ALSA_ENGINE_H
 #define ALSA_ENGINE_H
 
-#include <pthread.h>
+#include <thread>
 #include <string>
 #include <alsa/asoundlib.h>
 #include <queue>
@@ -42,9 +42,7 @@ class AlsaEngine:public AudioOut, MidiIn
 
     protected:
         void *AudioThread();
-        static void *_AudioThread(void *arg);
         void *MidiThread();
-        static void *_MidiThread(void *arg);
 
     private:
         bool openMidi();
@@ -59,7 +57,7 @@ class AlsaEngine:public AudioOut, MidiIn
             snd_seq_t  *handle;
             int alsaId;
             bool exiting;
-            pthread_t pThread;
+            std::thread thread;
         } midi;
 
         struct {
@@ -69,7 +67,7 @@ class AlsaEngine:public AudioOut, MidiIn
             snd_pcm_uframes_t frames;
             unsigned int      periods;
             short    *buffer;
-            pthread_t pThread;
+            std::thread thread;
             float peaks[1];
         } audio;
 

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -14,6 +14,7 @@
 #ifndef ALSA_ENGINE_H
 #define ALSA_ENGINE_H
 
+#include <atomic>
 #include <thread>
 #include <string>
 #include <alsa/asoundlib.h>
@@ -56,7 +57,7 @@ class AlsaEngine:public AudioOut, MidiIn
             std::string device;
             snd_seq_t  *handle;
             int alsaId;
-            bool exiting;
+            std::atomic_flag running = false;
             std::thread thread;
         } midi;
 

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -41,8 +41,8 @@ class AlsaEngine:public AudioOut, MidiIn
         bool getMidiEn() const;
 
     protected:
-        void *AudioThread();
-        void *MidiThread();
+        void AudioThread();
+        void MidiThread();
 
     private:
         bool openMidi();

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -57,7 +57,7 @@ class AlsaEngine:public AudioOut, MidiIn
             std::string device;
             snd_seq_t  *handle;
             int alsaId;
-            std::atomic_flag running = false;
+            std::atomic_flag running{false};
             std::thread thread;
         } midi;
 
@@ -69,6 +69,7 @@ class AlsaEngine:public AudioOut, MidiIn
             unsigned int      periods;
             short    *buffer;
             std::thread thread;
+            std::atomic_flag running{false};
             float peaks[1];
         } audio;
 

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -57,7 +57,7 @@ class AlsaEngine:public AudioOut, MidiIn
             std::string device;
             snd_seq_t  *handle;
             int alsaId;
-            std::atomic_flag running{false};
+            std::atomic_flag running;
             std::thread thread;
         } midi;
 
@@ -69,7 +69,7 @@ class AlsaEngine:public AudioOut, MidiIn
             unsigned int      periods;
             short    *buffer;
             std::thread thread;
-            std::atomic_flag running{false};
+            std::atomic_flag running;
             float peaks[1];
         } audio;
 

--- a/src/Nio/AlsaEngine.h
+++ b/src/Nio/AlsaEngine.h
@@ -71,7 +71,7 @@ class AlsaEngine:public AudioOut, MidiIn
             float peaks[1];
         } audio;
 
-        void *processAudio();
+        void processAudio();
 };
 
 }

--- a/src/Nio/JackEngine.cpp
+++ b/src/Nio/JackEngine.cpp
@@ -22,7 +22,6 @@
 #include <sys/stat.h>
 #include <cassert>
 #include <cstring>
-#include <unistd.h> // access()
 #include <fstream> // std::istream
 
 #include "Nio.h"

--- a/src/Nio/JackEngine.h
+++ b/src/Nio/JackEngine.h
@@ -15,10 +15,7 @@
 #define JACK_ENGINE_H
 
 #include <string>
-#include <pthread.h>
-#include <semaphore.h>
 #include <jack/jack.h>
-#include <pthread.h>
 
 #include "MidiIn.h"
 #include "AudioOut.h"

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -42,7 +42,7 @@ void NulEngine::AudioThread()
         else {
             using namespace std::chrono_literals;
             duration remaining = std::chrono::duration_cast<duration>(playing_until - now);
-            if(remaining > 10ms) //Don't x() less than 10ms.
+            if(remaining > 10ms) //Don't sleep_for() less than 10ms.
                 //This will add latency...
                 this_thread::sleep_for(remaining  - 10ms);
             else if(remaining < 0us) {

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -15,53 +15,43 @@
 #include "../globals.h"
 #include "../Misc/Util.h"
 
+#include <chrono>
 #include <iostream>
 using namespace std;
 
 namespace zyn {
 
 NulEngine::NulEngine(const SYNTH_T &synth_)
-    :AudioOut(synth_), pThread(NULL)
+    :AudioOut(synth_)
 {
     name = "NULL";
-    playing_until.tv_sec  = 0;
-    playing_until.tv_usec = 0;
 }
 
-void *NulEngine::_AudioThread(void *arg)
+void NulEngine::AudioThread()
 {
-    return (static_cast<NulEngine *>(arg))->AudioThread();
-}
+    using duration = chrono::microseconds;
+    const duration increase(synth.buffersize * 1'000'000 / synth.samplerate);
 
-void *NulEngine::AudioThread()
-{
-    while(pThread) {
+    while(thread.joinable()) {
         getNext();
 
-        struct timeval now;
-        int remaining = 0;
-        gettimeofday(&now, NULL);
-        if((playing_until.tv_usec == 0) && (playing_until.tv_sec == 0)) {
-            playing_until.tv_usec = now.tv_usec;
-            playing_until.tv_sec  = now.tv_sec;
+        time_point now = chrono::steady_clock::now();
+        if(playing_until == time_point()) {
+            playing_until = now;
         }
         else {
-            remaining = (playing_until.tv_usec - now.tv_usec)
-                        + (playing_until.tv_sec - now.tv_sec) * 1000000;
-            if(remaining > 10000) //Don't sleep() less than 10ms.
+            using namespace std::chrono_literals;
+            duration remaining = std::chrono::duration_cast<duration>(playing_until - now);
+            if(remaining > 10ms) //Don't x() less than 10ms.
                 //This will add latency...
-                os_usleep(remaining  - 10000);
-            if(remaining < 0)
+                this_thread::sleep_for(remaining  - 10ms);
+            else if(remaining < 0us) {
+                playing_until -= remaining;
                 cerr << "WARNING - too late" << endl;
+            }
         }
-        playing_until.tv_usec += synth.buffersize * 1000000
-                                 / synth.samplerate;
-        if(remaining < 0)
-            playing_until.tv_usec -= remaining;
-        playing_until.tv_sec  += playing_until.tv_usec / 1000000;
-        playing_until.tv_usec %= 1000000;
+        playing_until += increase;
     }
-    return NULL;
 }
 
 NulEngine::~NulEngine()
@@ -82,26 +72,19 @@ void NulEngine::setAudioEn(bool nval)
 {
     if(nval) {
         if(!getAudioEn()) {
-            pthread_t     *thread = new pthread_t;
-            pthread_attr_t attr;
-            pthread_attr_init(&attr);
-            pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-            pThread = thread;
-            pthread_create(pThread, &attr, _AudioThread, this);
+            thread = std::thread(&NulEngine::AudioThread, this);
         }
     }
     else
     if(getAudioEn()) {
-        pthread_t *thread = pThread;
-        pThread = NULL;
-        pthread_join(*thread, NULL);
-        delete thread;
+        std::thread tmpthread = std::move(thread);
+        tmpthread.join();
     }
 }
 
 bool NulEngine::getAudioEn() const
 {
-    return pThread;
+    return thread.joinable();
 }
 
 }

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -79,8 +79,8 @@ void NulEngine::setAudioEn(bool nval)
     else
     if(getAudioEn()) {
         running.clear();
-        std::thread tmpthread = std::move(thread);
-        tmpthread.join();
+        if(thread.joinable())
+            thread.join();
     }
 }
 

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -32,7 +32,7 @@ void NulEngine::AudioThread()
     using duration = chrono::microseconds;
     const duration increase(synth.buffersize * 1'000'000 / synth.samplerate);
 
-    while(thread.joinable()) {
+    while(running.test()) {
         getNext();
 
         time_point now = chrono::steady_clock::now();
@@ -72,11 +72,13 @@ void NulEngine::setAudioEn(bool nval)
 {
     if(nval) {
         if(!getAudioEn()) {
+            running.test_and_set();
             thread = std::thread(&NulEngine::AudioThread, this);
         }
     }
     else
     if(getAudioEn()) {
+        running.clear();
         std::thread tmpthread = std::move(thread);
         tmpthread.join();
     }
@@ -84,7 +86,7 @@ void NulEngine::setAudioEn(bool nval)
 
 bool NulEngine::getAudioEn() const
 {
-    return thread.joinable();
+    return running.test();
 }
 
 }

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -55,7 +55,9 @@ void NulEngine::AudioThread()
 }
 
 NulEngine::~NulEngine()
-{}
+{
+    Stop();
+}
 
 bool NulEngine::Start()
 {

--- a/src/Nio/NulEngine.cpp
+++ b/src/Nio/NulEngine.cpp
@@ -73,16 +73,14 @@ void NulEngine::Stop()
 void NulEngine::setAudioEn(bool nval)
 {
     if(nval) {
-        if(!getAudioEn()) {
-            running.test_and_set();
+        if(!running.test_and_set()) {
             thread = std::thread(&NulEngine::AudioThread, this);
         }
     }
     else
     if(getAudioEn()) {
         running.clear();
-        if(thread.joinable())
-            thread.join();
+        thread.join();
     }
 }
 

--- a/src/Nio/NulEngine.h
+++ b/src/Nio/NulEngine.h
@@ -14,8 +14,7 @@
 #ifndef NUL_ENGINE_H
 #define NUL_ENGINE_H
 
-#include <sys/time.h>
-#include <pthread.h>
+#include <thread>
 #include "../globals.h"
 #include "AudioOut.h"
 #include "MidiIn.h"
@@ -35,15 +34,15 @@ class NulEngine:public AudioOut, MidiIn
         bool getAudioEn() const;
 
         void setMidiEn(bool) {}
-        bool getMidiEn() const {return true; }
+        bool getMidiEn() const { return true; }
 
     protected:
-        void *AudioThread();
-        static void *_AudioThread(void *arg);
+        void AudioThread();
 
     private:
-        struct timeval playing_until;
-        pthread_t     *pThread;
+        using time_point = std::chrono::time_point<std::chrono::steady_clock>;
+        time_point     playing_until;
+        std::thread    thread;
 };
 
 }

--- a/src/Nio/NulEngine.h
+++ b/src/Nio/NulEngine.h
@@ -45,7 +45,7 @@ class NulEngine:public AudioOut, MidiIn
         using time_point = std::chrono::time_point<std::chrono::steady_clock>;
         time_point       playing_until;
         std::thread      thread;
-        std::atomic_flag running = false;
+        std::atomic_flag running{false};
 };
 
 }

--- a/src/Nio/NulEngine.h
+++ b/src/Nio/NulEngine.h
@@ -14,6 +14,7 @@
 #ifndef NUL_ENGINE_H
 #define NUL_ENGINE_H
 
+#include <atomic>
 #include <thread>
 #include <chrono>
 #include "../globals.h"
@@ -42,8 +43,9 @@ class NulEngine:public AudioOut, MidiIn
 
     private:
         using time_point = std::chrono::time_point<std::chrono::steady_clock>;
-        time_point     playing_until;
-        std::thread    thread;
+        time_point       playing_until;
+        std::thread      thread;
+        std::atomic_flag running = false;
 };
 
 }

--- a/src/Nio/NulEngine.h
+++ b/src/Nio/NulEngine.h
@@ -45,7 +45,7 @@ class NulEngine:public AudioOut, MidiIn
         using time_point = std::chrono::time_point<std::chrono::steady_clock>;
         time_point       playing_until;
         std::thread      thread;
-        std::atomic_flag running{false};
+        std::atomic_flag running;
 };
 
 }

--- a/src/Nio/NulEngine.h
+++ b/src/Nio/NulEngine.h
@@ -15,6 +15,7 @@
 #define NUL_ENGINE_H
 
 #include <thread>
+#include <chrono>
 #include "../globals.h"
 #include "AudioOut.h"
 #include "MidiIn.h"

--- a/src/Nio/OssEngine.h
+++ b/src/Nio/OssEngine.h
@@ -14,6 +14,7 @@
 #ifndef OSS_ENGINE_H
 #define OSS_ENGINE_H
 
+#include <thread>
 #include <sys/time.h>
 #include "../globals.h"
 #include "AudioOut.h"
@@ -51,15 +52,12 @@ class OssEngine:public AudioOut, MidiIn
         bool getMidiEn() const;
 
     protected:
-        void *audioThreadCb();
-        static void *_audioThreadCb(void *arg);
-
-        void *midiThreadCb();
-        static void *_midiThreadCb(void *arg);
+        void audioThreadCb();
+        void midiThreadCb();
 
     private:
-        pthread_t *audioThread;
-        pthread_t *midiThread;
+        std::thread audioThread;
+        std::thread midiThread;
 
         //Audio
         bool openAudio();

--- a/src/Nio/OssMultiEngine.h
+++ b/src/Nio/OssMultiEngine.h
@@ -13,6 +13,7 @@
 #ifndef OSS_MULTI_ENGINE_H
 #define OSS_MULTI_ENGINE_H
 
+#include <thread>
 #include <sys/time.h>
 #include "../globals.h"
 #include "AudioOut.h"
@@ -33,11 +34,10 @@ class OssMultiEngine : public AudioOut
         bool getAudioEn() const;
 
     protected:
-        void *audioThreadCb();
-        static void *_audioThreadCb(void *arg);
+        void audioThreadCb();
 
     private:
-        pthread_t audioThread;
+        std::thread audioThread;
 
         /* Audio */
         bool openAudio();

--- a/src/Nio/OutMgr.cpp
+++ b/src/Nio/OutMgr.cpp
@@ -32,12 +32,6 @@ OutMgr &OutMgr::getInstance(const SYNTH_T *synth)
 
 #if HAVE_BG_SYNTH_THREAD
 void *
-OutMgr::_refillThread(void *arg)
-{
-    return static_cast<OutMgr *>(arg)->refillThread();
-}
-
-void *
 OutMgr::refillThread()
 {
     refillLock();
@@ -53,8 +47,6 @@ OutMgr::refillThread()
 void
 OutMgr::setBackgroundSynth(bool enable)
 {
-    void *dummy;
-
     if (bgSynthEnabled == enable)
         return;
     if (bgSynthEnabled) {
@@ -63,13 +55,13 @@ OutMgr::setBackgroundSynth(bool enable)
         refillWakeup();
         refillUnlock();
 
-        pthread_join(bgSynthThread, &dummy);
+        bgSynthThread.join();
     } else {
         refillLock();
         bgSynthEnabled = true;
         refillUnlock();
 
-        pthread_create(&bgSynthThread, 0, &_refillThread, this);
+        bgSynthThread = std::thread(&OutMgr::refillThread, this);
     }
 }
 #endif
@@ -90,8 +82,6 @@ OutMgr::OutMgr(const SYNTH_T *synth_)
     memset(outr, 0, synth.bufferbytes);
 
 #if HAVE_BG_SYNTH_THREAD
-    pthread_mutex_init(&bgSynthMtx, 0);
-    pthread_cond_init(&bgSynthCond, 0);
     bgSynthEnabled = false;
 #endif
     midiFlushOffset = 0;
@@ -113,10 +103,6 @@ OutMgr::~OutMgr()
     delete [] priBuf.r;
     delete [] outr;
     delete [] outl;
-#if HAVE_BG_SYNTH_THREAD
-    pthread_cond_destroy(&bgSynthCond);
-    pthread_mutex_destroy(&bgSynthMtx);
-#endif
 }
 
 void OutMgr::refillSmps(unsigned int smpsLimit)
@@ -223,7 +209,6 @@ string OutMgr::getSink() const
         cerr << "BUG: No current output in OutMgr " << __LINE__ << endl;
         return "ERROR";
     }
-    return "ERROR";
 }
 
 void OutMgr::setAudioCompressor(bool isEnabled)

--- a/src/Nio/OutMgr.cpp
+++ b/src/Nio/OutMgr.cpp
@@ -34,13 +34,12 @@ OutMgr &OutMgr::getInstance(const SYNTH_T *synth)
 void *
 OutMgr::refillThread()
 {
-    refillLock();
+    auto lock = refillLock();
     while (bgSynthEnabled) {
-        refillSmps(stales + synth.buffersize);
+        refillSmps(stales + synth.buffersize, lock);
         refillWakeup();
-        refillWait();
+        refillWait(lock);
     }
-    refillUnlock();
     return 0;
 }
 
@@ -50,17 +49,17 @@ OutMgr::setBackgroundSynth(bool enable)
     if (bgSynthEnabled == enable)
         return;
     if (bgSynthEnabled) {
-        refillLock();
-        bgSynthEnabled = false;
-        refillWakeup();
-        refillUnlock();
-
+        {
+            auto lock = refillLock();
+            bgSynthEnabled = false;
+            refillWakeup();
+        }
         bgSynthThread.join();
     } else {
-        refillLock();
-        bgSynthEnabled = true;
-        refillUnlock();
-
+        {
+            auto lock = refillLock();
+            bgSynthEnabled = true;
+        }
         bgSynthThread = std::thread(&OutMgr::refillThread, this);
     }
 }
@@ -105,12 +104,12 @@ OutMgr::~OutMgr()
     delete [] outl;
 }
 
-void OutMgr::refillSmps(unsigned int smpsLimit)
+void OutMgr::refillSmps(unsigned int smpsLimit, LockType& lock)
 {
     InMgr &midi = InMgr::getInstance();
 
     while(smpsLimit > curStoredSmps()) {
-        refillUnlock();
+        lock.unlock();
         if(!midi.empty() &&
            !midi.flush(midiFlushOffset, midiFlushOffset + synth.buffersize)) {
           midiFlushOffset += synth.buffersize;
@@ -118,7 +117,7 @@ void OutMgr::refillSmps(unsigned int smpsLimit)
           midiFlushOffset = 0;
         }
         master->AudioOut(outl, outr);
-        refillLock();
+        lock.lock();
         addSmps(outl, outr);
     }
 }
@@ -136,7 +135,7 @@ Stereo<float *> OutMgr::tick(unsigned int frameSize)
 {
     auto retval = priBuf;
     //SysEv->execute();
-    refillLock();
+    [[maybe_unused]] auto lock = refillLock();
     /* cleanup stales, if any */
     if(frameSize + stales > maxStoredSmps)
         removeStaleSmps();
@@ -146,13 +145,13 @@ Stereo<float *> OutMgr::tick(unsigned int frameSize)
         assert(frameSize <= (unsigned int)synth.buffersize);
         /* wait for background samples to complete, if any */
         while(frameSize + stales > curStoredSmps())
-            refillWait();
+            refillWait(lock);
     } else {
 #endif
         /* check if drivers ask for too many samples */
         assert(frameSize + stales <= maxStoredSmps);
         /* produce samples foreground, if any */
-        refillSmps(frameSize + stales);
+        refillSmps(frameSize + stales, lock);
 #if HAVE_BG_SYNTH_THREAD
     }
 #endif
@@ -165,7 +164,6 @@ Stereo<float *> OutMgr::tick(unsigned int frameSize)
         refillWakeup();
     }
 #endif
-    refillUnlock();
     return retval;
 }
 

--- a/src/Nio/OutMgr.h
+++ b/src/Nio/OutMgr.h
@@ -16,10 +16,11 @@
 #include "../globals.h"
 #include <list>
 #if HAVE_BG_SYNTH_THREAD
-#include <pthread.h>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
 #endif
 #include <string>
-#include <semaphore.h>
 
 namespace zyn {
 
@@ -67,7 +68,6 @@ class OutMgr
         void applyOscEventRt(const char *msg);
 #if HAVE_BG_SYNTH_THREAD
         void setBackgroundSynth(bool);
-        static void *_refillThread(void *);
         void *refillThread();
 #endif
     private:
@@ -76,10 +76,10 @@ class OutMgr
         unsigned int curStoredSmps() const {return priBuffCurrent.l - priBuf.l; }
         void removeStaleSmps();
 #if HAVE_BG_SYNTH_THREAD
-        void refillLock() { pthread_mutex_lock(&bgSynthMtx); }
-        void refillUnlock() { pthread_mutex_unlock(&bgSynthMtx); }
-        void refillWait() { pthread_cond_wait(&bgSynthCond, &bgSynthMtx); }
-        void refillWakeup() { pthread_cond_broadcast(&bgSynthCond); }
+        void refillLock() { bgSynthMtx.lock(); }
+        void refillUnlock() { bgSynthMtx.unlock(); }
+        void refillWait() { std::unique_lock<std::mutex> lock(bgSynthMtx); bgSynthCond.wait(lock); }
+        void refillWakeup() { bgSynthCond.notify_one(); }
 #else
         void refillLock() { }
         void refillUnlock() { }
@@ -87,8 +87,6 @@ class OutMgr
         void refillSmps(unsigned int);
 
         AudioOut *currentOut; /**<The current output driver*/
-
-        sem_t requested;
 
         /**Buffer*/
         Stereo<float *> priBuf;         //buffer for primary drivers
@@ -106,9 +104,9 @@ class OutMgr
 
 #if HAVE_BG_SYNTH_THREAD
         /**Background synth*/
-        pthread_mutex_t bgSynthMtx;
-        pthread_cond_t bgSynthCond;
-        pthread_t bgSynthThread;
+        std::mutex bgSynthMtx;
+        std::condition_variable bgSynthCond;
+        std::thread bgSynthThread;
         bool bgSynthEnabled;
 #endif
 };

--- a/src/Nio/OutMgr.h
+++ b/src/Nio/OutMgr.h
@@ -76,15 +76,19 @@ class OutMgr
         unsigned int curStoredSmps() const {return priBuffCurrent.l - priBuf.l; }
         void removeStaleSmps();
 #if HAVE_BG_SYNTH_THREAD
-        void refillLock() { bgSynthMtx.lock(); }
-        void refillUnlock() { bgSynthMtx.unlock(); }
-        void refillWait() { std::unique_lock<std::mutex> lock(bgSynthMtx); bgSynthCond.wait(lock); }
+        using LockType = std::unique_lock<std::mutex>;
+        LockType refillLock() { return std::unique_lock<std::mutex>(bgSynthMtx); }
+        void refillWait(std::unique_lock<std::mutex>& lock) { bgSynthCond.wait(lock); }
         void refillWakeup() { bgSynthCond.notify_one(); }
 #else
-        void refillLock() { }
-        void refillUnlock() { }
+        struct DummyLock {
+            void lock() const {}
+            void unlock() const {};
+        };
+        using LockType = DummyLock;
+        LockType refillLock() { return {}; }
 #endif
-        void refillSmps(unsigned int);
+        void refillSmps(unsigned int, LockType&);
 
         AudioOut *currentOut; /**<The current output driver*/
 

--- a/src/Nio/SafeQueue.h
+++ b/src/Nio/SafeQueue.h
@@ -14,7 +14,6 @@
 #define SAFEQUEUE_H
 #include <cstdlib>
 #include "ZynSema.h"
-#include <pthread.h>
 
 namespace zyn {
 

--- a/src/Nio/SndioEngine.cpp
+++ b/src/Nio/SndioEngine.cpp
@@ -30,12 +30,9 @@ SndioEngine::SndioEngine(const SYNTH_T &synth)
     :AudioOut(synth)
 {
     name = "SNDIO";
-    audio.handle = NULL;
     audio.buffer = new short[synth.buffersize * 2];
     audio.buffer_size = synth.buffersize * 2 * sizeof(short);
     audio.peaks[0] = 0;
-
-    midi.handle  = NULL;
 }
 
 SndioEngine::~SndioEngine()
@@ -102,8 +99,6 @@ bool SndioEngine::openAudio()
     if(audio.running.test_and_set())
         return true;
 
-    audio.handle = NULL;
-
     auto crash = [](std::atomic_flag& audio_running, const char* msg) {
         fprintf(stderr, "%s\n", msg);
         audio_running.clear();
@@ -146,8 +141,6 @@ void SndioEngine::stopAudio()
         return;
     audio.running.clear();
 
-    audio.handle = NULL;
-
     if(audio.thread.joinable())
         audio.thread.join();
 
@@ -162,8 +155,6 @@ bool SndioEngine::openMidi()
 {
     if(midi.running.test_and_set())
         return true;
-
-    midi.handle = NULL;
 
     if((midi.handle = mio_open(MIO_PORTANY, MIO_IN, 1)) == NULL) {
         fprintf(stderr, "unable to open sndio midi device\n");
@@ -185,21 +176,16 @@ void SndioEngine::stopMidi()
     if(midi.thread.joinable())
         midi.thread.join();
 
-    midi.handle = NULL;
-
-    if(handle)
-        mio_close(handle);
+    mio_close(handle);
 }
 
 void SndioEngine::processAudio()
 {
     size_t len;
-    struct sio_hdl *handle;
 
     while(audio.running.test()) {
         audio.buffer = interleave(getNext());
-        handle = audio.handle;
-        len = sio_write(handle, audio.buffer, audio.buffer_size);
+        len = sio_write(audio.handle, audio.buffer, audio.buffer_size);
         if(len == 0) // write error according to sndio examples
             cerr << "sio_write error" << endl;
     }

--- a/src/Nio/SndioEngine.cpp
+++ b/src/Nio/SndioEngine.cpp
@@ -67,7 +67,7 @@ void SndioEngine::setAudioEn(bool nval)
 
 bool SndioEngine::getAudioEn() const
 {
-    return audio.handle;
+    return audio.running.test();
 }
 
 void SndioEngine::setMidiEn(bool nval)
@@ -80,7 +80,7 @@ void SndioEngine::setMidiEn(bool nval)
 
 bool SndioEngine::getMidiEn() const
 {
-    return midi.handle;
+    return midi.running.test();
 }
 
 void SndioEngine::AudioThread()
@@ -99,13 +99,18 @@ bool SndioEngine::openAudio()
 {
     int rc;
 
-    if(getAudioEn())
+    if(audio.running.test_and_set())
         return true;
 
     audio.handle = NULL;
 
+    auto crash = [](std::atomic_flag& audio_running, const char* msg) {
+        fprintf(stderr, "%s\n", msg);
+        audio_running.clear();
+    };
+
     if((audio.handle = sio_open(SIO_DEVANY, SIO_PLAY, 0)) == NULL) {
-        fprintf(stderr, "unable to open sndio audio device\n");
+        crash(audio.running, "unable to open sndio audio device");
         return false;
     }
 
@@ -116,7 +121,7 @@ bool SndioEngine::openAudio()
 
     rc = sio_setpar(audio.handle, &audio.params);
     if(rc != 1) {
-        fprintf(stderr, "unable to set sndio audio parameters");
+        crash(audio.running, "unable to set sndio audio parameters");
         return false;
     }
 
@@ -124,7 +129,7 @@ bool SndioEngine::openAudio()
 
     rc = sio_start(audio.handle);
     if(rc != 1) {
-        fprintf(stderr, "unable to start sndio audio");
+        crash(audio.running, "unable to start sndio audio");
         return false;
     }
 
@@ -139,6 +144,7 @@ void SndioEngine::stopAudio()
 
     if(!getAudioEn())
         return;
+    audio.running.clear();
 
     audio.handle = NULL;
 
@@ -154,17 +160,16 @@ void SndioEngine::stopAudio()
 
 bool SndioEngine::openMidi()
 {
-    if(getMidiEn())
+    if(midi.running.test_and_set())
         return true;
 
     midi.handle = NULL;
 
     if((midi.handle = mio_open(MIO_PORTANY, MIO_IN, 1)) == NULL) {
         fprintf(stderr, "unable to open sndio midi device\n");
+        midi.running.clear();
         return false;
     }
-
-    midi.exiting = false;
 
     midi.thread = std::thread(&SndioEngine::MidiThread, this);
     return true;
@@ -176,12 +181,9 @@ void SndioEngine::stopMidi()
 
     if(!getMidiEn())
         return;
-
-    if(midi.handle) {
-        midi.exiting = true;
-        if(midi.thread.joinable())
-            midi.thread.join();
-    }
+    midi.running.clear();
+    if(midi.thread.joinable())
+        midi.thread.join();
 
     midi.handle = NULL;
 
@@ -194,7 +196,7 @@ void SndioEngine::processAudio()
     size_t len;
     struct sio_hdl *handle;
 
-    while(audio.handle) {
+    while(audio.running.test()) {
         audio.buffer = interleave(getNext());
         handle = audio.handle;
         len = sio_write(handle, audio.buffer, audio.buffer_size);
@@ -226,7 +228,7 @@ void SndioEngine::processMidi()
     }
 
     while(1) {
-        if(midi.exiting)
+        if(!midi.running.test())
             break;
 
         nfds = mio_pollfd(midi.handle, pfd, POLLIN);

--- a/src/Nio/SndioEngine.cpp
+++ b/src/Nio/SndioEngine.cpp
@@ -140,9 +140,7 @@ void SndioEngine::stopAudio()
     if(!getAudioEn())
         return;
     audio.running.clear();
-
-    if(audio.thread.joinable())
-        audio.thread.join();
+    audio.thread.join();
 
     rc = sio_stop(handle);
     if(rc != 1)
@@ -173,8 +171,7 @@ void SndioEngine::stopMidi()
     if(!getMidiEn())
         return;
     midi.running.clear();
-    if(midi.thread.joinable())
-        midi.thread.join();
+    midi.thread.join();
 
     mio_close(handle);
 }

--- a/src/Nio/SndioEngine.h
+++ b/src/Nio/SndioEngine.h
@@ -13,7 +13,7 @@
 #ifndef SNDIO_ENGINE_H
 #define SNDIO_ENGINE_H
 
-#include <pthread.h>
+#include <thread>
 #include <queue>
 #include <sndio.h>
 #include <string>
@@ -40,10 +40,8 @@ class SndioEngine:public AudioOut, MidiIn
         bool getMidiEn() const;
 
     protected:
-        void *AudioThread();
-        static void *_AudioThread(void *arg);
-        void *MidiThread();
-        static void *_MidiThread(void *arg);
+        void AudioThread();
+        void MidiThread();
 
     private:
         bool openAudio();
@@ -51,17 +49,17 @@ class SndioEngine:public AudioOut, MidiIn
         bool openMidi();
         void stopMidi();
 
-        void *processAudio();
-        void *processMidi();
+        void processAudio();
+        void processMidi();
         short *interleave(const Stereo<float *> &smps);
-	void showAudioInfo(struct sio_hdl *handle);
+        void showAudioInfo(struct sio_hdl *handle);
 
         struct {
             struct sio_hdl *handle;
             struct sio_par params;
             short *buffer;
-	    size_t buffer_size;
-            pthread_t pThread;
+            size_t buffer_size;
+            std::thread thread;
             float peaks[1];
         } audio;
 
@@ -69,7 +67,7 @@ class SndioEngine:public AudioOut, MidiIn
             std::string device;
             struct mio_hdl *handle;
             bool exiting;
-            pthread_t pThread;
+            std::thread thread;
         } midi;
 };
 

--- a/src/Nio/SndioEngine.h
+++ b/src/Nio/SndioEngine.h
@@ -13,6 +13,7 @@
 #ifndef SNDIO_ENGINE_H
 #define SNDIO_ENGINE_H
 
+#include <atomic>
 #include <thread>
 #include <queue>
 #include <sndio.h>
@@ -59,6 +60,7 @@ class SndioEngine:public AudioOut, MidiIn
             struct sio_par params;
             short *buffer;
             size_t buffer_size;
+            std::atomic_flag running{false};
             std::thread thread;
             float peaks[1];
         } audio;
@@ -66,7 +68,7 @@ class SndioEngine:public AudioOut, MidiIn
         struct {
             std::string device;
             struct mio_hdl *handle;
-            bool exiting;
+            std::atomic_flag running{false};
             std::thread thread;
         } midi;
 };

--- a/src/Nio/SndioEngine.h
+++ b/src/Nio/SndioEngine.h
@@ -60,7 +60,7 @@ class SndioEngine:public AudioOut, MidiIn
             struct sio_par params;
             short *buffer;
             size_t buffer_size;
-            std::atomic_flag running{false};
+            std::atomic_flag running;
             std::thread thread;
             float peaks[1];
         } audio;
@@ -68,7 +68,7 @@ class SndioEngine:public AudioOut, MidiIn
         struct {
             std::string device;
             struct mio_hdl *handle;
-            std::atomic_flag running{false};
+            std::atomic_flag running;
             std::thread thread;
         } midi;
 };

--- a/src/Nio/WavEngine.cpp
+++ b/src/Nio/WavEngine.cpp
@@ -22,7 +22,7 @@ using namespace std;
 namespace zyn {
 
 WavEngine::WavEngine(const SYNTH_T &synth_)
-    :AudioOut(synth_), file(NULL), buffer(synth.samplerate * 4), pThread(NULL)
+    :AudioOut(synth_), file(NULL), buffer(synth.samplerate * 4)
 {
     work.init(PTHREAD_PROCESS_PRIVATE, 0);
 }
@@ -40,35 +40,27 @@ bool WavEngine::openAudio()
 
 bool WavEngine::Start()
 {
-    if(pThread)
-        return true;
-    pThread = new pthread_t;
-
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_create(pThread, &attr, _AudioThread, this);
+    if(!thread.joinable())
+        thread = std::thread(&WavEngine::AudioThread, this);
 
     return true;
 }
 
 void WavEngine::Stop()
 {
-    if(!pThread)
+    if(!thread.joinable())
         return;
 
-    pthread_t *tmp = pThread;
-    pThread = NULL;
+    std::thread tmp = std::move(thread);
 
     work.post();
-    pthread_join(*tmp, NULL);
-    delete pThread;
+    tmp.join();
     destroyFile();
 }
 
 void WavEngine::push(Stereo<float *> smps, size_t len)
 {
-    if(!pThread)
+    if(!thread.joinable())
         return;
 
 
@@ -100,16 +92,11 @@ void WavEngine::destroyFile()
     file = NULL;
 }
 
-void *WavEngine::_AudioThread(void *arg)
-{
-    return (static_cast<WavEngine *>(arg))->AudioThread();
-}
-
-void *WavEngine::AudioThread()
+void WavEngine::AudioThread()
 {
     short *recordbuf_16bit = new short[2 * synth.buffersize];
 
-    while(!work.wait() && pThread) {
+    while(!work.wait() && thread.joinable()) {
         for(int i = 0; i < synth.buffersize; ++i) {
             float left = 0.0f, right = 0.0f;
             buffer.pop(left);
@@ -126,8 +113,6 @@ void *WavEngine::AudioThread()
     }
 
     delete[] recordbuf_16bit;
-
-    return NULL;
 }
 
 }

--- a/src/Nio/WavEngine.cpp
+++ b/src/Nio/WavEngine.cpp
@@ -40,7 +40,7 @@ bool WavEngine::openAudio()
 
 bool WavEngine::Start()
 {
-    if(!thread.joinable())
+    if(!running.test_and_set())
         thread = std::thread(&WavEngine::AudioThread, this);
 
     return true;
@@ -48,17 +48,20 @@ bool WavEngine::Start()
 
 void WavEngine::Stop()
 {
-    if(!thread.joinable())
+    if(!running.test())
         return;
 
-    thread.join();
+    running.clear();
     work.post();
+    if(thread.joinable())
+        thread.join();
+
     destroyFile();
 }
 
 void WavEngine::push(Stereo<float *> smps, size_t len)
 {
-    if(!thread.joinable())
+    if(!running.test())
         return;
 
 
@@ -94,7 +97,7 @@ void WavEngine::AudioThread()
 {
     short *recordbuf_16bit = new short[2 * synth.buffersize];
 
-    while(!work.wait() && thread.joinable()) {
+    while(!work.wait() && running.test()) {
         for(int i = 0; i < synth.buffersize; ++i) {
             float left = 0.0f, right = 0.0f;
             buffer.pop(left);

--- a/src/Nio/WavEngine.cpp
+++ b/src/Nio/WavEngine.cpp
@@ -53,8 +53,7 @@ void WavEngine::Stop()
 
     running.clear();
     work.post();
-    if(thread.joinable())
-        thread.join();
+    thread.join();
 
     destroyFile();
 }

--- a/src/Nio/WavEngine.cpp
+++ b/src/Nio/WavEngine.cpp
@@ -51,10 +51,8 @@ void WavEngine::Stop()
     if(!thread.joinable())
         return;
 
-    std::thread tmp = std::move(thread);
-
+    thread.join();
     work.post();
-    tmp.join();
     destroyFile();
 }
 

--- a/src/Nio/WavEngine.h
+++ b/src/Nio/WavEngine.h
@@ -16,7 +16,7 @@
 #define WAVENGINE_H
 #include "AudioOut.h"
 #include <string>
-#include <pthread.h>
+#include <thread>
 #include "ZynSema.h"
 #include "SafeQueue.h"
 
@@ -42,15 +42,14 @@ class WavEngine:public AudioOut
         void destroyFile();
 
     protected:
-        void *AudioThread();
-        static void *_AudioThread(void *arg);
+        void AudioThread();
 
     private:
         WavFile *file;
         ZynSema  work;
         SafeQueue<float> buffer;
 
-        pthread_t *pThread;
+        std::thread thread;
 };
 
 }

--- a/src/Nio/WavEngine.h
+++ b/src/Nio/WavEngine.h
@@ -51,7 +51,7 @@ class WavEngine:public AudioOut
         SafeQueue<float> buffer;
 
         std::thread thread;
-        std::atomic_flag running{false};
+        std::atomic_flag running;
 };
 
 }

--- a/src/Nio/WavEngine.h
+++ b/src/Nio/WavEngine.h
@@ -15,6 +15,7 @@
 #ifndef WAVENGINE_H
 #define WAVENGINE_H
 #include "AudioOut.h"
+#include <atomic>
 #include <string>
 #include <thread>
 #include "ZynSema.h"
@@ -50,6 +51,7 @@ class WavEngine:public AudioOut
         SafeQueue<float> buffer;
 
         std::thread thread;
+        std::atomic_flag running{false};
 };
 
 }

--- a/src/Nio/ZynSema.h
+++ b/src/Nio/ZynSema.h
@@ -83,6 +83,7 @@ private:
 
 #else // POSIX semaphore
 
+#include <pthread.h>  // for the "s" parameter to "init"
 #include <semaphore.h>
 
 namespace zyn {

--- a/src/Params/PresetsStore.cpp
+++ b/src/Params/PresetsStore.cpp
@@ -91,7 +91,8 @@ void PresetsStore::scanforpresets()
 
         namespace fs = std::filesystem;
         fs::path dir(dirname);
-        for(const auto& file : fs::directory_iterator(dir))
+        std::error_code ec;
+        for(const auto& file : fs::directory_iterator(dir, ec))
         {
             if(file.is_directory())
                 continue;

--- a/src/Params/PresetsStore.cpp
+++ b/src/Params/PresetsStore.cpp
@@ -13,9 +13,9 @@
 #include <iostream>
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <stdlib.h>
 #include <string.h>
-#include <dirent.h>
 #include <sys/stat.h>
 
 #include "PresetsStore.h"
@@ -88,21 +88,21 @@ void PresetsStore::scanforpresets()
         //open directory
         string dirname = config.cfg.presetsDirList[i];
         expanddirname(dirname);
-        DIR   *dir     = opendir(dirname.c_str());
-        if(dir == NULL)
-            continue;
-        struct dirent *fn;
 
-        //check all files in directory
-        while((fn = readdir(dir))) {
-            string filename = fn->d_name;
-            if(filename.find(ftype) == string::npos)
+        namespace fs = std::filesystem;
+        fs::path dir(dirname);
+        for(const auto& file : fs::directory_iterator(dir))
+        {
+            if(file.is_directory())
+                continue;
+            fs::path path = file.path();
+            string filename = path.filename().string();
+            auto ftype_pos = filename.find(ftype);
+            if(ftype_pos == string::npos)
                 continue;
 
-            string location = dirname + filename;
-
             //trim file type off of name
-            string name_type = filename.substr(0, filename.find(ftype));
+            string name_type = filename.substr(0, ftype_pos);
 
             size_t tmp  = name_type.find_last_of(".");
             if(tmp == string::npos)
@@ -111,10 +111,8 @@ void PresetsStore::scanforpresets()
             string name = name_type.substr(0, tmp);
 
             //put on list
-            presets.push_back(presetstruct{location, name, type});
+            presets.push_back(presetstruct{path.string(), name, type});
         }
-
-        closedir(dir);
     }
 
     //sort the presets

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -24,8 +24,6 @@
 #include <cstddef>
 #include <complex>
 
-#include <unistd.h>
-
 #include <rtosc/ports.h>
 #include <rtosc/port-sugar.h>
 

--- a/src/Tests/WatchTest.cpp
+++ b/src/Tests/WatchTest.cpp
@@ -31,7 +31,6 @@
 #include "../Params/LFOParams.h"
 #include "../Synth/LFO.h"
 #include "../Synth/SynthNote.h"
-#include <unistd.h>
 using namespace std;
 using namespace zyn;
 

--- a/src/UI/ConnectionDummy.cpp
+++ b/src/UI/ConnectionDummy.cpp
@@ -10,7 +10,10 @@
   of the License, or (at your option) any later version.
 */
 #include "Connection.h"
-#include <unistd.h>
+
+#include <thread>
+#include <chrono>
+
 namespace GUI {
 ui_handle_t createUi(Fl_Osc_Interface*, void *)
 {
@@ -27,7 +30,7 @@ void raiseUi(ui_handle_t, const char *, const char *, ...)
 }
 void tickUi(ui_handle_t)
 {
-    usleep(1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
 }
 Fl_Osc_Interface *genOscInterface(zyn::MiddleWare*)
 {

--- a/src/UI/NSM.C
+++ b/src/UI/NSM.C
@@ -29,7 +29,6 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <stdlib.h>
 
 extern int Pexitprogram;

--- a/src/UI/NSM/Client.C
+++ b/src/UI/NSM/Client.C
@@ -21,8 +21,14 @@
 #include <assert.h>
 #include <string.h>
 #include <sys/types.h>
-#include <unistd.h>
 #include <stdlib.h>
+
+#if defined(_WIN32)
+  #include <process.h>   // for _getpid()
+  #define getpid _getpid
+#else
+  #include <unistd.h>    // for getpid()
+#endif
 
 namespace NSM
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,8 +24,6 @@
 #ifndef WIN32
 #include <err.h>
 #endif
-#include <unistd.h>
-
 #include <getopt.h>
 
 #include <sys/types.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,11 @@
 #include <algorithm>
 #include <signal.h>
 
+#ifdef ZEST_GUI
 #ifndef WIN32
 #include <err.h>
+#include <unistd.h>
+#endif
 #endif
 #include <getopt.h>
 


### PR DESCRIPTION
Test list:

1. FFTWrapper: Check ADD and PAD synth work :heavy_check_mark: 
2. Bank::loadbank -> Load a bank in GUI :heavy_check_mark: 
3. Bank::scanrootdir -> Open bank browser :heavy_check_mark: 
4. BankDb::scanBanks -> Start zyn, print `filename` -> Same output as on master :heavy_check_mark:
5. MiddleWare's `getFiles`: Call `/file_list_files` and `/file_list_dirs` using oscprompt :heavy_check_mark: 
6. MiddleWare::checkAutoSave-> check that an autosave is found and can be restored :heavy_check_mark: 
7. AlsaEngine: MidiIn, AudioOut :heavy_check_mark: 
8. NullEngine: VU Meter should show something. MIDI cannot be tested here. :heavy_check_mark:
9. OssEngine: Not Tested
10. OutMgr: Zyn basically still produces normal sound when `bgSynthThread` is "on" AND "off" :heavy_check_mark:
11. SndioEngine: MidiIn, AudioOut -> :heavy_check_mark: 
12. WavEngine: AudioOut -> Test recording works :heavy_check_mark: 
13. PresetsStore::scanforpresets -> :heavy_check_mark: 

Summary: All non-trivial changes tested, except:

* OssEngine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized threading, timing and filesystem internals across the app.
  * Replaced legacy platform-specific APIs with C++ standard utilities for more reliable background tasks, safer file scanning, and cleaner resource handling.
  * Reduced platform header usage and tightened conditional compilation to improve portability, stability, and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->