### PR TITLE
add polyphonic portamento

### DIFF
--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -483,6 +483,12 @@ void NotePool::release(NoteDescriptor &d)
         s.note->releasekey();
 }
 
+void NotePool::finishPortamento(NoteDescriptor &d)
+{
+    for(auto s:activeNotes(d))
+        s.note->finishPortamento();
+}
+
 void NotePool::latch(NoteDescriptor &d)
 {
     d.setStatus(KEY_LATCHED);

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -149,6 +149,7 @@ class NotePool
         void releaseSustainingNotes(void);
         void releaseNote(note_t note);
         void release(NoteDescriptor &d);
+        void finishPortamento(NoteDescriptor &d);
         void latch(NoteDescriptor &d);
 
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -905,6 +905,18 @@ void Part::ReleaseAllKeys(void)
     }
 }
 
+/*
+ * Thos tells the portamento to jump to target frequency
+ */
+void Part::FinishPortamento(void)
+{
+    for(auto &desc:notePool.activeDesc()) {
+        if(!desc.playing())
+            continue;
+        notePool.finishPortamento(desc);
+    }
+}
+
 void Part::PolyphonicAftertouch(note_t note,
                 unsigned char velocity)
 {
@@ -977,6 +989,9 @@ void Part::SetController(unsigned int type, int par)
             ctl.setsustain(par);
             if(ctl.sustain.sustain == 0)
                 ReleaseSustainedKeys();
+            else if (true)//ctl.sustain.finishesPortamento)
+                FinishPortamento();
+
             break;
         case C_allsoundsoff:
             AllNotesOff(); //Panic

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -615,7 +615,7 @@ PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
             return nullptr;
         return memory.alloc<PortamentoRealtime>(
             this, memory,
-            [](PortamentoRealtime *realtime) {
+            []([[maybe_unused]]PortamentoRealtime *realtime) {
                 // Cleanup callback - nothing special to do here
             },
             portamento
@@ -712,7 +712,6 @@ bool Part::NoteOnInternal(note_t note,
     // still held down or sustained for the Portamento to activate
     // (that's like Legato).
     PortamentoRealtime *portamento_realtime = NULL;
-    //~ Portamento *portamentoptr = NULL;
 
     if (oldportamento && oldportamento->portamento.active) {
             oldportamentofreq_log2 += oldportamento->portamento.freqdelta_log2;
@@ -770,8 +769,6 @@ bool Part::NoteOnInternal(note_t note,
         if(Pkitmode != 0 && !item.validNote(note))
             continue;
 
-        //~ SynthParams pars{memory, ctl, synth, time, vel,
-            //~ portamentoptr, note_log2_freq, false, prng()};
         const int sendto = Pkitmode ? item.sendto() : 0;
 
         // Enforce voice limit, before we trigger new note

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -491,7 +491,7 @@ Part::~Part()
     }
 }
 
-static void assert_kit_sanity(const Part::Kit *kits)
+static void assert_kit_sanity([[maybe_unused]] const Part::Kit *kits)
 {
     for(int i=0; i<NUM_KIT_ITEMS; ++i) {
         //an enabled kit must have a corresponding parameter object

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -989,7 +989,7 @@ void Part::SetController(unsigned int type, int par)
             ctl.setsustain(par);
             if(ctl.sustain.sustain == 0)
                 ReleaseSustainedKeys();
-            else if (true)//ctl.sustain.finishesPortamento)
+            else if (ctl.sustain.stopsPortamento)
                 FinishPortamento();
 
             break;

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -409,6 +409,7 @@ void Part::defaults()
     Pvoicelimit = 0;
     defaultsinstrument();
     ctl.defaults();
+    recent_note_pool.clear();
 }
 
 void Part::defaultsinstrument()
@@ -492,16 +493,12 @@ Part::~Part()
 
 static void assert_kit_sanity(const Part::Kit *kits)
 {
-#ifdef NDEBUG
-    (void)kits;
-#else
     for(int i=0; i<NUM_KIT_ITEMS; ++i) {
         //an enabled kit must have a corresponding parameter object
         assert(!kits[i].Padenabled  || kits[i].adpars);
         assert(!kits[i].Ppadenabled || kits[i].padpars);
         assert(!kits[i].Psubenabled || kits[i].subpars);
     }
-#endif
 }
 
 static int kit_usage(const Part::Kit *kits, int note, int mode)
@@ -525,6 +522,142 @@ static int kit_usage(const Part::Kit *kits, int note, int mode)
     }
 
     return synth_usage;
+}
+
+RecentNotePool::RecentNote* RecentNotePool::getBestSource(float target_freq_log2,
+                                                         unsigned char mode)
+{
+    if (mode == FIFO) {
+        // Jupiter 8 style: Return oldest available note (FIFO order)
+        // This creates crossing glides when chord intervals change
+        uint32_t oldest_time = UINT32_MAX;
+        RecentNote* oldest = nullptr;
+
+        for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+            if (!recent_notes[i].available) continue;
+            if (recent_notes[i].timestamp < oldest_time) {
+                oldest = &recent_notes[i];
+                oldest_time = recent_notes[i].timestamp;
+            }
+        }
+
+        if (oldest) {
+            oldest->available = false; // Mark as used so next note gets next oldest
+        }
+        return oldest;
+
+    } else if (mode == LIFO) {
+        // Most recent released note for each new note (LIFO/stack order)
+        // Each released note is used once, starting with most recently released
+        uint32_t newest_time = 0;
+        RecentNote* newest = nullptr;
+
+        for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+            if (!recent_notes[i].available) continue;
+            float distance = fabsf(recent_notes[i].freq_log2 - target_freq_log2);
+            if(distance <= 0.01f ) continue;
+
+            if (recent_notes[i].timestamp > newest_time) {
+                newest = &recent_notes[i];
+                newest_time = recent_notes[i].timestamp;
+            }
+        }
+
+        if (newest) {
+            newest->available = false; // Mark as used - each note used only once
+        }
+        return newest;
+
+    } else { // SMART
+        // Strategy: find closest frequency match, or most recent if no close match
+        RecentNote* best = nullptr;
+        float best_distance = 999999.0f;
+        uint32_t best_time = 0;
+
+        for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+            if (!recent_notes[i].available) continue;
+
+            float distance = fabsf(recent_notes[i].freq_log2 - target_freq_log2);
+
+            // Prefer closer frequencies, but also consider recency
+            if (distance < best_distance ||
+                (distance < best_distance + 0.5f && recent_notes[i].timestamp > best_time)) {
+                best = &recent_notes[i];
+                best_distance = distance;
+                best_time = recent_notes[i].timestamp;
+            }
+        }
+
+        if (best) {
+            best->available = false; // Mark as used
+        }
+
+        return best;
+    }
+}
+
+// HELPER method to create portamento for individual notes
+PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
+                                                 bool isRunningNote)
+{
+    // Legacy mode prefers currently-playing notes as sources (to match old
+    // behaviour / KitTest expectations). Non-legacy modes prefer recent
+    // released notes first and fall back to playing notes.
+    const unsigned char mode = ctl.portamento.polyMode;
+
+    // Helper to create a PortamentoRealtime from oldfreq (base) and
+    // oldportamento-adjusted freq. The threshold check uses oldfreq_log2
+    // while the resulting initial freqdelta uses oldportamentofreq_log2.
+    auto make_from_source = [&](float oldfreq_log2, float oldportamentofreq_log2)->PortamentoRealtime* {
+        Portamento portamento(ctl, synth, isRunningNote, oldfreq_log2,
+                              oldportamentofreq_log2, target_freq_log2);
+        if (!portamento.active)
+            return nullptr;
+        return memory.alloc<PortamentoRealtime>(
+            this, memory,
+            [](PortamentoRealtime *realtime) {
+                // Cleanup callback - nothing special to do here
+            },
+            portamento
+        );
+    };
+
+    // Try recent released notes first (for non-legacy modes and as fallback)
+    RecentNotePool::RecentNote* source = recent_note_pool.getBestSource(target_freq_log2,
+                                            mode);
+    if (source) {
+        // RecentNotePool stores the final frequency (including any portamento
+        // offset). We attempt to recover the base frequency if the stored
+        // portamento_ptr is available; otherwise fall back to using the
+        // stored freq for both parameters (historic behaviour).
+        float oldportamentofreq = source->freq_log2;
+        float base_freq = source->freq_log2;
+        if (source->portamento_ptr) {
+            // If the released note stored a pointer to its realtime portamento,
+            // subtract its current freqdelta to recover the base frequency.
+            base_freq = source->freq_log2 - source->portamento_ptr->portamento.freqdelta_log2;
+        }
+        return make_from_source(base_freq, oldportamentofreq);
+    }
+
+    // For non-legacy modes try playing notes as a last resort
+    if (mode != LEGACY) {
+        for (auto &d : notePool.activeDesc()) {
+            if (!d.playing()) continue;
+
+            float base_freq = log2f(440.0f) + (d.note - 69.0f) / 12.0f;
+            float oldportamentofreq = base_freq;
+            if (d.portamentoRealtime && d.portamentoRealtime->portamento.active)
+                oldportamentofreq += d.portamentoRealtime->portamento.freqdelta_log2;
+
+            PortamentoRealtime* rt = make_from_source(base_freq, oldportamentofreq);
+            if (rt)
+                return rt;
+        }
+    }
+
+    // No suitable source available
+    return nullptr;
 }
 
 /*
@@ -567,6 +700,9 @@ bool Part::NoteOnInternal(note_t note,
     //Portamento
     lastnote = note;
 
+    // Advance time counter for recent note pool
+    recent_note_pool.advance();
+
     /* check if first note is played */
     if(oldfreq_log2 < 0.0f)
         oldfreq_log2 = note_log2_freq;
