### PR TITLE
more intialialization and hpf latency compensation

### DIFF
--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -112,11 +112,10 @@ void CombFilter::setfreq_and_q(float freq, float q)
     setq(q);
 }
 
-void CombFilter::setfreq(float freq)
+void CombFilter::setfreq(float freq_)
 {
-    float ff = limit(freq, 25.0f, 40000.0f);
-    freq = ff;
-    delay = ((float)samplerate)/ff - lpfDelay - hpfDelay;
+    freq = limit(freq_, 25.0f, 40000.0f);
+    delay = ((float)samplerate)/freq - lpfDelay - hpfDelay;
 }
 
 void CombFilter::setq(float q_)

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -8,22 +8,41 @@
 #include "CombFilter.h"
 #include "AnalogFilter.h"
 
-// theory from `Introduction to Digital Filters with Audio Applications'', by Julius O. Smith III, (September 2007 Edition).
-// https://www.dsprelated.com/freebooks/filters/Analysis_Digital_Comb_Filter.html
+/**
+ * @file CombFilter.cpp
+ * @brief Implementation of a digital comb filter with variable feedback and interpolation.
+ * * Theory based on "Introduction to Digital Filters with Audio Applications" by Julius O. Smith III.
+ * This implementation supports both Feed-Forward (FIR) and Feed-Backward (IIR) structures.
+ * @see https://www.dsprelated.com/freebooks/filters/Analysis_Digital_Comb_Filter.html
+ */
 
