### PR TITLE
FL: Fix crash when clicking "Refresh bank list"

### DIFF
--- a/src/UI/Fl_Osc_Widget.cpp
+++ b/src/UI/Fl_Osc_Widget.cpp
@@ -96,7 +96,7 @@ void Fl_Osc_Widget::oscRegister(const char *path)
 
 void Fl_Osc_Widget::update(void)
 {
-    if(*((loc+ext).rbegin()) != '/' && osc)
+    if(!ext.empty() && *((loc+ext).rbegin()) != '/' && osc)
         osc->requestValue(loc+ext);
 }
 


### PR DESCRIPTION
Fix FL widgets without `ext` requesting values.

For reference, here is a backtrace of the crash, showing how sending `/damage` (#7) for `/bank/` (#6) causes a widget without `ext` (#4) to request a value from the backend, hitting an assertion `msg && *msg && strrchr(msg, '/')[1]` (#1)

```
 0  zyn::MiddleWareImpl::handleMsg (this=0x555555a46460, msg=0x7fffffff1390 "", msg_comes_from_realtime=false)
    at src/Misc/MiddleWare.cpp:2386
 1  0x00005555555f6e0b in zyn::MiddleWare::transmitMsg (this=0x555555a45e40, msg=0x7fffffff1390 "")
    at src/Misc/MiddleWare.cpp:2554
 2  0x00005555555f71fd in zyn::MiddleWare::transmitMsgGui (this=0x555555a45e40, gui_id=0, msg=0x7fffffff1390 "")
    at src/Misc/MiddleWare.cpp:2587
 3  0x00005555555f73f6 in zyn::MiddleWare::transmitMsgGui (this=0x555555a45e40, gui_id=0, path=0x7fffffff18d0 "",
    args=0x5555558e83c4 "") at src/Misc/MiddleWare.cpp:2596
 4  0x00005555557a9adb in UI_Interface::requestValue (this=0x555555a6c0e0, s="")
    at src/UI/Connection.cpp:298
 5  0x00005555557f0199 in Fl_Osc_Widget::update (this=0x5555568af348)
    at src/UI/Fl_Osc_Widget.cpp:100
 6  0x00005555557aa664 in UI_Interface::damage (this=0x555555a6c0e0, path=0x7fffffff201c "/bank/")
    at src/UI/Connection.cpp:417
 7  0x00005555557a6668 in GUI::raiseUi (gui=0x555556743c70, message=0x7fffffff2010 "/damage")
    at src/UI/Connection.cpp:249
 8  0x00005555555f5303 in zyn::MiddleWareImpl::sendToRemote (this=0x555555a46460, rtmsg=0x7fffffff2010 "/damage",
    dest="GUI") at src/Misc/MiddleWare.cpp:2223
```