@@ -576,70 +712,44 @@ bool Part::NoteOnInternal(note_t note,
     // still held down or sustained for the Portamento to activate
     // (that's like Legato).
     PortamentoRealtime *portamento_realtime = NULL;
-    // If there is a currently ongoing glide, shift the starting point
-    // for any new portamento to where the current glide is right now
-    if (oldportamento && oldportamento->portamento.active)
-        oldportamentofreq_log2 += oldportamento->portamento.freqdelta_log2;
-    // Non-portamento settings and conditions say the note may have
-    // portamento, but it remains for Portamento.init to make the
-    // final decision depending on the portamento enable, threshold and
-    // other parameters.
-    Portamento portamento(ctl, synth, isRunningNote, oldfreq_log2, oldportamentofreq_log2, note_log2_freq);
-    if(portamento.active) {
-        // If we're doing legato and we already have a portamento structure,
-        // reuse it.
-        if (doingLegato && legatoportamento) {
-            portamento_realtime = legatoportamento;
-            portamento_realtime->portamento = portamento;
-        } else {
-            // Create new one if we don't already have one, or for each
-            // note in poly/mono mode
-            portamento_realtime = memory.alloc<PortamentoRealtime>
-                (this,
-                 memory,
-                 // Cleanup function: Destroy any references we might
-                 // have to the current realtime pointer so that it
-                 // can not be (re)used, with disastrous results.
-                 [](PortamentoRealtime *realtime)
-                    {
-                        assert(realtime);
-                        Part *part = static_cast<Part *>(realtime->handle);
-                        assert(part);
-                        if (realtime == part->oldportamento) {
-                            // Since the last note is going away, capture
-                            // the portamento:ed pitch offset to our saved
-                            // previous note. This will be our starting
-                            // point for the next portamento glide.
-                            if (realtime->portamento.active)
-                                part->oldportamentofreq_log2 +=
-                                    realtime->portamento.freqdelta_log2;
-                            part->oldportamento = NULL;
-                        }
-                        if (realtime == part->legatoportamento)
-                            part->legatoportamento = NULL;
-                    },
-                 portamento
-                );
-            if (doingLegato)
-                legatoportamento = portamento_realtime;
+    //~ Portamento *portamentoptr = NULL;
+
+    if (oldportamento && oldportamento->portamento.active) {
+            oldportamentofreq_log2 += oldportamento->portamento.freqdelta_log2;
         }
-    }
 
-    // Create the portamento pointer that we distribute to the synth notes
-    Portamento *portamentoptr = NULL;
-    if(portamento_realtime)
-        portamentoptr = &portamento_realtime->portamento;
 
-    // Save note freq and pointer to portamento state for next note
-    oldfreq_log2 = note_log2_freq;
-    oldportamentofreq_log2 = oldfreq_log2;
-    oldportamento = portamento_realtime;
+    Portamento portamento(ctl, synth, isRunningNote, oldfreq_log2,
+                         oldportamentofreq_log2, note_log2_freq);
 
-    //Adjust Existing Notes
-    if(doingLegato) {
-        LegatoParams pars = {vel, portamentoptr, note_log2_freq, true, prng()};
-        notePool.applyLegato(note, pars, portamento_realtime);
-        return true;
+    // For legato mode, use existing single portamento logic
+    if(doingLegato || ctl.portamento.polyMode == LEGACY) {
+
+        if(portamento.active) {
+            if (legatoportamento) {
+                portamento_realtime = legatoportamento;
+                portamento_realtime->portamento = portamento;
+            } else {
+                portamento_realtime = memory.alloc<PortamentoRealtime>
+                    (this, memory,
+                     [](PortamentoRealtime *realtime) {
+                         Part *part = static_cast<Part *>(realtime->handle);
+                         if (realtime == part->legatoportamento)
+                             part->legatoportamento = NULL;
+                     },
+                     portamento);
+                if(doingLegato) legatoportamento = portamento_realtime;
+            }
+        }
+
+        Portamento *portamentoptr = portamento_realtime ?
+            &portamento_realtime->portamento : nullptr;
+
+        if (doingLegato) {
+            LegatoParams pars = {vel, portamentoptr, note_log2_freq, true, prng()};
+            notePool.applyLegato(note, pars, portamento_realtime);
+            return true;
+        }
     }
 
     // We know now that we are not doing legato, so we destroy the reference
@@ -653,35 +763,59 @@ bool Part::NoteOnInternal(note_t note,
     if(Platchmode)
         notePool.releaseLatched();
 
-    //Create New Notes
+    //Create New Notes with individual portamento instances
     for(uint8_t i = 0; i < NUM_KIT_ITEMS; ++i) {
         ScratchString pre = prefix;
         auto &item = kit[i];
         if(Pkitmode != 0 && !item.validNote(note))
             continue;
 
-        SynthParams pars{memory, ctl, synth, time, vel,
-            portamentoptr, note_log2_freq, false, prng()};
+        //~ SynthParams pars{memory, ctl, synth, time, vel,
+            //~ portamentoptr, note_log2_freq, false, prng()};
         const int sendto = Pkitmode ? item.sendto() : 0;
 
         // Enforce voice limit, before we trigger new note
         limit_voices(note);
 
         try {
-            if(item.Padenabled)
+            PortamentoRealtime* port_rt = portamento_realtime ? portamento_realtime : createPortamentoForNote(note_log2_freq,
+                                                                 isRunningNote);
+            Portamento* port_ptr = port_rt ? &port_rt->portamento : nullptr;
+
+    // Save note freq and pointer to portamento state for next note
+    oldfreq_log2 = note_log2_freq;
+    oldportamentofreq_log2 = oldfreq_log2;
+    oldportamento = port_rt;
+
+            if(item.Padenabled) {
+
+                SynthParams pars{memory, ctl, synth, time, vel,
+                    port_ptr, note_log2_freq, false, prng()};
+
                 notePool.insertNote(note, sendto,
                         {memory.alloc<ADnote>(kit[i].adpars, pars,
-                            wm, (pre+"kit"+i+"/adpars/").c_str, constPowerMixing), 0, i},
-                                    portamento_realtime);
-            if(item.Psubenabled)
+                            wm, (pre+"kit"+i+"/adpars/").c_str), 0, i},
+                                    port_rt);
+            }
+
+            if(item.Psubenabled) {
+                SynthParams pars{memory, ctl, synth, time, vel,
+                    port_ptr, note_log2_freq, false, prng()};
+
                 notePool.insertNote(note, sendto,
-                        {memory.alloc<SUBnote>(kit[i].subpars, pars, wm, (pre+"kit"+i+"/subpars/").c_str, constPowerMixing), 1, i},
-                                    portamento_realtime);
-            if(item.Ppadenabled)
+                        {memory.alloc<SUBnote>(kit[i].subpars, pars, wm,
+                            (pre+"kit"+i+"/subpars/").c_str), 1, i},
+                                    port_rt);
+            }
+            if(item.Ppadenabled) {
+                SynthParams pars{memory, ctl, synth, time, vel,
+                    port_ptr, note_log2_freq, false, prng()};
+
                 notePool.insertNote(note, sendto,
                         {memory.alloc<PADnote>(kit[i].padpars, pars, interpolation, wm,
-                            (pre+"kit"+i+"/padpars/").c_str, constPowerMixing), 2, i},
-                                    portamento_realtime);
+                            (pre+"kit"+i+"/padpars/").c_str), 2, i},
+                                    port_rt);
+            }
         } catch (std::bad_alloc & ba) {
             std::cerr << "dropped new note: " << ba.what() << std::endl;
         }
