### PR TITLE
Self pm

### DIFF
--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1557,6 +1557,7 @@ Master::~Master()
 
     delete fft;
     delete memory;
+    delete sync;
 }
 
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1093,8 +1093,8 @@ void Part::ComputePartSmps()
                 for (auto &s : notePool.activeNotes(d)) {
                     if (s.note)
                         s.note->applyPartEffectToRelevantVoices(
-                            partefx[nefx]->efxoutl,
-                            partefx[nefx]->efxoutr);
+                            partfxinputl[nefx],
+                            partfxinputr[nefx]);
                 }
             }
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1093,8 +1093,8 @@ void Part::ComputePartSmps()
                 for (auto &s : notePool.activeNotes(d)) {
                     if (s.note)
                         s.note->applyPartEffectToRelevantVoices(
-                            partfxinputl[nefx],
-                            partfxinputr[nefx]);
+                            partefx[nefx]->efxoutl,
+                            partefx[nefx]->efxoutr);
                 }
             }
 

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -176,7 +176,7 @@ static const Ports voicePorts = {
 
     //Modulator Stuff
     rOption(PFMEnabled, rShort("mode"), rOptions(none, mix, ring, phase,
-                frequency, pulse), rLinear(0,127), rDefault(none), "Modulator mode"),
+                frequency, pulse, selfPM), rLinear(0,127), rDefault(none), "Modulator mode"),
     rParamI(PFMVoice,                   rShort("voice"), rDefault(-1),
         "Modulator Oscillator Selection"),
     rParamF(FMvolume,                   rShort("vol."),  rLinear(0.0, 100.0),

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1368,7 +1368,7 @@ void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
         const bool upgrade_3_0_3 = (xml.fileversion() < version_type(3,0,3)) ||
             (xml.getparreal("volume", -1) < 0);
 
-        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice - 1);
+        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice);
         if (upgrade_3_0_3) {
             int Pvolume = xml.getpar127("volume", 0);
             FMvolume    = 100.0f * Pvolume / 127.0f;

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1368,7 +1368,7 @@ void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
         const bool upgrade_3_0_3 = (xml.fileversion() < version_type(3,0,3)) ||
             (xml.getparreal("volume", -1) < 0);
 
-        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice);
+        PFMVoice      = xml.getpar("input_voice", PFMVoice, -2, nvoice);
         if (upgrade_3_0_3) {
             int Pvolume = xml.getpar127("volume", 0);
             FMvolume    = 100.0f * Pvolume / 127.0f;

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -21,7 +21,7 @@
 namespace zyn {
 
 enum class FMTYPE {
-    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD
+    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD, SELFPM_MOD
 };
 
 /*****************************************************************/

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -662,7 +662,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
     // Forbids the Modulation Voice to be greater or equal than voice
     for(int i = 0; i < NUM_VOICES; ++i)
-        if(NoteVoicePar[i].FMVoice >= i)
+        if(NoteVoicePar[i].FMVoice > i)
             NoteVoicePar[i].FMVoice = -1;
 
     // Voice Parameter init
@@ -826,7 +826,7 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
 
     // Forbids the Modulation Voice to be greater or equal than voice
     for(int i = 0; i < NUM_VOICES; ++i)
-        if(NoteVoicePar[i].FMVoice >= i)
+        if(NoteVoicePar[i].FMVoice > i)
             NoteVoicePar[i].FMVoice = -1;
 
     // Voice Parameter init
@@ -1367,7 +1367,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(NoteVoicePar[nvoice].FMVoice >= 0) {
+    if(NoteVoicePar[nvoice].FMVoice > 0) {
         //if I use VoiceOut[] as modullator
         int FMVoice = NoteVoicePar[nvoice].FMVoice;
         for(int k = 0; k < vce.unison_size; ++k) {

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -957,9 +957,9 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
     }
 
     for(int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
-        for(int i = nvoice + 1; i < NUM_VOICES; ++i)
+        for(int i = nvoice; i < NUM_VOICES; ++i)
             tmp[i] = 0;
-        for(int i = nvoice + 1; i < NUM_VOICES; ++i)
+        for(int i = nvoice; i < NUM_VOICES; ++i)
             if((NoteVoicePar[i].FMVoice == nvoice) && (tmp[i] == 0)) {
                 NoteVoicePar[nvoice].VoiceOut =
                     memory.valloc<float>(synth.buffersize);
@@ -1367,7 +1367,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(NoteVoicePar[nvoice].FMVoice > 0) {
+    if(NoteVoicePar[nvoice].FMVoice >= 0) {
         //if I use VoiceOut[] as modullator
         int FMVoice = NoteVoicePar[nvoice].FMVoice;
         for(int k = 0; k < vce.unison_size; ++k) {

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -439,7 +439,7 @@ void ADnote::setupVoiceMod(int nvoice, bool first_run)
     voice.FMFreqFixed  = param.PFMFixedFreq;
 
     //Triggers when a user enables modulation on a running voice
-    if(!first_run && (voice.FMEnabled != FMTYPE::NONE || voice.syncEnabled) && voice.FMSmp == NULL && voice.FMVoice < 0) {
+    if(!first_run && (voice.FMEnabled != FMTYPE::NONE || voice.syncEnabled) && voice.FMSmp == NULL && voice.FMVoice == -1) {
         param.FmGn->newrandseed(prng());
         voice.FMSmp = memory.valloc<float>(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES);
         memset(voice.FMSmp, 0, sizeof(float)*(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES));
@@ -710,7 +710,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
         /* Voice Modulation Parameters Init */
         if((NoteVoicePar[nvoice].FMEnabled != FMTYPE::NONE || NoteVoicePar[nvoice].syncEnabled)
-           && (NoteVoicePar[nvoice].FMVoice < 0)) {
+           && (NoteVoicePar[nvoice].FMVoice == -1)) {
             pars.VoicePar[nvoice].FmGn->newrandseed(prng());
 
             //Perform Anti-aliasing only on MIX or RING MODULATION
@@ -903,7 +903,7 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
         }
 
         /* Voice Modulation Parameters Init */
-        if((vce.FMEnabled != FMTYPE::NONE) && (vce.FMVoice < 0)) {
+        if((vce.FMEnabled != FMTYPE::NONE) && (vce.FMVoice == -1)) {
             param.FmGn->newrandseed(prng());
             vce.FMSmp = memory.valloc<float>(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES);
 
@@ -960,7 +960,7 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
         for(int i = nvoice; i < NUM_VOICES; ++i)
             tmp[i] = 0;
         for(int i = nvoice; i < NUM_VOICES; ++i)
-            if((NoteVoicePar[i].FMVoice == nvoice) && (tmp[i] == 0)) {
+            if((NoteVoicePar[i].FMVoice == nvoice ) && (tmp[i] == 0)) {
                 NoteVoicePar[nvoice].VoiceOut =
                     memory.valloc<float>(synth.buffersize);
                 tmp[i] = 1;
@@ -968,9 +968,11 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
 
         // Also allocate VoiceOut if this voice is configured to receive
         // Part post-effect feedback (FMVOICE_PART_FEEDBACK).
-        if(!NoteVoicePar[nvoice].VoiceOut &&
-           NoteVoicePar[nvoice].FMVoice == FMVOICE_PART_FEEDBACK) {
+
+        if(!NoteVoicePar[nvoice].VoiceOut && NoteVoicePar[nvoice].FMVoice == FMVOICE_PART_FEEDBACK) {
             NoteVoicePar[nvoice].VoiceOut = memory.valloc<float>(synth.buffersize);
+            //~ printf("NoteVoicePar[nvoice].FMVoice: FMVOICE_PART_FEEDBACK\n");
+
         }
 
         if(NoteVoicePar[nvoice].VoiceOut)
@@ -985,16 +987,20 @@ void ADnote::applyPartEffectToRelevantVoices(const float *efxoutl,
     // part-feedback (FMVoice == FMVOICE_PART_FEEDBACK). This allows
     // that voice to use the last-part-effect output as its modulation
     // source on the next processing block.
+    //~ printf("applyPartEffectToRelevantVoices\n");
     for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
         auto &voice = NoteVoicePar[nvoice];
         if (voice.FMVoice != FMVOICE_PART_FEEDBACK)
             continue;
         if (!voice.VoiceOut)
             continue; // allocation should have happened in init; be defensive
-
+        //~ printf("nvoice: %d\n", nvoice);
+        //~ printf("stereo: %d\n", stereo);
         if (stereo) {
-            for (int i = 0; i < synth.buffersize; ++i)
+            for (int i = 0; i < synth.buffersize; ++i) {
                 voice.VoiceOut[i] = efxoutl[i] + efxoutr[i];
+                //~ if(i==0) printf("voice.VoiceOut[i]: %f\n", voice.VoiceOut[i]);
+            }
         } else {
             // Mono: use left channel as the input
             memcpy(voice.VoiceOut, efxoutl, synth.bufferbytes);
@@ -1398,7 +1404,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(NoteVoicePar[nvoice].FMVoice >= 0) {
+    if(NoteVoicePar[nvoice].FMVoice != -1) {
         //if I use VoiceOut[] as modullator
         int FMVoice = NoteVoicePar[nvoice].FMVoice;
         for(int k = 0; k < vce.unison_size; ++k) {
@@ -1409,7 +1415,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
                                             i,
                                             synth.buffersize);
                 tw[i] = tw[i]
-                    * (1.0f - amp) + amp * NoteVoicePar[FMVoice].VoiceOut[i];
+                    * (1.0f - amp) + amp * NoteVoicePar[FMVoice==-2 ? nvoice : FMVoice].VoiceOut[i];
             }
         }
     }
@@ -1457,20 +1463,20 @@ inline void ADnote::ComputeVoiceOscillatorRingModulation(int nvoice)
         vce.FMnewamplitude = 1.0f;
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
-    if(NoteVoicePar[nvoice].FMVoice >= 0)
+    if(NoteVoicePar[nvoice].FMVoice != -1)
         // if I use VoiceOut[] as modullator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
+            int FMVoice = NoteVoicePar[nvoice].FMVoice;
             for(int i = 0; i < synth.buffersize; ++i) {
                 const float amp = INTERPOLATE_AMPLITUDE(vce.FMoldamplitude,
                                             vce.FMnewamplitude,
                                             i,
                                             synth.buffersize);
-                int FMVoice = NoteVoicePar[nvoice].FMVoice;
-                tw[i] *= (1.0f - amp) + amp * NoteVoicePar[FMVoice].VoiceOut[i];
+                tw[i] *= (1.0f - amp) + amp * NoteVoicePar[FMVoice==-2 ? nvoice : FMVoice].VoiceOut[i];
             }
         }
-    else
+    else if(NoteVoicePar[nvoice].FMVoice == -1)
         for(int k = 0; k < vce.unison_size; ++k) {
             int    poshiFM  = vce.oscposhiFM[k];
             float  posloFM  = vce.oscposloFM[k];
@@ -1512,12 +1518,12 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(vce.FMVoice >= 0)
+    if(vce.FMVoice != -1)
         // if I use VoiceOut[] as modulator
         // copy it to tmpwave_unison[][]
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : NoteVoicePar[nvoice].FMVoice].VoiceOut;
             memcpy(tw, smps, synth.bufferbytes);
         }
     else{
@@ -1597,11 +1603,11 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                                                               FMTYPE FMmode)
 {
     Voice& vce = NoteVoicePar[nvoice];
-    if(vce.FMVoice >= 0) {
+    if(vce.FMVoice != -1) {
         //if I use VoiceOut[] as modulator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : vce.FMVoice].VoiceOut;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 for (int i = 0; i < synth.buffersize; ++i)
                     tw[i] = -smps[i];
@@ -2169,7 +2175,7 @@ void ADnote::Voice::kill(Allocator &memory, const SYNTH_T &synth)
     memory.dealloc(FMFreqEnvelope);
     memory.dealloc(FMAmpEnvelope);
 
-    if((FMEnabled != FMTYPE::NONE) && (FMVoice < 0))
+    if((FMEnabled != FMTYPE::NONE) && (FMVoice == -1))
         memory.devalloc(FMSmp);
 
     if(VoiceOut)

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -971,7 +971,6 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
 
         if(!NoteVoicePar[nvoice].VoiceOut && NoteVoicePar[nvoice].FMVoice == FMVOICE_PART_FEEDBACK) {
             NoteVoicePar[nvoice].VoiceOut = memory.valloc<float>(synth.buffersize);
-            //~ printf("NoteVoicePar[nvoice].FMVoice: FMVOICE_PART_FEEDBACK\n");
 
         }
 
@@ -987,15 +986,12 @@ void ADnote::applyPartEffectToRelevantVoices(const float *efxoutl,
     // part-feedback (FMVoice == FMVOICE_PART_FEEDBACK). This allows
     // that voice to use the last-part-effect output as its modulation
     // source on the next processing block.
-    //~ printf("applyPartEffectToRelevantVoices\n");
     for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
         auto &voice = NoteVoicePar[nvoice];
         if (voice.FMVoice != FMVOICE_PART_FEEDBACK)
             continue;
         if (!voice.VoiceOut)
             continue; // allocation should have happened in init; be defensive
-        //~ printf("nvoice: %d\n", nvoice);
-        //~ printf("stereo: %d\n", stereo);
         if (stereo) {
             for (int i = 0; i < synth.buffersize; ++i) {
                 voice.VoiceOut[i] = efxoutl[i] + efxoutr[i];
@@ -1523,7 +1519,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
         // copy it to tmpwave_unison[][]
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : NoteVoicePar[nvoice].FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == FMVOICE_PART_FEEDBACK) ? nvoice : NoteVoicePar[nvoice].FMVoice].VoiceOut;
             memcpy(tw, smps, synth.bufferbytes);
         }
     else{
@@ -1607,7 +1603,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
         //if I use VoiceOut[] as modulator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : vce.FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == FMVOICE_PART_FEEDBACK) ? nvoice : vce.FMVoice].VoiceOut;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 for (int i = 0; i < synth.buffersize; ++i)
                     tw[i] = -smps[i];
@@ -1654,8 +1650,8 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                                                vce.FMnewamplitude,
                                                i,
                                                synth.buffersize);
-            vce.FMoldamplitude = vce.FMnewamplitude;
         }
+        vce.FMoldamplitude = vce.FMnewamplitude;
     } else {
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
@@ -2182,6 +2178,8 @@ void ADnote::Voice::kill(Allocator &memory, const SYNTH_T &synth)
         memset(VoiceOut, 0, synth.bufferbytes);
     //the buffer can't be safely deleted as it may be
     //an input to another voice
+
+    memory.devalloc(twold);
 
     Enabled = OFF;
 }

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -54,6 +54,17 @@ class ADnote:public SynthNote
 
 
         virtual SynthNote *cloneLegato(void) override;
+    // special FMVoice value meaning: use Part post-effect output as modulator
+    static const int FMVOICE_PART_FEEDBACK = -2;
+
+    /**Hook called by Part after an effect writes its output.
+     * Implementations may copy the post-effect buffers into internal
+     * per-voice buffers (e.g. VoiceOut) so they can be used as
+     * modulation sources on the next processing block.
+     * Default behaviour is to do nothing (see SynthNote).
+     */
+    virtual void applyPartEffectToRelevantVoices(const float *efxoutl,
+                                                 const float *efxoutr);
     private:
 
         void setupVoice(int nvoice);
@@ -252,6 +263,7 @@ class ADnote:public SynthNote
 
             // Voice Output used by other voices if use this as modullator
             float *VoiceOut;
+            
 
             /* Wave of the Voice */
             float *FMSmp;

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -120,6 +120,7 @@ class ADnote:public SynthNote
         float note_log2_freq;
         float velocity;
 
+
         ONOFFTYPE   NoteEnabled;
 
         /*****************************************************************/
@@ -315,6 +316,8 @@ class ADnote:public SynthNote
 
             //1 - if it is the fitst tick (used to fade in the sound)
             char firsttick;
+
+            float *twold;
 
         } NoteVoicePar[NUM_VOICES];
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -263,7 +263,7 @@ class ADnote:public SynthNote
 
             // Voice Output used by other voices if use this as modullator
             float *VoiceOut;
-            
+
 
             /* Wave of the Voice */
             float *FMSmp;

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -68,6 +68,14 @@ class SynthNote
 
         virtual SynthNote *cloneLegato(void) = 0;
 
+    /**
+     * Hook: deliver part-effect outputs to the note so the note
+     * implementation may copy them into internal buffers (e.g. VoiceOut).
+     * Called from Part after an insertion effect has produced its output.
+     * Default implementation does nothing.
+     */
+    virtual void applyPartEffectToRelevantVoices(const float *efxoutl, const float *efxoutr) { (void)efxoutl; (void)efxoutr; }
+
         /* For polyphonic aftertouch needed */
         void setVelocity(float velocity_);
 


### PR DESCRIPTION
adds a new FMtype selfPM where the osc is phase modulated by its own output via a feedback
inspired by the Nonlinear Labs C-15 shown in this vid: 
[https://youtu.be/Pl7BY4C9Cg4?si=v3cFXogosq1h_sZw&t=294](https://youtu.be/Pl7BY4C9Cg4?si=v3cFXogosq1h_sZw&t=294)

To make the zest GUI see it, you have to update the osc-bridge schema

`zynaddsubfx -U -I NULL -O NULL --dump-json-schema=../../mruby-zest-build/src/osc-bridge/schema/test.json`

because of our block processing architecture we cannot do the feedback over all, that makes the C-15 even more special.

GUI at 
https://github.com/mruby-zest/mruby-zest-build/pull/130



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new self modulation mode for ADnote oscillators (self-PM) to expand creative voice/modulator behavior.
  * Enabled part insertion effects to feed back into relevant voices, allowing post-effect output to drive per-voice modulation.

* **Improvements**
  * Enhanced modulation routing and parameter loading for safer, more predictable voice-to-modulator mappings.
  * Improved internal memory cleanup and voice effect/output allocation.

* **Bug Fixes**
  * Tightened FM modulation buffer regeneration and “invalid voice” handling to prevent incorrect updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->