-namespace zyn{
+namespace zyn {
 
+/**
+ * @brief Constructor for the CombFilter.
+ * Initializes ring buffers for input and output and calculates the required buffer size
+ * based on the lowest supported frequency (25Hz) to ensure enough delay memory.
+ * * @param alloc Pointer to the real-time safe Memory Allocator.
+ * @param Ftype Filter type (determines feed-forward and feed-backward gains).
+ * @param Ffreq Initial frequency in Hz.
+ * @param Fq Filter quality factor (resonance/feedback strength).
+ * @param srate System sample rate.
+ * @param bufsize Size of the processing audio block.
+ * @param Plpf_ Initial Low-Pass Filter coefficient for the feedback loop.
+ * @param Phpf_ Initial High-Pass Filter coefficient for the feedback loop.
+ */
 CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float Fq,
     unsigned int srate, int bufsize, unsigned char Plpf_, unsigned char Phpf_)
-    :Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), Plpf(127), Phpf(0),
+    : Filter(srate, bufsize), gain(1.0f), q(Fq), type(Ftype), Plpf(127), Phpf(0),
     lpf(nullptr), hpf(nullptr), memory(*alloc)
 {
-    //worst case: looking back from smps[0] at 25Hz using higher order interpolation
-    mem_size = (int)ceilf((float)samplerate/25.0) + buffersize + 2; // 2178 at 48000Hz and 256Samples
-    input = (float*)memory.alloc_mem(mem_size*sizeof(float));
-    output = (float*)memory.alloc_mem(mem_size*sizeof(float));
-    memset(input, 0, mem_size*sizeof(float));
-    memset(output, 0, mem_size*sizeof(float));
+    // Worst case: looking back from smps[0] at 25Hz using higher order interpolation.
+    // Calculation: (Samplerate / 25Hz) + buffer safety margin.
+    mem_size = (int)ceilf((float)samplerate / 25.0) + buffersize + 2;
+    input = (float*)memory.alloc_mem(mem_size * sizeof(float));
+    output = (float*)memory.alloc_mem(mem_size * sizeof(float));
+    memset(input, 0, mem_size * sizeof(float));
+    memset(output, 0, mem_size * sizeof(float));
 
     setfreq_and_q(Ffreq, q);
     settype(type);
@@ -31,145 +50,162 @@ CombFilter::CombFilter(Allocator *alloc, unsigned char Ftype, float Ffreq, float
     sethpf(Phpf_);
 }
 
+/**
+ * @brief Destructor. Releases allocated memory for buffers and internal filters.
+ */
 CombFilter::~CombFilter(void)
 {
     memory.dealloc(input);
     memory.dealloc(output);
-    memory.dealloc(lpf);
-    memory.dealloc(hpf);
+    if (lpf) memory.dealloc(lpf);
+    if (hpf) memory.dealloc(hpf);
 }
 
-
+/**
+ * @brief Pade approximation of the hyperbolic tangent function.
+ * Used as a saturation function for the feedback loop to prevent clipping/instability
+ * and to add "analog-style" warmth to high resonance settings.
+ * * @param x Input signal value.
+ * @return float Approximated tanh(x) result bounded to [-1.0, +1.0].
+ */
 inline float CombFilter::tanhX(const float x)
 {
-    // Pade approximation of tanh(x) bound to [-1 .. +1]
-    // https://mathr.co.uk/blog/2017-09-06_approximating_hyperbolic_tangent.html
-    const float x2 = x*x;
-    return (x*(105.0f+10.0f*x2)/(105.0f+(45.0f+x2)*x2)); //
+    const float x2 = x * x;
+    return (x * (105.0f + 10.0f * x2) / (105.0f + (45.0f + x2) * x2));
 }
 
+/**
+ * @brief Linear interpolation between samples in the ring buffer.
+ * Essential for sub-sample delay times, allowing for precise frequency tuning.
+ * * @param smp Pointer to the ring buffer (input or output).
+ * @param pos Floating point index position within the buffer.
+ * @return float Interpolated sample value.
+ */
 inline float CombFilter::sampleLerp(float *smp, float pos) {
-    int poshi = (int)pos; // integer part (pos >= 0)
-    float poslo = pos - (float) poshi; // decimal part
+    int poshi = (int)pos;
+    float poslo = pos - (float)poshi;
     int poshi_next = (poshi + 1) % mem_size;
-    // linear interpolation between samples
-    return smp[poshi] + poslo * (smp[poshi_next]-smp[poshi]);
+    return smp[poshi] + poslo * (smp[poshi_next] - smp[poshi]);
 }
 
+/**
+ * @brief Main audio processing routine.
+ * Implements the comb filter difference equation by mixing the input signal with
+ * a delayed version of itself. Includes saturation and optional filtering in the loop.
+ * * @param smp The audio buffer to be processed "in-place".
+ */
 void CombFilter::filterout(float *smp)
 {
+    // 1. Copy incoming samples into the input ring buffer (handling wrap-around)
     int endSize = mem_size - inputIndex;
-    if (endSize < buffersize)
-    {
-        // Copy the part of the samples that fit at the end of the buffer
+    if (endSize < buffersize) {
         memcpy(&input[inputIndex], smp, endSize * sizeof(float));
-        // Copy the remaining samples to the beginning of the buffer
         memcpy(&input[0], &smp[endSize], (buffersize - endSize) * sizeof(float));
-    }
-    else
-    {
-        // Copy new input samples to the buffer
+    } else {
         memcpy(&input[inputIndex], smp, buffersize * sizeof(float));
     }
 
-    for (int i = 0; i < buffersize; i++)
-    {
-        // Calculate the feedback sample positions in the input buffer
+    // 2. Sample-by-sample loop
+    for (int i = 0; i < buffersize; i++) {
         const float inputPos = fmodf(inputIndex + i - delay + mem_size, mem_size);
-        // Calculate the feedback sample positions in the output buffer
         const float outputPos = fmodf(outputIndex - delay + mem_size, mem_size);
 
-        // Feedback berechnen
+        // Calculate feedback with forward and backward gains
         float feedback = tanhX(
             gainfwd * sampleLerp(input, inputPos) -
             gainbwd * sampleLerp(output, outputPos));
 
-        // Optional: Feedback filtern
+        // Optional: Apply filtering within the feedback loop
         if (lpf) lpf->filterSample(feedback);
         if (hpf) hpf->filterSample(feedback);
 
         smp[i] = smp[i] * gain + feedback;
 
-        // Output in Ringpuffer schreiben
+        // Write resulting sample to the output ring buffer
         output[outputIndex] = smp[i];
 
-        // Output-Gain anwenden
+        // Apply output stage gain
         smp[i] *= outgain;
 
-        // increase ringbuffer index with turnaround
         outputIndex = (outputIndex + 1) % mem_size;
-
     }
 
-    //update inputIndex
+    // Update input pointer for next block
     inputIndex = (inputIndex + buffersize) % mem_size;
-
 }
 
+/**
+ * @brief Sets both frequency and resonance (Q) simultaneously.
+ */
 void CombFilter::setfreq_and_q(float freq, float q)
 {
     setfreq(freq);
     setq(q);
 }
 
+/**
+ * @brief Sets the filter frequency.
+ * Adjusts the delay length based on the frequency, compensating for the
+ * phase delays introduced by the internal LPF and HPF to keep the filter in tune.
+ * * @param freq_ Frequency in Hz (limited between 25Hz and 40kHz).
+ */
 void CombFilter::setfreq(float freq_)
 {
     freq = limit(freq_, 25.0f, 40000.0f);
-    delay = ((float)samplerate)/freq - lpfDelay - hpfDelay;
+    delay = ((float)samplerate) / freq - lpfDelay - hpfDelay;
 }
 
+/**
+ * @brief Sets the filter resonance (Q).
+ * Uses a cube-root scaling factor for a more musical/logarithmic feel of the parameter.
+ */
 void CombFilter::setq(float q_)
 {
-    q = cbrtf(0.0015f*q_);
+    q = cbrtf(0.0015f * q_);
     settype(type);
 }
 
+/**
+ * @brief Sets the input gain of the filter.
+ * @param dBgain Gain in decibels.
+ */
 void CombFilter::setgain(float dBgain)
 {
     gain = dB2rap(dBgain);
 }
 
+/**
+ * @brief Configures the comb filter topology.
+ * Determines how much of the forward (FIR) and backward (IIR) signal is mixed
+ * into the output, and controls the phase (positive/negative feedback).
+ * * @param type_ Type index (0-5) representing different routing modes.
+ */
 void CombFilter::settype(unsigned char type_)
 {
     type = type_;
-    switch (type)
-    {
-        case 0:
-        default:
-            gainfwd = 0.0f;
-            gainbwd = q;
-            break;
-        case 1:
-            gainfwd = q;
-            gainbwd = 0.0f;
-            break;
-        case 2:
-            gainfwd = q;
-            gainbwd = q;
-            break;
-        case 3:
-            gainfwd = 0.0f;
-            gainbwd = -q;
-            break;
-        case 4:
-            gainfwd = -q;
-            gainbwd = 0.0f;
-            break;
-        case 5:
-            gainfwd = -q;
-            gainbwd = -q;
-            break;
+    switch (type) {
+        case 0: default: gainfwd = 0.0f;  gainbwd = q;     break; // IIR Positive
+        case 1:          gainfwd = q;     gainbwd = 0.0f;  break; // FIR Positive
+        case 2:          gainfwd = q;     gainbwd = q;     break; // Mix Positive
+        case 3:          gainfwd = 0.0f;  gainbwd = -q;    break; // IIR Negative
+        case 4:          gainfwd = -q;    gainbwd = 0.0f;  break; // FIR Negative
+        case 5:          gainfwd = -q;    gainbwd = -q;    break; // Mix Negative
     }
 }
 
+/**
+ * @brief Configures the High-Pass Filter within the feedback loop.
+ * Also calculates the group delay of the HPF to offset the main delay line
+ * and maintain frequency accuracy.
+ * * @param _Phpf HPF parameter value (0 = Off, >0 = frequency).
+ */
 void CombFilter::sethpf(unsigned char _Phpf)
 {
     if(Phpf == _Phpf) return;
     Phpf = _Phpf;
-    if(Phpf == 0) { //No HighPass
-        memory.dealloc(hpf);
-
-        hpfDelay = 0.0f; // Reset delay
+    if(Phpf == 0) {
+        if (hpf) { memory.dealloc(hpf); hpf = nullptr; }
+        hpfDelay = 0.0f;
     } else {
         const float fr = expf(sqrtf(Phpf / 127.0f) * logf(10000.0f)) + 20.0f;
 
@@ -179,19 +215,24 @@ void CombFilter::sethpf(unsigned char _Phpf)
             hpf->setfreq(fr);
 
         const float a = expf(-2.0f * PI * fr / samplerate);
-
+        // Approximation of filter phase delay for compensation
         hpfDelay = -a / (1.0f + a);
-
     }
     setfreq(freq);
 }
 
+/**
+ * @brief Configures the Low-Pass Filter within the feedback loop.
+ * Similar to sethpf, this adjusts lpfDelay to ensure the comb filter's
+ * fundamental frequency remains stable regardless of LPF settings.
+ * * @param _Plpf LPF parameter value (127 = Off, <127 = frequency).
+ */
 void CombFilter::setlpf(unsigned char _Plpf)
 {
     if(Plpf == _Plpf) return;
     Plpf = _Plpf;
-    if(Plpf == 127) { //No LowPass
-        memory.dealloc(lpf);
+    if(Plpf == 127) {
+        if (lpf) { memory.dealloc(lpf); lpf = nullptr; }
         lpfDelay = 0.0f;
     } else {
         const float fr = expf(sqrtf(Plpf / 127.0f) * logf(25000.0f)) + 40.0f;
@@ -199,11 +240,12 @@ void CombFilter::setlpf(unsigned char _Plpf)
             lpf = memory.alloc<AnalogFilter>(0, fr, 1, 0, samplerate, buffersize);
         else
             lpf->setfreq(fr);
-        const float a = expf(-2.0f * PI * fr / samplerate);
-        lpfDelay = a / (1.0f - a);
 
+        const float a = expf(-2.0f * PI * fr / samplerate);
+        // Approximation of filter phase delay for compensation
+        lpfDelay = a / (1.0f - a);
     }
     setfreq(freq);
 }
 
-};
+} // end namespace zyn

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -102,8 +102,8 @@ inline float feedback_saturate_direct(float x, float knee) {
 inline float CombFilter::sampleLerp(float *smp, float pos) {
     int poshi = (int)pos;
     float poslo = pos - (float)poshi;
-    int poshi_next = poshi + 1;
-    if (poshi_next == mem_size)
+    unsigned int poshi_next = poshi + 1;
+    if (poshi_next >= mem_size)
         poshi_next = 0;
 
     return smp[poshi] + poslo * (smp[poshi_next] - smp[poshi]);
@@ -155,7 +155,10 @@ void CombFilter::filterout(float *smp)
         // Apply output stage gain
         smp[i] *= outgain;
 
-        outputIndex = (outputIndex + 1) % mem_size;
+        outputIndex += 1;
+        if (outputIndex >= mem_size)
+            outputIndex -= mem_size;
+
         inputPos += 1.0f;
         if (inputPos >= mem_size)
             inputPos -= mem_size;
@@ -196,7 +199,7 @@ void CombFilter::setfreq(float freq_)
 void CombFilter::updatedelay()
 {
     delay = ((float)samplerate) / freq - lpfDelay - hpfDelay;
-    delay = limit((float)samplerate/40000.0f, 1.0f, delay);
+    delay = max(delay, (float)samplerate/40000.0f);
 }
 
 /**

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -168,15 +168,24 @@ void CombFilter::setfreq_and_q(float freq, float q)
 
 /**
  * @brief Sets the filter frequency.
- * Adjusts the delay length based on the frequency, compensating for the
- * phase delays introduced by the internal LPF and HPF to keep the filter in tune.
+ * Sets the frequency and updates delay accordingly
  * * @param freq_ Frequency in Hz (limited between 25Hz and 40kHz).
  */
 void CombFilter::setfreq(float freq_)
 {
     freq = limit(freq_, 25.0f, 40000.0f);
+    updatedelay();
+}
+/**
+ * @brief Updates the delay length.
+ * Adjusts the delay length based on the frequency, compensating for the
+ * phase delays introduced by the internal LPF and HPF to keep the filter in tune.
+ * * @param freq_ Frequency in Hz (limited between 25Hz and 40kHz).
+ */
+void CombFilter::updatedelay()
+{
     delay = ((float)samplerate) / freq - lpfDelay - hpfDelay;
-    delay = max((float)samplerate/40000.0f, delay);
+    delay = limit((float)samplerate/40000.0f, 1.0f, delay);
 }
 
 /**
@@ -242,7 +251,7 @@ void CombFilter::sethpf(unsigned char _Phpf)
         // Approximation of filter phase delay for compensation
         hpfDelay = -a / (1.0f + a);
     }
-    setfreq(freq);
+    updatedelay();
 }
 
 /**
@@ -269,7 +278,7 @@ void CombFilter::setlpf(unsigned char _Plpf)
         // Approximation of filter phase delay for compensation
         lpfDelay = a / (1.0f - a);
     }
-    setfreq(freq);
+    updatedelay();
 }
 
 } // end namespace zyn

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -115,10 +115,17 @@ void CombFilter::filterout(float *smp)
         memcpy(&input[inputIndex], smp, buffersize * sizeof(float));
     }
 
+
+    float inputPos = inputIndex - delay;
+    if (inputPos < 0.0f)
+        inputPos += mem_size;
+
+    float outputPos = outputIndex - delay;
+    if (outputPos < 0.0f)
+        outputPos += mem_size;
+
     // 2. Sample-by-sample loop
     for (int i = 0; i < buffersize; i++) {
-        const float inputPos = fmodf(inputIndex + i - delay + mem_size, mem_size);
-        const float outputPos = fmodf(outputIndex - delay + mem_size, mem_size);
 
         // Calculate feedback with forward and backward gains
         float feedback = feedback_saturate_direct(
@@ -138,6 +145,12 @@ void CombFilter::filterout(float *smp)
         smp[i] *= outgain;
 
         outputIndex = (outputIndex + 1) % mem_size;
+        inputPos += 1.0f;
+        if (inputPos >= mem_size)
+            inputPos -= mem_size;
+        outputPos += 1.0f;
+        if (outputPos >= mem_size)
+            outputPos -= mem_size;
     }
 
     // Update input pointer for next block

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -74,6 +74,16 @@ inline float CombFilter::tanhX(const float x)
     return (x * (105.0f + 10.0f * x2) / (105.0f + (45.0f + x2) * x2));
 }
 
+// Adjustable knee for different characters
+// knee > 1.0: softer limiting (later saturation)
+// knee < 1.0: harder limiting (earlier compression)
+// Use this if you want to control both threshold AND gain
+inline float feedback_saturate_direct(float x, float knee) {
+    // Lower knee = earlier saturation + lower gain
+    // Higher knee = later saturation + higher gain
+    return x / sqrtf(x * x + knee * knee);
+}
+
 /**
  * @brief Linear interpolation between samples in the ring buffer.
  * Essential for sub-sample delay times, allowing for precise frequency tuning.
@@ -111,9 +121,9 @@ void CombFilter::filterout(float *smp)
         const float outputPos = fmodf(outputIndex - delay + mem_size, mem_size);
 
         // Calculate feedback with forward and backward gains
-        float feedback = tanhX(
+        float feedback = feedback_saturate_direct(
             gainfwd * sampleLerp(input, inputPos) -
-            gainbwd * sampleLerp(output, outputPos));
+            gainbwd * sampleLerp(output, outputPos), 1.0f);
 
         // Optional: Apply filtering within the feedback loop
         if (lpf) lpf->filterSample(feedback);

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -153,6 +153,7 @@ void CombFilter::setfreq(float freq_)
 {
     freq = limit(freq_, 25.0f, 40000.0f);
     delay = ((float)samplerate) / freq - lpfDelay - hpfDelay;
+    delay = max((float)samplerate/40000.0f, delay);
 }
 
 /**

--- a/src/DSP/CombFilter.cpp
+++ b/src/DSP/CombFilter.cpp
@@ -74,10 +74,18 @@ inline float CombFilter::tanhX(const float x)
     return (x * (105.0f + 10.0f * x2) / (105.0f + (45.0f + x2) * x2));
 }
 
-// Adjustable knee for different characters
-// knee > 1.0: softer limiting (later saturation)
-// knee < 1.0: harder limiting (earlier compression)
-// Use this if you want to control both threshold AND gain
+/**
+ * @brief Direct feedback saturation with adjustable knee characteristic.
+ * Used as a saturation function for the feedback loop to control compression
+ * threshold and character. Lower knee values result in earlier saturation and
+ * lower gain, while higher knee values produce later saturation and higher gain.
+ *
+ * @param x Input signal value.
+ * @param knee Saturation knee parameter. Values > 1.0 produce softer limiting
+ *            (later saturation), values < 1.0 produce harder limiting
+ *            (earlier compression).
+ * @return float Saturated output value bounded to the range defined by the knee.
+ */
 inline float feedback_saturate_direct(float x, float knee) {
     // Lower knee = earlier saturation + lower gain
     // Higher knee = later saturation + higher gain
@@ -94,7 +102,10 @@ inline float feedback_saturate_direct(float x, float knee) {
 inline float CombFilter::sampleLerp(float *smp, float pos) {
     int poshi = (int)pos;
     float poslo = pos - (float)poshi;
-    int poshi_next = (poshi + 1) % mem_size;
+    int poshi_next = poshi + 1;
+    if (poshi_next == mem_size)
+        poshi_next = 0;
+
     return smp[poshi] + poslo * (smp[poshi_next] - smp[poshi]);
 }
 

--- a/src/DSP/CombFilter.h
+++ b/src/DSP/CombFilter.h
@@ -52,8 +52,10 @@ class CombFilter:public Filter
 
         float gainfwd;
         float gainbwd;
-        float delay;
-        float lpfDelay;
+        float delay = 0.0f;
+        float lpfDelay = 0.0f;
+        float hpfDelay = 0.0f;
+        float freq = 440.0f;
 
         class AnalogFilter *lpf, *hpf; //filters
 

--- a/src/DSP/CombFilter.h
+++ b/src/DSP/CombFilter.h
@@ -48,6 +48,7 @@ class CombFilter:public Filter
 
         float tanhX(const float x);
         float sampleLerp(float *smp, float pos);
+        void updatedelay();
 
 
         float gainfwd;

--- a/src/DSP/CombFilter.h
+++ b/src/DSP/CombFilter.h
@@ -64,7 +64,7 @@ class CombFilter:public Filter
         unsigned int outputIndex=0;
 
         Allocator &memory;
-        int mem_size;
+        unsigned int mem_size;
 
 };
 

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -281,7 +281,7 @@ protected:
       Load a program.
       The host may call this function from any context, including realtime processing.
     */
-    void loadProgram(uint32_t index) override
+    void loadProgram([[maybe_unused]]uint32_t index) override
     {
         setState(nullptr, defaultState);
         /*


### PR DESCRIPTION
fixes some uninitializes memory issues in comb filter
adds group delay compensation for feedback hpf in comb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More stable comb-filter tuning with enforced minimum delay and automatic resync after filter changes; improved feedback saturation to reduce audio artifacts.

* **Refactor**
  * Safer memory handling and more reliable ring-buffer read/write and wrap logic for audio stability.

* **New Features**
  * Improved filter stability when enabling/disabling high/low-pass stages with phase-delay compensation.

* **Documentation**
  * Expanded file-level comments for clearer filter behavior.

* **Style**
  * Added initializers and a minor parameter annotation to reduce compiler warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->