@@ -704,6 +838,23 @@ bool Part::NoteOnInternal(note_t note,
  */
 void Part::NoteOff(note_t note) //release the key
 {
+    // Before releasing notes, record their frequencies for portamento
+    for(auto &desc:notePool.activeDesc()) {
+        if(desc.note != note || !desc.playing())
+            continue;
+
+        // Calculate base frequency from MIDI note
+        float base_freq_log2 = (desc.note - 69.0f) / 12.0f + log2f(440.0f);
+
+        // Add any portamento offset
+        float final_freq_log2 = base_freq_log2;
+        if (desc.portamentoRealtime && desc.portamentoRealtime->portamento.active) {
+            final_freq_log2 += desc.portamentoRealtime->portamento.freqdelta_log2;
+        }
+        recent_note_pool.addReleasedNote(final_freq_log2, desc.portamentoRealtime);
+    }
+
+    // Original NoteOff logic continues...
     // This note is released, so we remove it from the list.
     if(!monomemEmpty())
         monomemPop(note);
@@ -1061,8 +1212,8 @@ void Part::ComputePartSmps()
     for(auto &d:notePool.activeDesc()) {
         d.age++;
         for(auto &s:notePool.activeNotes(d)) {
-            STACKALLOC(float, tmpoutr, synth.buffersize);
-            STACKALLOC(float, tmpoutl, synth.buffersize);
+            float tmpoutr[synth.buffersize];
+            float tmpoutl[synth.buffersize];
             auto &note = *s.note;
             note.noteout(&tmpoutl[0], &tmpoutr[0]);
 
@@ -1519,7 +1670,7 @@ void Part::getfromXML(XMLwrapper& xml)
         // portamento.automode will default to off, so no need to do anything
         // here).
         if (upgrade_3_0_7 && !Ppolymode)
-            ctl.portamento.automode = true;
+            ctl.portamento.automode = 1;
         xml.exitbranch();
     }
 }
@@ -1538,6 +1689,48 @@ uint8_t Part::Kit::sendto(void) const
 bool Part::Kit::validNote(char note) const
 {
     return !Pmuted && Penabled && inRange((uint8_t)note, Pminkey, Pmaxkey);
+}
+
+void RecentNotePool::addReleasedNote(float freq_log2,
+                                    PortamentoRealtime *port_ptr)
+{
+    recent_notes[write_index] = {
+        freq_log2, port_ptr,
+        current_time, true
+    };
+    write_index = (write_index + 1) % MAX_RECENT_NOTES;
+}
+
+
+bool RecentNotePool::hasRecentNotes() const
+{
+    for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+        if (recent_notes[i].available) return true;
+    }
+    return false;
+}
+
+void RecentNotePool::clear()
+{
+    for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+        recent_notes[i].available = false;
+        recent_notes[i].portamento_ptr = nullptr;
+    }
+    write_index = 0;
+}
+
+void RecentNotePool::cleanup()
+{
+    // Remove entries older than ~5 seconds TBD: use samplerate
+    const uint32_t max_age = 240000;
+
+    for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
+        if (recent_notes[i].available &&
+            (current_time - recent_notes[i].timestamp) > max_age) {
+            recent_notes[i].available = false;
+            recent_notes[i].portamento_ptr = nullptr;
+        }
+    }
 }
 
 }

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -309,7 +309,8 @@ Part::Part(Allocator &alloc, const SYNTH_T &synth_, const AbsTime &time_, Sync* 
     time(time_),
     sync(sync_),
     gzip_compression(gzip_compression),
-    interpolation(interpolation)
+    interpolation(interpolation),
+    recent_note_pool(synth_, time_)
 {
     loaded_file[0] = '\0';
 
@@ -583,7 +584,6 @@ RecentNotePool::RecentNote* RecentNotePool::getBestSource(float target_freq_log2
         // Strategy: find closest frequency match, or most recent if no close match
         RecentNote* best = nullptr;
         float best_distance = 999999.0f;
-        uint32_t best_time = 0;
 
         for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
             if (!recent_notes[i].available) continue;
@@ -591,11 +591,9 @@ RecentNotePool::RecentNote* RecentNotePool::getBestSource(float target_freq_log2
             float distance = fabsf(recent_notes[i].freq_log2 - target_freq_log2);
 
             // Prefer closer frequencies, but also consider recency
-            if (distance < best_distance ||
-                (distance < best_distance + 0.5f && recent_notes[i].timestamp > best_time)) {
+            if (distance < best_distance) {
                 best = &recent_notes[i];
                 best_distance = distance;
-                best_time = recent_notes[i].timestamp;
             }
         }
 
@@ -726,9 +724,6 @@ bool Part::NoteOnInternal(note_t note,
 
     //Portamento
     lastnote = note;
-
-    // Advance time counter for recent note pool
-    recent_note_pool.advance();
 
     /* check if first note is played */
     if(oldfreq_log2 < 0.0f)
@@ -1739,12 +1734,25 @@ bool Part::Kit::validNote(char note) const
     return !Pmuted && Penabled && inRange((uint8_t)note, Pminkey, Pmaxkey);
 }
 
+
+RecentNotePool::RecentNotePool(const SYNTH_T &synth_, const AbsTime &time_) :
+     write_index(0),
+    synth(synth_),
+    time(time_),
+    max_age(10 * synth.samplerate) {
+
+        for(int i = 0; i < MAX_RECENT_NOTES; ++i) {
+            recent_notes[i].available = false;
+            recent_notes[i].portamento_ptr = nullptr;
+        }
+    }
+
 void RecentNotePool::addReleasedNote(float freq_log2,
                                     PortamentoRealtime *port_ptr)
 {
     recent_notes[write_index] = {
         freq_log2, port_ptr,
-        current_time, true
+        time.time(), true
     };
     write_index = (write_index + 1) % MAX_RECENT_NOTES;
 }
@@ -1769,12 +1777,9 @@ void RecentNotePool::clear()
 
 void RecentNotePool::cleanup()
 {
-    // Remove entries older than ~5 seconds TBD: use samplerate
-    const uint32_t max_age = 240000;
-
     for (int i = 0; i < MAX_RECENT_NOTES; ++i) {
         if (recent_notes[i].available &&
-            (current_time - recent_notes[i].timestamp) > max_age) {
+            (time.time() - recent_notes[i].timestamp) > max_age) {
             recent_notes[i].available = false;
             recent_notes[i].portamento_ptr = nullptr;
         }

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -816,6 +816,7 @@ bool Part::NoteOnInternal(note_t note,
                         {memory.alloc<ADnote>(kit[i].adpars, pars,
                             wm, (pre+"kit"+i+"/adpars/").c_str), 0, i},
                                     port_rt);
+                inserted_any = true;
             }
 
             if(item.Psubenabled) {
@@ -826,6 +827,7 @@ bool Part::NoteOnInternal(note_t note,
                         {memory.alloc<SUBnote>(kit[i].subpars, pars, wm,
                             (pre+"kit"+i+"/subpars/").c_str), 1, i},
                                     port_rt);
+                inserted_any = true;
             }
             if(item.Ppadenabled) {
                 SynthParams pars{memory, ctl, synth, time, vel,
@@ -835,11 +837,11 @@ bool Part::NoteOnInternal(note_t note,
                         {memory.alloc<PADnote>(kit[i].padpars, pars, interpolation, wm,
                             (pre+"kit"+i+"/padpars/").c_str), 2, i},
                                     port_rt);
+                inserted_any = true;
             }
         } catch (std::bad_alloc & ba) {
             std::cerr << "dropped new note: " << ba.what() << std::endl;
         }
-        inserted_any = true;
         //Partial Kit Use
         if(isNonKit() || (isSingleKit() && item.active()))
             break;

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -623,6 +623,9 @@ PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
     // released notes first and fall back to playing notes.
     const unsigned char mode = ctl.portamento.polyMode;
 
+    if (mode == LEGACY)
+        return nullptr;
+
     // Helper to create a PortamentoRealtime from oldfreq (base) and
     // oldportamento-adjusted freq. The threshold check uses oldfreq_log2
     // while the resulting initial freqdelta uses oldportamentofreq_log2.
@@ -658,21 +661,20 @@ PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
         return make_from_source(base_freq, oldportamentofreq);
     }
 
-    // For non-legacy modes try playing notes as a last resort
-    if (mode != LEGACY) {
-        for (auto &d : notePool.activeDesc()) {
-            if (!d.playing()) continue;
+    // Try playing notes as a last resort
+    for (auto &d : notePool.activeDesc()) {
+        if (!d.playing()) continue;
 
-            float base_freq = log2f(440.0f) + (d.note - 69.0f) / 12.0f;
-            float oldportamentofreq = base_freq;
-            if (d.portamentoRealtime && d.portamentoRealtime->portamento.active)
-                oldportamentofreq += d.portamentoRealtime->portamento.freqdelta_log2;
+        float base_freq = log2f(440.0f) + (d.note - 69.0f) / 12.0f;
+        float oldportamentofreq = base_freq;
+        if (d.portamentoRealtime && d.portamentoRealtime->portamento.active)
+            oldportamentofreq += d.portamentoRealtime->portamento.freqdelta_log2;
 
-            PortamentoRealtime* rt = make_from_source(base_freq, oldportamentofreq);
-            if (rt)
-                return rt;
-        }
+        PortamentoRealtime* rt = make_from_source(base_freq, oldportamentofreq);
+        if (rt)
+            return rt;
     }
+
 
     // No suitable source available
     return nullptr;
@@ -787,6 +789,10 @@ bool Part::NoteOnInternal(note_t note,
     if(Platchmode)
         notePool.releaseLatched();
 
+    PortamentoRealtime* port_rt = portamento_realtime ? portamento_realtime : createPortamentoForNote(note_log2_freq,                                                         isRunningNote);
+    Portamento* port_ptr = port_rt ? &port_rt->portamento : nullptr;
+
+    bool inserted_any = false;
     //Create New Notes with individual portamento instances
     for(uint8_t i = 0; i < NUM_KIT_ITEMS; ++i) {
         ScratchString pre = prefix;
@@ -800,14 +806,6 @@ bool Part::NoteOnInternal(note_t note,
         limit_voices(note);
 
         try {
-            PortamentoRealtime* port_rt = portamento_realtime ? portamento_realtime : createPortamentoForNote(note_log2_freq,
-                                                                 isRunningNote);
-            Portamento* port_ptr = port_rt ? &port_rt->portamento : nullptr;
-
-    // Save note freq and pointer to portamento state for next note
-    oldfreq_log2 = note_log2_freq;
-    oldportamentofreq_log2 = oldfreq_log2;
-    oldportamento = port_rt;
 
             if(item.Padenabled) {
 
@@ -841,11 +839,20 @@ bool Part::NoteOnInternal(note_t note,
         } catch (std::bad_alloc & ba) {
             std::cerr << "dropped new note: " << ba.what() << std::endl;
         }
-
+        inserted_any = true;
         //Partial Kit Use
         if(isNonKit() || (isSingleKit() && item.active()))
             break;
     }
+
+    // Save note freq and pointer to portamento state for next note
+    if (inserted_any) {
+        oldfreq_log2 = note_log2_freq;
+        oldportamentofreq_log2 = oldfreq_log2;
+        oldportamento = port_rt;
+    }
+
+
 
     if(isLegatoMode())
         notePool.upgradeToLegato();

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -636,8 +636,12 @@ PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
             return nullptr;
         return memory.alloc<PortamentoRealtime>(
             this, memory,
-            []([[maybe_unused]]PortamentoRealtime *realtime) {
-                // Cleanup callback - nothing special to do here
+            [](PortamentoRealtime *realtime) {
+                Part *part = static_cast<Part *>(realtime->handle);
+                if(realtime == part->oldportamento)
+                    part->oldportamento = NULL;
+                if(realtime == part->legatoportamento)
+                    part->legatoportamento = NULL;
             },
             portamento
         );
@@ -760,6 +764,8 @@ bool Part::NoteOnInternal(note_t note,
                     (this, memory,
                      [](PortamentoRealtime *realtime) {
                          Part *part = static_cast<Part *>(realtime->handle);
+                         if (realtime == part->oldportamento)
+                             part->oldportamento = NULL;
                          if (realtime == part->legatoportamento)
                              part->legatoportamento = NULL;
                      },

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -636,12 +636,8 @@ PortamentoRealtime* Part::createPortamentoForNote(float target_freq_log2,
             return nullptr;
         return memory.alloc<PortamentoRealtime>(
             this, memory,
-            [](PortamentoRealtime *realtime) {
-                Part *part = static_cast<Part *>(realtime->handle);
-                if(realtime == part->oldportamento)
-                    part->oldportamento = NULL;
-                if(realtime == part->legatoportamento)
-                    part->legatoportamento = NULL;
+            []([[maybe_unused]]PortamentoRealtime *realtime) {
+                // Cleanup callback - nothing special to do here
             },
             portamento
         );
@@ -764,8 +760,6 @@ bool Part::NoteOnInternal(note_t note,
                     (this, memory,
                      [](PortamentoRealtime *realtime) {
                          Part *part = static_cast<Part *>(realtime->handle);
-                         if (realtime == part->oldportamento)
-                             part->oldportamento = NULL;
                          if (realtime == part->legatoportamento)
                              part->legatoportamento = NULL;
                      },

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -122,6 +122,8 @@ class Part
         void ReleaseSustainedKeys() REALTIME; //this is called when the sustain pedal is released
         void ReleaseAllKeys() REALTIME; //this is called on AllNotesOff controller
 
+        void FinishPortamento() REALTIME;
+
         /* The synthesizer part output */
         void ComputePartSmps() REALTIME; //Part output
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -25,6 +25,54 @@
 namespace zyn {
 
 struct PortamentoParams;
+
+class RecentNotePool {
+    public:
+    struct RecentNote {
+        float freq_log2;
+        PortamentoRealtime *portamento_ptr;
+        uint32_t timestamp;  // frame counter for aging
+        bool available;
+    };
+
+    static const int MAX_RECENT_NOTES = 16;  // configurable
+    RecentNote recent_notes[MAX_RECENT_NOTES];
+    int write_index;
+    uint32_t current_time;
+
+public:
+    RecentNotePool() : write_index(0), current_time(0) {
+        for(int i = 0; i < MAX_RECENT_NOTES; ++i) {
+            recent_notes[i].available = false;
+            recent_notes[i].portamento_ptr = nullptr;
+        }
+    }
+
+    // Add a note when it's released
+    void addReleasedNote(float freq_log2,
+                        PortamentoRealtime *port_ptr);
+
+    // Get best matching source for a new note
+    RecentNote* getBestSource(float target_freq_log2, unsigned char mode);
+
+    // Clean up old entries and advance time
+    void advance() {
+        current_time++;
+        if(current_time % 1000 == 0) // cleanup every ~20 seconds at 48kHz
+            cleanup();
+    }
+
+    // Check if we have any recent notes for portamento
+    bool hasRecentNotes() const;
+
+    // Clear all recent notes
+    void clear();
+
+private:
+    void cleanup();
+};
+
+
 /** Part implementation*/
 class Part
 {
@@ -218,6 +266,20 @@ class Part
            monomem[] is used in conjunction with the list to
            store the velocity and logarithmic frequency values of a given note.
            For example 'monomem[note].velocity' would be the velocity value of the note 'note'.*/
+
+        // ADD polyphonic tracking:
+        RecentNotePool recent_note_pool;
+
+        // Keep legato portamento separate as it works differently
+        // PortamentoRealtime *legatoportamento;  // KEEP this existing member
+
+        // Helper methods for polyphonic portamento
+        // If isRunningNote is true, this indicates there is at least one running
+        // note in the pool (useful for legacy behavior which prefers running
+        // notes as portamento sources).
+        PortamentoRealtime* createPortamentoForNote(float target_freq_log2,
+                               bool isRunningNote);
+        void recordNoteRelease(float freq_log2, PortamentoRealtime *port_ptr);
 
         float oldfreq_log2;    // previous note pitch, used for portamento
         float oldportamentofreq_log2; // previous portamento pitch

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -31,22 +31,16 @@ class RecentNotePool {
     struct RecentNote {
         float freq_log2;
         PortamentoRealtime *portamento_ptr;
-        uint32_t timestamp;  // frame counter for aging
+        int64_t timestamp;  // frame counter for aging
         bool available;
     };
+
+    RecentNotePool(const SYNTH_T &synth_, const AbsTime &time_);
 
     static const int MAX_RECENT_NOTES = 16;  // configurable
     RecentNote recent_notes[MAX_RECENT_NOTES];
     int write_index;
-    uint32_t current_time;
-
-public:
-    RecentNotePool() : write_index(0), current_time(0) {
-        for(int i = 0; i < MAX_RECENT_NOTES; ++i) {
-            recent_notes[i].available = false;
-            recent_notes[i].portamento_ptr = nullptr;
-        }
-    }
+    int64_t current_time;
 
     // Add a note when it's released
     void addReleasedNote(float freq_log2,
@@ -54,13 +48,6 @@ public:
 
     // Get best matching source for a new note
     RecentNote* getBestSource(float target_freq_log2, unsigned char mode);
-
-    // Clean up old entries and advance time
-    void advance() {
-        current_time++;
-        if(current_time % 1000 == 0) // cleanup every ~20 seconds at 48kHz
-            cleanup();
-    }
 
     // Check if we have any recent notes for portamento
     bool hasRecentNotes() const;
@@ -70,6 +57,9 @@ public:
 
 private:
     void cleanup();
+    const SYNTH_T &synth;
+    const AbsTime &time;
+    int64_t max_age;
 };
 
 
@@ -269,8 +259,7 @@ class Part
            store the velocity and logarithmic frequency values of a given note.
            For example 'monomem[note].velocity' would be the velocity value of the note 'note'.*/
 
-        // ADD polyphonic tracking:
-        RecentNotePool recent_note_pool;
+
 
         // Keep legato portamento separate as it works differently
         // PortamentoRealtime *legatoportamento;  // KEEP this existing member
@@ -298,6 +287,8 @@ class Part
         Sync* sync;
         const int &gzip_compression, &interpolation;
         bool constPowerMixing = true;
+        // ADD polyphonic tracking:
+        RecentNotePool recent_note_pool;
 };
 
 }

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -86,6 +86,8 @@ const rtosc::Ports Controller::ports = {
         "Portamento MIDI Receive"),
     rToggle(portamento.portamento, rDefault(false),
         "Portamento Enable"),
+    rOption(portamento.polyMode, rOptions(POLYMODES), rDefault(LEGACY),
+        "Polyphonic Mode"),
     rToggle(portamento.automode, rDefault(true),
         "Portamento Auto mode"),
     rParamZyn(portamento.time,          rShort("time"), rDefault(64),
@@ -144,6 +146,7 @@ void Controller::defaults()
     NRPN.receive                 = true;
 
     portamento.portamento        = false;
+    portamento.polyMode          = LEGACY;
     portamento.automode          = true;
     portamento.proportional      = false;
     portamento.propRate          = 80;

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -82,6 +82,8 @@ const rtosc::Ports Controller::ports = {
         "Sustain MIDI Receive"),
 #undef rChangeCb
 #define rChangeCb rChangeCbBase
+    rToggle(sustain.stopsPortamento, rDefault(false),
+        "Sustain finishes Portamento"),
     rToggle(portamento.receive, rShort("prt.rcv"), rDefault(true),
         "Portamento MIDI Receive"),
     rToggle(portamento.portamento, rDefault(false),

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -88,6 +88,8 @@ const rtosc::Ports Controller::ports = {
         "Portamento Enable"),
     rOption(portamento.polyMode, rOptions(POLYMODES), rDefault(LEGACY),
         "Polyphonic Mode"),
+    rParamZyn(portamento.glissando,     rShort("gliss"), rDefault(0),
+        "Portamento <-> Glissando"),
     rToggle(portamento.automode, rDefault(true),
         "Portamento Auto mode"),
     rParamZyn(portamento.time,          rShort("time"), rDefault(64),

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -456,8 +456,10 @@ void Controller::add2XML(XMLwrapper& xml)
     xml.addparbool("fm_amp_receive", fmamp.receive);
     xml.addparbool("volume_receive", volume.receive);
     xml.addparbool("sustain_receive", sustain.receive);
-
+    xml.addparbool("sustain_stops_portamento", sustain.stopsPortamento);
     xml.addparbool("portamento_receive", portamento.receive);
+    xml.addpar("portamento_polymode", portamento.polyMode);
+    xml.addpar("portamento_glissando", portamento.glissando);
     xml.addpar("portamento_time", portamento.time);
     xml.addpar("portamento_pitchthresh", portamento.pitchthresh);
     xml.addpar("portamento_pitchthreshtype", portamento.pitchthreshtype);
@@ -501,9 +503,14 @@ void Controller::getfromXML(XMLwrapper& xml)
                                      volume.receive);
     sustain.receive = xml.getparbool("sustain_receive",
                                       sustain.receive);
-
+    sustain.stopsPortamento = xml.getparbool("sustain_stops_portamento",
+                                             sustain.stopsPortamento);
     portamento.receive = xml.getparbool("portamento_receive",
                                          portamento.receive);
+    portamento.polyMode = xml.getpar("portamento_polymode",
+                                     portamento.polyMode, LEGACY, SMART);
+    portamento.glissando = xml.getpar127("portamento_glissando",
+                                         portamento.glissando);
     portamento.automode = xml.getparbool("portamento_auto",
                                          portamento.automode);
     portamento.time = xml.getpar127("portamento_time",

--- a/src/Params/Controller.cpp
+++ b/src/Params/Controller.cpp
@@ -147,10 +147,12 @@ void Controller::defaults()
     fmamp.receive                = true;
     volume.receive               = true;
     sustain.receive              = true;
+    sustain.stopsPortamento      = false;
     NRPN.receive                 = true;
 
     portamento.portamento        = false;
     portamento.polyMode          = LEGACY;
+    portamento.glissando         = 0;
     portamento.automode          = true;
     portamento.proportional      = false;
     portamento.propRate          = 80;

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -21,6 +21,15 @@
 
 namespace zyn {
 
+#define POLYMODES LEGACY, \
+FIFO, \
+LIFO, \
+SMART
+
+enum {
+    POLYMODES
+};
+
 /**(Midi) Controllers implementation*/
 class Controller
 {
@@ -135,6 +144,7 @@ class Controller
             //parameters
             int  data;
             bool portamento;
+            unsigned char polyMode = LEGACY;
             /**Whether the portamento midi events are received or not*/
             bool receive;
             /**Whether legato playing is needed to get portamento*/

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -138,6 +138,7 @@ class Controller
         struct { //Sustain
             int  data, sustain;
             bool receive;
+            bool finishesPortamento;
         } sustain;
 
         struct { /**<Portamento*/

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -145,6 +145,7 @@ class Controller
             int  data;
             bool portamento;
             unsigned char polyMode = LEGACY;
+            unsigned char glissando = 0;
             /**Whether the portamento midi events are received or not*/
             bool receive;
             /**Whether legato playing is needed to get portamento*/

--- a/src/Params/Controller.h
+++ b/src/Params/Controller.h
@@ -138,7 +138,7 @@ class Controller
         struct { //Sustain
             int  data, sustain;
             bool receive;
-            bool finishesPortamento;
+            bool stopsPortamento;
         } sustain;
 
         struct { /**<Portamento*/

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -281,7 +281,7 @@ protected:
       Load a program.
       The host may call this function from any context, including realtime processing.
     */
-    void loadProgram(uint32_t index) override
+    void loadProgram([[maybe_unused]]uint32_t index) override
     {
         setState(nullptr, defaultState);
         /*

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -2068,6 +2068,16 @@ void ADnote::releasekey()
 }
 
 /*
+ * finish Portamento
+ */
+void ADnote::finishPortamento()
+{
+    if (portamento) {
+            portamento->finish();
+        }
+}
+
+/*
  * Check if the note is finished
  */
 bool ADnote::finished() const

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -114,6 +114,8 @@ class ADnote:public SynthNote
         /**Fadein in a way that removes clicks but keep sound "punchy"*/
         inline void fadein(float *smps) const;
 
+        void finishPortamento(void) override;
+
         //GLOBALS
         ADnoteParameters &pars;
         unsigned char     stereo; //if the note is stereo (allows note Panning)

--- a/src/Synth/Portamento.cpp
+++ b/src/Synth/Portamento.cpp
@@ -137,6 +137,14 @@ void Portamento::update(void)
     }
 }
 
+void Portamento::finish(void)
+{
+    if(!active)
+        return;
+    dx *= 100.0f;
+    update();
+}
+
 PortamentoRealtime::PortamentoRealtime(void *handle,
                                        Allocator &memory,
                                        std::function<void(PortamentoRealtime *)> cleanup,

--- a/src/Synth/Portamento.cpp
+++ b/src/Synth/Portamento.cpp
@@ -74,6 +74,8 @@ void Portamento::init(const Controller &ctl,
     if((ctl.portamento.pitchthreshtype == 1) && (absdeltanotefreq_log2 + 0.00001f < threshold_log2))
         return;
 
+    q = ctl.portamento.glissando / 127.0f;  // 0..1
+
     x = 0.0f;
     dx = synth.buffersize_f / (portamentotime * synth.samplerate_f);
     origfreqdelta_log2 = deltafreq_log2;
@@ -87,12 +89,52 @@ void Portamento::update(void)
     if(!active)
         return;
 
+    // Original portamento progress (0 to 1 over total time)
     x += dx;
     if(x > 1.0f) {
-        x    = 1.0f;
+        x = 1.0f;
         active = false;
     }
-    freqdelta_log2 = (1.0f - x) * origfreqdelta_log2;
+
+    // Parameter: 0 = pure portamento (continuous), 1 = pure glissando (stepped)
+    float hold_ratio = q;  // 0..1
+
+    // Calculate number of semitone steps
+    float total_semitones = fabsf(origfreqdelta_log2 * 12.0f);
+    int num_steps = (int)ceilf(total_semitones);
+
+    if(num_steps > 0 && hold_ratio > 0.001f) {
+        // Position within current step (0..1)
+        float step_position = x * num_steps;
+        int current_step = (int)floorf(step_position);
+        float step_progress = step_position - current_step;  // 0..1 within step
+
+        // Glissando curve: hold phase + slide phase
+        float effective_progress;
+
+        if(step_progress < hold_ratio) {
+            // Hold phase: constant frequency at current semitone
+            effective_progress = (float)current_step / num_steps;
+        } else {
+            // Slide phase: transition to next semitone
+            float slide_progress = (step_progress - hold_ratio) / (1.0f - hold_ratio);
+            effective_progress = (current_step + slide_progress) / num_steps;
+        }
+
+        // Ensure we reach exactly 1.0 at the end
+        if(current_step >= num_steps - 1) {
+            if(step_progress >= hold_ratio) {
+                // Final slide completed
+                effective_progress = 1.0f;
+            }
+        }
+
+        freqdelta_log2 = (1.0f - effective_progress) * origfreqdelta_log2;
+
+    } else {
+        // Original portamento (continuous)
+        freqdelta_log2 = (1.0f - x) * origfreqdelta_log2;
+    }
 }
 
 PortamentoRealtime::PortamentoRealtime(void *handle,

--- a/src/Synth/Portamento.h
+++ b/src/Synth/Portamento.h
@@ -58,6 +58,7 @@ class Portamento {
                   float newfreq_log2);
         /**Update portamento's freqrap to next value based upon dx*/
         void update(void);
+        void finish(void);
         /**if the portamento is in use*/
         bool active;
         /**this value is used to compute the actual portamento

--- a/src/Synth/Portamento.h
+++ b/src/Synth/Portamento.h
@@ -75,6 +75,8 @@ class Portamento {
         float dx;
         /** this is used for computing freqdelta_log2 value from x*/
         float origfreqdelta_log2;
+        /** q morphs from portamento at 0.0 to glissando at 1.0 */
+        float q;
 };
 
 class PortamentoRealtime {

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -186,6 +186,11 @@ void SynthNote::setFilterCutoff(float value)
         (value - 64.0f) * ctl.filtercutoff.depth / 4096.0f * 3.321928f;
 }
 
+void SynthNote::finishPortamento(void)
+{
+
+}
+
 float SynthNote::getFilterCutoffRelFreq(void)
 {
     if (filtercutoff_relfreq.isSet() == false)

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -77,6 +77,7 @@ class SynthNote
         /* For per-note filter cutoff */
         void setFilterCutoff(float);
         float getFilterCutoffRelFreq(void);
+        virtual void finishPortamento(void);
 
         /* Random numbers with own seed */
         float getRandomFloat();

--- a/src/Tests/guitar-adnote.xmz
+++ b/src/Tests/guitar-adnote.xmz
@@ -923,7 +923,10 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="fm_amp_receive" value="yes" />
 <par_bool name="volume_receive" value="no" />
 <par_bool name="sustain_receive" value="yes" />
+<par_bool name="sustain_stops_portamento" value="no" />
 <par_bool name="portamento_receive" value="yes" />
+<par name="portamento_polymode" value="0" />
+<par name="portamento_glissando" value="0" />
 <par name="portamento_time" value="64" />
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />
@@ -1197,7 +1200,10 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="fm_amp_receive" value="yes" />
 <par_bool name="volume_receive" value="yes" />
 <par_bool name="sustain_receive" value="yes" />
+<par_bool name="sustain_stops_portamento" value="no" />
 <par_bool name="portamento_receive" value="yes" />
+<par name="portamento_polymode" value="0" />
+<par name="portamento_glissando" value="0" />
 <par name="portamento_time" value="64" />
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />
@@ -3576,7 +3582,10 @@ version-revision="7" ZynAddSubFX-author="Nasca Octavian Paul">
 <par_bool name="fm_amp_receive" value="yes" />
 <par_bool name="volume_receive" value="yes" />
 <par_bool name="sustain_receive" value="yes" />
+<par_bool name="sustain_stops_portamento" value="no" />
 <par_bool name="portamento_receive" value="yes" />
+<par name="portamento_polymode" value="0" />
+<par name="portamento_glissando" value="0" />
 <par name="portamento_time" value="64" />
 <par name="portamento_pitchthresh" value="3" />
 <par name="portamento_pitchthreshtype" value="1" />


### PR DESCRIPTION
This PR adds 

1. polyphonic portamento, allowing independent glide effects for each note in polyphonic mode.

Previously, portamento in ZynAddSubFX was limited to monophonic legato playing. This implementation enables per-note portamento by introducing a RecentNotePool that tracks released notes and their frequencies (including active portamento offsets). When a new note is played, the pool selects a suitable source note based on the selected mode:

- LEGACY: Original behavior (portamento only if previous note is still held)
- FIFO: Oldest released note (Jupiter-8 style)
- LIFO: Most recently released note
- SMART: Combines frequency proximity and recency

Each note gets its own PortamentoRealtime instance when needed, allowing simultaneous glides on different notes. The feature is backward-compatible (default mode = LEGACY) and configurable via the new portamento.polyMode parameter.

2. glissando gliding in semitone steps instead of linear
The glissando parameter keeps the glide linear at 0.0 and carves increasingly larger steps until 1.0

3. finish on sustain mode
It the mode is enabled, the portamento/glissando is finished (by speeding it uü to prevent discontinuities) when the sustain pedal is pressed down.

Zest GUI at https://github.com/mruby-zest/mruby-zest-build/pull/131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polyphonic portamento modes (LEGACY, FIFO, LIFO, SMART) for smarter glide source selection
  * New glissando parameter enabling stepped (hold-and-slide) glide behavior
  * "Sustain finishes Portamento" option to end glides when sustain stops
  * Explicit "Finish Portamento" action to reliably complete active glides
  * Recent-note recall to use released/active notes as glide sources for smoother transitions

* **Tests**
  * Updated instrument test data to include new portamento parameters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->