### PR TITLE
Fmaa rb Add kernel-based anti-aliasing to ADnote oscillators

### DIFF
--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -1082,6 +1082,22 @@ void Part::ComputePartSmps()
     for(int nefx = 0; nefx < NUM_PART_EFX; ++nefx) {
         if(!Pefxbypass[nefx]) {
             partefx[nefx]->out(partfxinputl[nefx], partfxinputr[nefx]);
+
+            // Deliver this effect's output to notes that were routed to this
+            // effect. Notes can pick up the post-effect signal (e.g. copy
+            // it into their VoiceOut buffers) by implementing the
+            // applyPartEffectToRelevantVoices() hook.
+            for (auto &d : notePool.activeDesc()) {
+                if ((int)d.sendto != nefx)
+                    continue;
+                for (auto &s : notePool.activeNotes(d)) {
+                    if (s.note)
+                        s.note->applyPartEffectToRelevantVoices(
+                            partfxinputl[nefx],
+                            partfxinputr[nefx]);
+                }
+            }
+
             if(Pefxroute[nefx] == 2)
                 for(int i = 0; i < synth.buffersize; ++i) {
                     partfxinputl[nefx + 1][i] += partefx[nefx]->efxoutl[i];

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -82,13 +82,13 @@ inline void HannWindow(int N, float* w ) {
 void windowedsinc(float fc, float gain, int N, float *h) {
 
   // Compute the sinc filter.
-  float s[N];
+  STACKALLOC(float, s, N);
   for (int n = 0; n < N; n++) {
     s[n] = (n == (N-1)/2) ? 1 : sin(2 * M_PI * fc * (n - (N - 1) / 2)) / (2 * M_PI * fc * (n - (N - 1) / 2));
   }
 
   // Compute the window.
-  float w[N];
+  STACKALLOC(float, w, N);
   BlackmanHarrisWindow(N, w);
   //~ HannWindow(N, w);
 
@@ -153,7 +153,7 @@ float getdetune(unsigned char type,
     int fdetune = finedetune - 8192;
 
     switch(type) {
-//	case 1: is used for the default (see below)
+//  case 1: is used for the default (see below)
         case 2:
             cdet   = fabsf(cdetune * 10.0f);
             findet = fabsf(fdetune / 8192.0f) * 10.0f;

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -44,6 +44,76 @@ bool isPlugin = false;
 
 prng_t prng_state = 0x1234;
 
+inline void BlackmanHarrisWindow(int N, float* w )
+{
+    const float a0      = 0.35875f;
+    const float a1      = 0.48829f;
+    const float a2      = 0.14128f;
+    const float a3      = 0.01168f;
+
+    for(auto i = 0; i < N; i++ )
+    {
+        w[i]   = a0 - (a1 * cosf( (2.0f * M_PI * i) / (N - 1) )) + (a2 * cosf( (4.0f * M_PI * i) / (N - 1) )) - (a3 * cosf( (6.0f * M_PI * i) / (N - 1) ));
+    }
+}
+
+inline float i0(float x) {
+  return 1 + x * x / 4;
+}
+
+// Compute the Kaiser window.
+inline void KaiserWindow(float beta, int N, float* w ) {
+    for (int n = 0; n < N; n++) {
+        w[n] = i0(beta * sqrt(1 - pow(2 * n / (N - 1) - 1, 2))) / i0(beta);
+    }
+}
+
+inline void HannWindow(int N, float* w ) {
+    for (int n = 0; n < N; n++) {
+        w[n] = 0.5 * (1 - cos(2 * M_PI * n / (N - 1)));
+    }
+}
+
+// Compute a windowed sinc kernel
+//
+// Args:
+//   fc:    Cutoff frequency as a fraction of the sampling rate (in (0, 0.5))
+//   gain:  gain factor of the kernel
+//   h:     Output array
+//
+void windowedsinc(float fc, float gain, int N, float *h) {
+
+  // Compute the sinc filter.
+  float s[N];
+  for (int n = 0; n < N; n++) {
+    s[n] = (n == (N-1)/2) ? 1 : sin(2 * M_PI * fc * (n - (N - 1) / 2)) / (2 * M_PI * fc * (n - (N - 1) / 2));
+  }
+
+  // Compute the window.
+  float w[N];
+  BlackmanHarrisWindow(N, w);
+  //~ HannWindow(N, w);
+
+
+  // Multiply the sinc filter by the window.
+  for (int n = 0; n < N; n++) {
+    h[n] = s[n] * w[n];
+  }
+
+  // summarize the kernel to get gain.
+  float sum = 0;
+  for (int n = 0; n < N; n++) {
+    sum += h[n];
+  }
+
+  // divide by measured gain, multiply wanted gain.
+  for (int n = 0; n < N; n++) {
+    const float factor = gain/sum;
+    h[n] *= factor;
+  }
+}
+
+
 /*
  * Transform the velocity according the scaling parameter (velocity sensing)
  */

--- a/src/Misc/Util.cpp
+++ b/src/Misc/Util.cpp
@@ -84,13 +84,13 @@ inline void HannWindow(int N, float* w ) {
 void windowedsinc(float fc, float gain, int N, float *h) {
 
   // Compute the sinc filter.
-  float s[N];
+  STACKALLOC(float, s, N);
   for (int n = 0; n < N; n++) {
     s[n] = (n == (N-1)/2) ? 1 : sin(2 * M_PI * fc * (n - (N - 1) / 2)) / (2 * M_PI * fc * (n - (N - 1) / 2));
   }
 
   // Compute the window.
-  float w[N];
+  STACKALLOC(float, w, N);
   BlackmanHarrisWindow(N, w);
   //~ HannWindow(N, w);
 
@@ -155,7 +155,7 @@ float getdetune(unsigned char type,
     int fdetune = finedetune - 8192;
 
     switch(type) {
-//	case 1: is used for the default (see below)
+//  case 1: is used for the default (see below)
         case 2:
             cdet   = fabsf(cdetune * 10.0f);
             findet = fabsf(fdetune / 8192.0f) * 10.0f;

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -31,6 +31,14 @@ namespace zyn {
 #define STACKALLOC(type, name, size) type name[size]
 #endif
 
+
+void windowedsinc(float fc, float gain, int N, float *h);
+
+template <typename T>
+constexpr const T& clamp(const T& v, const T& lo, const T& hi) {
+    return (v < lo) ? lo : (v > hi) ? hi : v;
+}
+
 extern bool isPlugin;
 bool fileexists(const char *filename);
 

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -176,7 +176,7 @@ static const Ports voicePorts = {
 
     //Modulator Stuff
     rOption(PFMEnabled, rShort("mode"), rOptions(none, mix, ring, phase,
-                frequency, pulse), rLinear(0,127), rDefault(none), "Modulator mode"),
+                frequency, pulse, selfPM), rLinear(0,127), rDefault(none), "Modulator mode"),
     rParamI(PFMVoice,                   rShort("voice"), rDefault(-1),
         "Modulator Oscillator Selection"),
     rParamF(FMvolume,                   rShort("vol."),  rLinear(0.0, 100.0),
@@ -1368,7 +1368,7 @@ void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
         const bool upgrade_3_0_3 = (xml.fileversion() < version_type(3,0,3)) ||
             (xml.getparreal("volume", -1) < 0);
 
-        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice - 1);
+        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice);
         if (upgrade_3_0_3) {
             int Pvolume = xml.getpar127("volume", 0);
             FMvolume    = 100.0f * Pvolume / 127.0f;

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -494,6 +494,10 @@ ADnoteGlobalParam::ADnoteGlobalParam(const AbsTime *time_) :
     FilterEnvelope->init(ad_global_filter);
     FilterLfo = new LFOParams(ad_global_filter, time_);
     Reson     = new Resonance();
+
+    wskernel = new float[WSKERNELSIZE];
+    windowedsinc(WSREALCUTOFF, 1.0f, WSKERNELSIZE, wskernel);
+
 }
 
 void ADnoteParameters::defaults()
@@ -721,6 +725,7 @@ ADnoteGlobalParam::~ADnoteGlobalParam()
     delete FilterEnvelope;
     delete FilterLfo;
     delete Reson;
+    delete [] wskernel;
 }
 
 ADnoteParameters::~ADnoteParameters()

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -176,7 +176,7 @@ static const Ports voicePorts = {
 
     //Modulator Stuff
     rOption(PFMEnabled, rShort("mode"), rOptions(none, mix, ring, phase,
-                frequency, pulse), rLinear(0,127), rDefault(none), "Modulator mode"),
+                frequency, pulse, selfPM), rLinear(0,127), rDefault(none), "Modulator mode"),
     rParamI(PFMVoice,                   rShort("voice"), rDefault(-1),
         "Modulator Oscillator Selection"),
     rParamF(FMvolume,                   rShort("vol."),  rLinear(0.0, 100.0),
@@ -1373,7 +1373,7 @@ void ADnoteVoiceParam::getfromXML(XMLwrapper& xml, unsigned nvoice)
         const bool upgrade_3_0_3 = (xml.fileversion() < version_type(3,0,3)) ||
             (xml.getparreal("volume", -1) < 0);
 
-        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice - 1);
+        PFMVoice      = xml.getpar("input_voice", PFMVoice, -1, nvoice);
         if (upgrade_3_0_3) {
             int Pvolume = xml.getpar127("volume", 0);
             FMvolume    = 100.0f * Pvolume / 127.0f;

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1239,7 +1239,6 @@ void ADnoteGlobalParam::paste(ADnoteGlobalParam &a)
     RCopy(FilterEnvelope);
     RCopy(FilterLfo);
     RCopy(Reson);
-    copy(wskernel);
 
     if ( time ) {
         last_update_timestamp = time->time();

--- a/src/Params/ADnoteParameters.cpp
+++ b/src/Params/ADnoteParameters.cpp
@@ -1239,6 +1239,7 @@ void ADnoteGlobalParam::paste(ADnoteGlobalParam &a)
     RCopy(FilterEnvelope);
     RCopy(FilterLfo);
     RCopy(Reson);
+    copy(wskernel);
 
     if ( time ) {
         last_update_timestamp = time->time();

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -21,7 +21,7 @@
 namespace zyn {
 
 enum class FMTYPE {
-    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD
+    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD, SELFPM_MOD
 };
 
 /*****************************************************************/

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -20,6 +20,16 @@
 
 namespace zyn {
 
+/**
+ * The size of the windowes sinc kernel
+ * This must be an odd number
+ */
+#define WSBASESIZE 8
+#define WSCUTOFF 0.05f
+#define WSOVERSAMPLING 32.0f
+const int WSKERNELSIZE = WSBASESIZE * WSOVERSAMPLING + 1;
+const float WSREALCUTOFF = WSCUTOFF / WSOVERSAMPLING;
+
 enum class FMTYPE {
     NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD
 };
@@ -41,6 +51,8 @@ struct ADnoteGlobalParam {
 
     bool PStereo;
 
+    // float array for windowed sinc kernel
+    float_t* wskernel;
 
     /******************************************
     *     FREQUENCY GLOBAL PARAMETERS        *

--- a/src/Params/ADnoteParameters.h
+++ b/src/Params/ADnoteParameters.h
@@ -31,7 +31,7 @@ const int WSKERNELSIZE = WSBASESIZE * WSOVERSAMPLING + 1;
 const float WSREALCUTOFF = WSCUTOFF / WSOVERSAMPLING;
 
 enum class FMTYPE {
-    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD
+    NONE, MIX, RING_MOD, PHASE_MOD, FREQ_MOD, PW_MOD, SELFPM_MOD
 };
 
 /*****************************************************************/

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -281,7 +281,7 @@ protected:
       Load a program.
       The host may call this function from any context, including realtime processing.
     */
-    void loadProgram(uint32_t index) override
+    void loadProgram([[maybe_unused]]uint32_t index) override
     {
         setState(nullptr, defaultState);
         /*

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -176,6 +176,7 @@ void ADnote::setupVoice(int nvoice)
         pars.VoicePar[vc].OscilGn->get(NoteVoicePar[nvoice].OscilSmp,
                 getvoicebasefreq(nvoice),
                 pars.VoicePar[nvoice].Presonance);
+    voice.OscilSmpMax = pars.VoicePar[vc].OscilGn->getMaxFreq();
 
     // This code was planned for biasing the carrier in MOD_RING
     // but that's on hold for the moment.  Disabled 'cos small
@@ -1227,125 +1228,74 @@ inline void ADnote::fadein(float *smps) const
 inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
 {
     Voice& vce = NoteVoicePar[nvoice];
-    for(int k = 0; k < vce.unison_size; ++k) {
-        int    poshi  = vce.oscposhi[k];
-        // convert floating point fractional part (sample interval phase)
-        // with range [0.0 ... 1.0] to fixed point with 1 digit is 2^-24
-        // by multiplying with precalculated 2^24 and casting to integer:
-        int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
-        int    freqhi = vce.oscfreqhi[k];
-        // same for phase increment:
-        int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
-        float *smps   = NoteVoicePar[nvoice].OscilSmp;
-        float *tw     = tmpwave_unison[k];
-        assert(vce.oscfreqlo[k] < 1.0f);
-        for(int i = 0; i < synth.buffersize; ++i) {
-            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
-            poslo += freqlo;                // increment fractional part (sample interval phase)
-            poshi += freqhi + (poslo>>24);  // add overflow over 24 bits in poslo to poshi
-            poslo &= 0xffffff;              // remove overflow from poslo
-            poshi &= synth.oscilsize - 1;   // remove overflow
-        }
-        vce.oscposhi[k] = poshi;
-        vce.oscposlo[k] = poslo/(16777216.0f);
-    }
-}
+    float* smps = vce.OscilSmp;
 
-
-/*
- * Computes the Oscillator (Without Modulation) - windowed sinc Interpolation
- */
-
-/* As the code here is a bit odd due to optimization, here is what happens
- * First the current position and frequency are retrieved from the running
- * state. These are broken up into high and low portions to indicate how many
- * samples are skipped in one step and how many fractional samples are skipped.
- * Outside of this method the fractional samples are just handled with floating
- * point code, but that's a bit slower than it needs to be. In this code the low
- * portions are known to exist between 0.0 and 1.0 and it is known that they are
- * stored in single precision floating point IEEE numbers. This implies that
- * a maximum of 24 bits are significant. The below code does your standard
- * linear interpolation that you'll see throughout this codebase, but by
- * sticking to integers for tracking the overflow of the low portion, around 15%
- * of the execution time was shaved off in the ADnote test.
- */
-inline void ADnote::ComputeVoiceOscillator_SincInterpolation(int nvoice)
-{
-    // windowed sinc kernel factor Fs*0.3, rejection 80dB
-    const float_t kernel[] = {
-        0.0010596256917418426f,
-        0.004273442181254887f,
-        0.0035466063043375785f,
-        -0.014555483937137638f,
-        -0.04789321342588484f,
-        -0.050800020978553066f,
-        0.04679847159974432f,
-        0.2610646708018185f,
-        0.4964802251145513f,
-        0.6000513532962539f,
-        0.4964802251145513f,
-        0.2610646708018185f,
-        0.04679847159974432f,
-        -0.050800020978553066f,
-        -0.04789321342588484f,
-        -0.014555483937137638f,
-        0.0035466063043375785f,
-        0.004273442181254887f,
-        0.0010596256917418426f
-        };
-
-
-
-    Voice& vce = NoteVoicePar[nvoice];
-    for(int k = 0; k < vce.unison_size; ++k) {
-        int    poshi  = vce.oscposhi[k];
-        int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
-        int    freqhi = vce.oscfreqhi[k];
-        int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
-        int    ovsmpfreqhi = vce.oscfreqhi[k] / 2;
-        int    ovsmpfreqlo = (int)((vce.oscfreqlo[k] / 2) * (1<<24));
-
-        int    ovsmpposlo;
-        int    ovsmpposhi;
-        int    uflow;
-        float *smps   = NoteVoicePar[nvoice].OscilSmp;
-        float *tw     = tmpwave_unison[k];
-        assert(vce.oscfreqlo[k] < 1.0f);
-        float out = 0;
-
-        for(int i = 0; i < synth.buffersize; ++i) {
-            ovsmpposlo  = poslo - (LENGTHOF(kernel)-1)/2 * ovsmpfreqlo;
-            uflow = ovsmpposlo>>24;
-            ovsmpposhi  = poshi - (LENGTHOF(kernel)-1)/2 * ovsmpfreqhi - ((0x00 - uflow) & 0xff);
-            ovsmpposlo &= 0xffffff;
-            ovsmpposhi &= synth.oscilsize - 1;
-            out = 0;
-            for (int l = 0; l<LENGTHOF(kernel); l++) {
-                out += kernel[l] * (
-                    smps[ovsmpposhi]     * ((1<<24) - ovsmpposlo) +
-                    smps[ovsmpposhi + 1] * ovsmpposlo)/(1.0f*(1<<24));
-                // advance to next kernel sample
-                ovsmpposlo += ovsmpfreqlo;
-                ovsmpposhi += ovsmpfreqhi + (ovsmpposlo>>24); // add the 24-bit overflow
-                ovsmpposlo &= 0xffffff;
-                ovsmpposhi &= synth.oscilsize - 1;
-
-            }
-
-            // advance to next sample
+    for (int k = 0; k < vce.unison_size; ++k) {
+        int poshi  = vce.oscposhi[k];
+        int poslo  = static_cast<int>(vce.oscposlo[k] * 16777216.0f);  // 2^24
+        int freqhi = vce.oscfreqhi[k];
+        int freqlo = static_cast<int>(vce.oscfreqlo[k] * 16777216.0f);
+        float* tw  = tmpwave_unison[k];
+        //~ printf("freqhi: %d\n", freqhi);
+        assert(vce.oscfreqlo[k] < 1.0f);  // sanity check
+        for (int i = 0; i < synth.buffersize; ++i) {
+            // advance phase (fixed-point)
             poslo += freqlo;
-            poshi += freqhi + (poslo>>24);
-            poslo &= 0xffffff;
-            poshi &= synth.oscilsize - 1;
+            poshi += freqhi + (poslo >> 24);  // propagate carry
+            poslo &= 0xFFFFFF;                // keep lower 24 bits
+            poshi &= synth.oscilsize - 1;     // wrap around table size
 
-            tw[i] = out;
+            float out = 0.0f;
 
+            // Determine if Anti-Aliasing is needed:
+            const bool needsAA = (freqhi * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
+
+            if (NoteVoicePar[nvoice].AAEnabled && needsAA) {
+
+                // Calculate how many kernel samples to skip per step in the convolution loop.
+                // Higher oversampling → smaller step size → better filtering but more computation.
+                // If the highest frequency in the WT is low, we need less filtering so we increase the stpsize
+                int stpsize = roundf(2.0f*WSOVERSAMPLING / freqhi);
+                stpsize = clamp(stpsize, 1, WSKERNELSIZE / 2);
+
+                // Calculate the number of wavetable samples that are supported in the filter window
+                const int conv_steps = WSKERNELSIZE/(stpsize);
+                // We have to start half of the steps left of the sample position
+                const int startoffset = conv_steps/2;
+                // Calculate the initial position in the wavetable for the convolution.
+                // Apply wrapping to stay within the bounds of the wavetable size.
+                int ovsmpposhi = (poshi - startoffset) & (synth.oscilsize - 1);
+
+                // Use the fractional part of the phase (poslo) to align the start of the kernel
+                // This helps preserve phase continuity and prevents audible stepping or artifacts.
+                const int startpos = ((16777216 - poslo) * stpsize);  // 2^24 = fixed-point phase resolution
+                const int startposhi = startpos >> 24;  // Normalize to 0..WSKERNELSIZE range
+
+                // Apply the kernel convolution:
+                // Multiply the selected samples from the wavetable with the corresponding kernel values.
+                // Move forward in both kernel and wavetable positions according to the current step size.
+                for (int l = startposhi; l < WSKERNELSIZE; l += stpsize) {
+                    const float kernel_sample = pars.GlobalPar.wskernel[l];
+                    out += kernel_sample * smps[ovsmpposhi];
+                    ovsmpposhi = (ovsmpposhi + 1) & (synth.oscilsize - 1);  // wrap around wavetable
+                }
+
+                // Since we use fewer kernel samples at high frequencies (larger stpsize),
+                // scale the result to preserve amplitude consistency across frequencies.
+                tw[i] = out * static_cast<float>(stpsize);
+
+            } else {
+                // linear interpolation with wrapping
+                int poship1 = (poshi + 1) & (synth.oscilsize - 1);
+                tw[i] = (smps[poshi] * (16777216 - poslo) + smps[poship1] * poslo) * (1.0f / 16777216.0f);
+            }
         }
+
+        // save updated phase (convert back from fixed-point)
         vce.oscposhi[k] = poshi;
-        vce.oscposlo[k] = poslo/(1.0f*(1<<24));
+        vce.oscposlo[k] = static_cast<float>(poslo) / 16777216.0f;
     }
 }
-
 
 /*
  * Computes the Oscillator (Mixing)
@@ -1480,38 +1430,12 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
     if(vce.FMVoice >= 0)
         // if I use VoiceOut[] as modulator
         // copy it to tmpwave_unison[][]
+        // in sync oscillator this is the only option
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
             const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
             memcpy(tw, smps, synth.bufferbytes);
         }
-    else{
-        //Compute the modulator and store it in tmpwave_unison[][]
-        for(int k = 0; k < vce.unison_size; ++k) {
-            int    poshiFM  = vce.oscposhiFM[k];
-            int    posloFM  = (int)(vce.oscposloFM[k]  * (1<<24));
-            int    freqhiFM = vce.oscfreqhiFM[k];
-            int    freqloFM = (int)(vce.oscfreqloFM[k] * (1<<24));
-
-            float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[nvoice].FMSmp;
-
-            for(int i = 0; i < synth.buffersize; ++i) {
-                tw[i] = (smps[poshiFM] * ((1<<24) - posloFM)
-                         + smps[poshiFM + 1] * posloFM) / (1.0f*(1<<24));
-
-                posloFM += freqloFM;
-                if(posloFM >= (1<<24)) {
-                    posloFM &= 0xffffff;//fmod(posloFM, 1.0f);
-                    poshiFM++;
-                }
-                poshiFM += freqhiFM;
-                poshiFM &= synth.oscilsize - 1;
-            }
-            vce.oscposhiFM[k] = poshiFM;
-            vce.oscposloFM[k] = posloFM/((1<<24)*1.0f);
-        }
-    }
 
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
@@ -1629,7 +1553,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
-                fmold = fmold + (tw[i] * normalize);
+                fmold = fmodf(fmold + tw[i] * normalize, synth.oscilsize);
                 tw[i] = fmold;
             }
             vce.FMoldsmp[k] = fmold;
@@ -1682,9 +1606,44 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             }
             carposhi &= (synth.oscilsize - 1);
 
-            tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
-                    + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
 
+            // do AA stuff
+            // Determine if anti-aliasing is necessary based on effective frequency
+            const float absfreq = fabsf(tw[i] + freqhi);  // includes FM offset
+            const bool needsAA = (absfreq * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
+
+            if (vce.AAEnabled && needsAA) {
+                // Determine kernel step size based on frequency (higher freq = lower step size)
+                int stpsize = roundf(WSOVERSAMPLING / absfreq);
+                stpsize = clamp(stpsize, 1, WSKERNELSIZE / 2);
+
+                // Calculate convolution range and position in wavetable
+                const int conv_steps = WSKERNELSIZE / stpsize;
+                const int startoffset = conv_steps / 2;
+                int ovsmpposhi = (carposhi - startoffset) & (synth.oscilsize - 1);
+
+                // Initial kernel sample index based on fractional position
+                const int startpos = ((16777216 - carposlo) * stpsize);
+                const int startposhi = startpos >> 24;
+
+                // Convolve wavetable with kernel
+                float out = 0.0f;
+                for (int l = startposhi; l < WSKERNELSIZE; l += stpsize) {
+                    const float kernel_sample = pars.GlobalPar.wskernel[l];
+                    out += kernel_sample * smps[ovsmpposhi];
+                    ovsmpposhi = (ovsmpposhi + 1) & (synth.oscilsize - 1);
+                }
+
+                // Scale output based on step size
+                tw[i] = out * static_cast<float>(stpsize);
+            } else {
+
+
+
+
+                        tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
+                                + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
+            }
             poslo += freqlo;
             if(poslo >= (1<<24)) {
                 poslo &= 0xffffff;//fmod(poslo, 1.0f);
@@ -1789,9 +1748,7 @@ int ADnote::noteout(float *outl, float *outr)
                                                                   NoteVoicePar[nvoice].FMEnabled);
                         break;
                     default:
-                        if(NoteVoicePar[nvoice].AAEnabled)
-                            ComputeVoiceOscillator_SincInterpolation(nvoice);
-                        else
+
                             if(NoteVoicePar[nvoice].syncEnabled)
                                 ComputeVoiceOscillatorSync(nvoice);
                             else

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1454,7 +1454,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
             // if zero is crossed on the rising slope of the modulator
             // reset phase at the carrier
             // if no modulation is selected reset only in a timewindow narrowed by FMnewamplitude
-            if (
+            if (vce.FMVoice >= 0 &&
                  ( (tw[i]>0.0f && fmold <=0.0f) ||
                     (tw[i]>=0.0f && fmold <0.0f) )
                 && (( float(poshi)/float(synth.oscilsize) < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1583,8 +1583,9 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
         for(int i = 0; i < synth.buffersize; ++i) {
 
             if(NoteVoicePar[nvoice].syncEnabled &&
-                        ( (tw[i]>0.0f && fmold <=0.0f) ||
-                        (tw[i]>=0.0f && fmold <0.0f) )) {
+                         vce.FMVoice >= 0 &&  // B1
+   ( (tw[i]>0.0f && fmold <=0.0f) || (tw[i]>=0.0f && fmold <0.0f) ) &&  // B2
+   ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)) {
                 poshi = 0.0f;
                 poslo = 0.0f;
             }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -769,6 +769,7 @@ void ADnote::KillVoice(int nvoice)
     memory.devalloc(voice.unison_freq_rap);
     memory.devalloc(voice.unison_invert_phase);
     memory.devalloc(voice.FMoldsmp);
+    memory.devalloc(voice.FMtw_orig);
     memory.devalloc(voice.unison_vibratto.step);
     memory.devalloc(voice.unison_vibratto.position);
 
@@ -801,9 +802,12 @@ ADnote::~ADnote()
     memory.devalloc(tmpwaver);
     memory.devalloc(bypassl);
     memory.devalloc(bypassr);
-    for(int k = 0; k < max_unison; ++k)
+    for(int k = 0; k < max_unison; ++k) {
         memory.devalloc(tmpwave_unison[k]);
+        memory.devalloc(tmpwave_mod[k]);
+    }
     memory.devalloc(tmpwave_unison);
+    memory.devalloc(tmpwave_mod);
 }
 
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1231,19 +1231,20 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
     float* smps = vce.OscilSmp;
 
     for (int k = 0; k < vce.unison_size; ++k) {
-        int poshi  = vce.oscposhi[k];
-        int poslo  = static_cast<int>(vce.oscposlo[k] * 16777216.0f);  // 2^24
-        int freqhi = vce.oscfreqhi[k];
-        int freqlo = static_cast<int>(vce.oscfreqlo[k] * 16777216.0f);
+    int poshi  = vce.oscposhi[k];
+    int poslo  = (int)(vce.oscposlo[k] * (1<<24));  // REVERT-PHASE-CHANGE: use explicit 24-bit fixed point
+    int freqhi = vce.oscfreqhi[k];
+    int freqlo = (int)(vce.oscfreqlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
         float* tw  = tmpwave_unison[k];
         //~ printf("freqhi: %d\n", freqhi);
         assert(vce.oscfreqlo[k] < 1.0f);  // sanity check
         for (int i = 0; i < synth.buffersize; ++i) {
             // advance phase (fixed-point)
-            poslo += freqlo;
-            poshi += freqhi + (poslo >> 24);  // propagate carry
-            poslo &= 0xFFFFFF;                // keep lower 24 bits
-            poshi &= synth.oscilsize - 1;     // wrap around table size
+            // REVERT-PHASE-CHANGE: use original carry/overflow ordering
+            poslo += freqlo;                 // increment fractional part
+            poshi += freqhi + (poslo >> 24); // add overflow over 24 bits in poslo to poshi
+            poslo &= 0xFFFFFF;               // remove overflow from poslo (keep 24 bits)
+            poshi &= synth.oscilsize - 1;    // wrap around wavetable size
 
             float out = 0.0f;
 
@@ -1268,7 +1269,7 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
 
                 // Use the fractional part of the phase (poslo) to align the start of the kernel
                 // This helps preserve phase continuity and prevents audible stepping or artifacts.
-                const int startpos = ((16777216 - poslo) * stpsize);  // 2^24 = fixed-point phase resolution
+                const int startpos = (((1<<24) - poslo) * stpsize);  // REVERT-PHASE-CHANGE: use (1<<24)
                 const int startposhi = startpos >> 24;  // Normalize to 0..WSKERNELSIZE range
 
                 // Apply the kernel convolution:
@@ -1287,13 +1288,14 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
             } else {
                 // linear interpolation with wrapping
                 int poship1 = (poshi + 1) & (synth.oscilsize - 1);
-                tw[i] = (smps[poshi] * (16777216 - poslo) + smps[poship1] * poslo) * (1.0f / 16777216.0f);
+                // REVERT-PHASE-CHANGE: perform interpolation using 24-bit fixed point math
+                tw[i] = (smps[poshi] * ((1<<24) - poslo) + smps[poship1] * poslo) / (1.0f * (1<<24));
             }
         }
 
         // save updated phase (convert back from fixed-point)
         vce.oscposhi[k] = poshi;
-        vce.oscposlo[k] = static_cast<float>(poslo) / 16777216.0f;
+    vce.oscposlo[k] = static_cast<float>(poslo) / (1<<24); // REVERT-PHASE-CHANGE
     }
 }
 
@@ -1439,9 +1441,9 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
 
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
-        int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
-        int    freqhi = vce.oscfreqhi[k];
-        int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
+    int    poslo  = (int)(vce.oscposlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
+    int    freqhi = vce.oscfreqhi[k];
+    int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
         float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);
@@ -1458,7 +1460,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
                 && (( float(poshi)/float(synth.oscilsize) < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)
                 ) {
                 fmold = tw[i];
-                tw[i] = ((smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f) + smps[0])/2.0f;
+                tw[i] = ((smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(1.0f * (1<<24)) + smps[0])/2.0f; // REVERT-PHASE-CHANGE
                 poslo = 0;
                 poshi = 0;
                 continue;
@@ -1466,14 +1468,14 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
             }
             fmold = tw[i];
 
-            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
+            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(1.0f * (1<<24)); // REVERT-PHASE-CHANGE
             poslo += freqlo;                // increment fractional part (sample interval phase)
             poshi += freqhi + (poslo>>24);  // add overflow over 24 bits in poslo to poshi
             poslo &= 0xffffff;              // remove overflow from poslo
             poshi &= synth.oscilsize - 1;   // remove overflow
         }
         vce.oscposhi[k] = poshi;
-        vce.oscposlo[k] = poslo/(16777216.0f);
+    vce.oscposlo[k] = poslo/((1<<24) * 1.0f); // REVERT-PHASE-CHANGE
         vce.FMoldsmp[k] = fmold; // store value for next tick
     }
 }
@@ -1553,7 +1555,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
-                fmold = fmodf(fmold + tw[i] * normalize, synth.oscilsize);
+                fmold = fmold + tw[i] * normalize, synth.oscilsize);
                 tw[i] = fmold;
             }
             vce.FMoldsmp[k] = fmold;
@@ -1588,15 +1590,16 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             }
             fmold = tw[i];
 
-            int FMmodfreqhi = 0;
-            F2I(tw[i], FMmodfreqhi);
-            float FMmodfreqlo = tw[i]-FMmodfreqhi;//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
-            if(FMmodfreqlo < 0)
-                FMmodfreqlo++;
+            // REVERT-FM-CHANGE: use explicit 24-bit fixed point for FM fractional part
+            int FMmodposhi = 0;
+            F2I(tw[i], FMmodposhi);
+            int FMmodposlo = (int)((tw[i] - FMmodposhi) * (1<<24));
+            if(FMmodposlo < 0)
+                FMmodposlo++;
 
-            //carrier
-            int carposhi = poshi + FMmodfreqhi;
-            int carposlo = (int)(poslo + FMmodfreqlo);
+            // carrier positions (integer+fixed-point fractional)
+            int carposhi = poshi + FMmodposhi;
+            int carposlo = poslo + FMmodposlo;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 carposhi += NoteVoicePar[nvoice].phase_offset;
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1572,6 +1572,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
     else {  //Phase or PWM modulation
         const float normalize = synth.oscilsize_f / 262144.0f;
         for(int k = 0; k < vce.unison_size; ++k) {
+            memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw = tmpwave_unison[k];
             for(int i = 0; i < synth.buffersize; ++i)
                 tw[i] *= normalize;
@@ -1664,6 +1665,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             poshi += freqhi;
             poshi &= synth.oscilsize - 1;
         }
+        vce.FMtw_orig[k] = tw_orig_old;
         vce.oscposhi[k] = poshi;
         vce.oscposlo[k] = (poslo)/((1<<24)*1.0f);
     }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1308,38 +1308,6 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
     }
 }
 
-
-//~ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
-//~ {
-    //~ Voice& vce = NoteVoicePar[nvoice];
-    //~ for(int k = 0; k < vce.unison_size; ++k) {
-        //~ int    poshi  = vce.oscposhi[k];
-        //~ // convert floating point fractional part (sample interval phase)
-        //~ // with range [0.0 ... 1.0] to fixed point with 1 digit is 2^-24
-        //~ // by multiplying with precalculated 2^24 and casting to integer:
-        //~ int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
-        //~ int    freqhi = vce.oscfreqhi[k];
-        //~ // same for phase increment:
-        //~ int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
-        //~ float *smps   = NoteVoicePar[nvoice].OscilSmp;
-        //~ float *tw     = tmpwave_unison[k];
-        //~ assert(vce.oscfreqlo[k] < 1.0f);
-        //~ for(int i = 0; i < synth.buffersize; ++i) {
-            //~ tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
-            //~ poslo += freqlo;                // increment fractional part (sample interval phase)
-            //~ poshi += freqhi + (poslo>>24);  // add overflow over 24 bits in poslo to poshi
-            //~ poslo &= 0xffffff;              // remove overflow from poslo
-            //~ poshi &= synth.oscilsize - 1;   // remove overflow
-        //~ }
-        //~ vce.oscposhi[k] = poshi;
-        //~ vce.oscposlo[k] = poslo/(16777216.0f);
-    //~ }
-//~ }
-
-
-
-
-
 /*
  * Computes the Oscillator (Mixing)
  */

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1606,16 +1606,15 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             }
             tw_orig_old = tw_orig[i];
 
-            // REVERT-FM-CHANGE: use explicit 24-bit fixed point for FM fractional part
-            int FMmodposhi = 0;
-            F2I(tw[i], FMmodposhi);
-            int FMmodposlo = (int)((tw[i] - FMmodposhi) * (1<<24));
-            if(FMmodposlo < 0)
-                FMmodposlo++;
+            int FMmodfreqhi = 0;
+            F2I(tw[i], FMmodfreqhi);
+            float FMmodfreqlo = tw[i]-FMmodfreqhi;//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
+            if(FMmodfreqlo < 0)
+                FMmodfreqlo++;
 
             // carrier positions (integer+fixed-point fractional)
-            int carposhi = poshi + FMmodposhi;
-            int carposlo = poslo + FMmodposlo;
+            int carposhi = poshi + FMmodfreqhi;
+            int carposlo = (int)(poslo + FMmodfreqlo);
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 carposhi += vce.phase_offset;
 

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1451,9 +1451,9 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
 
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
-    int    poslo  = (int)(vce.oscposlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
-    int    freqhi = vce.oscfreqhi[k];
-    int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
+        int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
+        int    freqhi = vce.oscfreqhi[k];
+        int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
         float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);
@@ -1470,7 +1470,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
                 && (( float(poshi)/float(synth.oscilsize) < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)
                 ) {
                 fmold = tw[i];
-                tw[i] = ((smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(1.0f * (1<<24)) + smps[0])/2.0f; // REVERT-PHASE-CHANGE
+                tw[i] = ((smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f) + smps[0])/2.0f;
                 poslo = 0;
                 poshi = 0;
                 continue;
@@ -1478,14 +1478,14 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
             }
             fmold = tw[i];
 
-            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(1.0f * (1<<24)); // REVERT-PHASE-CHANGE
+            tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
             poslo += freqlo;                // increment fractional part (sample interval phase)
             poshi += freqhi + (poslo>>24);  // add overflow over 24 bits in poslo to poshi
             poslo &= 0xffffff;              // remove overflow from poslo
             poshi &= synth.oscilsize - 1;   // remove overflow
         }
         vce.oscposhi[k] = poshi;
-    vce.oscposlo[k] = poslo/((1<<24) * 1.0f); // REVERT-PHASE-CHANGE
+        vce.oscposlo[k] = poslo/(16777216.0f);
         vce.FMoldsmp[k] = fmold; // store value for next tick
     }
 }
@@ -1567,7 +1567,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
-                fmold = fmold + tw[i] * normalize;
+                fmold = fmold + (tw[i] * normalize);
                 tw[i] = fmold;
             }
             vce.FMoldsmp[k] = fmold;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1555,7 +1555,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
-                fmold = fmold + tw[i] * normalize, synth.oscilsize);
+                fmold = fmold + tw[i] * normalize;
                 tw[i] = fmold;
             }
             vce.FMoldsmp[k] = fmold;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1583,7 +1583,6 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
         float *smps   = vce.OscilSmp;
         float *tw     = tmpwave_unison[k];
         float *tw_orig = tmpwave_mod[k];
-        //~ float  fmold = vce.FMoldsmp[k];
         int    poshi  = vce.oscposhi[k];
         int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
         int    freqhi = vce.oscfreqhi[k];
@@ -1597,7 +1596,6 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                    ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || // soft sync
                    FMmode != FMTYPE::NONE) // no soft sync with other modulation
               ) {
-                  //~ printf("%d  synced vce.FMEnabled: %d\n", i, (int)vce.FMEnabled);
                 poshi = 0;
                 poslo = 0;
             }

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1241,21 +1241,18 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
     float* smps = vce.OscilSmp;
 
     for (int k = 0; k < vce.unison_size; ++k) {
-    int poshi  = vce.oscposhi[k];
-    int poslo  = (int)(vce.oscposlo[k] * (1<<24));  // REVERT-PHASE-CHANGE: use explicit 24-bit fixed point
-    int freqhi = vce.oscfreqhi[k];
-    int freqlo = (int)(vce.oscfreqlo[k] * (1<<24)); // REVERT-PHASE-CHANGE
-        float* tw  = tmpwave_unison[k];
-        //~ printf("freqhi: %d\n", freqhi);
+
+        int    poshi  = vce.oscposhi[k];
+        // convert floating point fractional part (sample interval phase)
+        // with range [0.0 ... 1.0] to fixed point with 1 digit is 2^-24
+        // by multiplying with precalculated 2^24 and casting to integer:
+        int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
+        int    freqhi = vce.oscfreqhi[k];
+        // same for phase increment:
+        int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
+        float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);  // sanity check
         for (int i = 0; i < synth.buffersize; ++i) {
-            // advance phase (fixed-point)
-            // REVERT-PHASE-CHANGE: use original carry/overflow ordering
-            poslo += freqlo;                 // increment fractional part
-            poshi += freqhi + (poslo >> 24); // add overflow over 24 bits in poslo to poshi
-            poslo &= 0xFFFFFF;               // remove overflow from poslo (keep 24 bits)
-            poshi &= synth.oscilsize - 1;    // wrap around wavetable size
-
             float out = 0.0f;
 
             // Determine if Anti-Aliasing is needed:
@@ -1297,17 +1294,51 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
 
             } else {
                 // linear interpolation with wrapping
-                int poship1 = (poshi + 1) & (synth.oscilsize - 1);
-                // REVERT-PHASE-CHANGE: perform interpolation using 24-bit fixed point math
-                tw[i] = (smps[poshi] * ((1<<24) - poslo) + smps[poship1] * poslo) / (1.0f * (1<<24));
+                tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
+                poslo += freqlo;                 // increment fractional part
+                poshi += freqhi + (poslo >> 24); // add overflow over 24 bits in poslo to poshi
+                poslo &= 0xFFFFFF;               // remove overflow from poslo (keep 24 bits)
+                poshi &= synth.oscilsize - 1;    // wrap around wavetable size
             }
         }
 
         // save updated phase (convert back from fixed-point)
         vce.oscposhi[k] = poshi;
-    vce.oscposlo[k] = static_cast<float>(poslo) / (1<<24); // REVERT-PHASE-CHANGE
+        vce.oscposlo[k] = poslo/(16777216.0f);
     }
 }
+
+
+//~ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
+//~ {
+    //~ Voice& vce = NoteVoicePar[nvoice];
+    //~ for(int k = 0; k < vce.unison_size; ++k) {
+        //~ int    poshi  = vce.oscposhi[k];
+        //~ // convert floating point fractional part (sample interval phase)
+        //~ // with range [0.0 ... 1.0] to fixed point with 1 digit is 2^-24
+        //~ // by multiplying with precalculated 2^24 and casting to integer:
+        //~ int    poslo  = (int)(vce.oscposlo[k] * 16777216.0f);
+        //~ int    freqhi = vce.oscfreqhi[k];
+        //~ // same for phase increment:
+        //~ int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
+        //~ float *smps   = NoteVoicePar[nvoice].OscilSmp;
+        //~ float *tw     = tmpwave_unison[k];
+        //~ assert(vce.oscfreqlo[k] < 1.0f);
+        //~ for(int i = 0; i < synth.buffersize; ++i) {
+            //~ tw[i]  = (smps[poshi] * (0x01000000 - poslo) + smps[poshi + 1] * poslo)/(16777216.0f);
+            //~ poslo += freqlo;                // increment fractional part (sample interval phase)
+            //~ poshi += freqhi + (poslo>>24);  // add overflow over 24 bits in poslo to poshi
+            //~ poslo &= 0xffffff;              // remove overflow from poslo
+            //~ poshi &= synth.oscilsize - 1;   // remove overflow
+        //~ }
+        //~ vce.oscposhi[k] = poshi;
+        //~ vce.oscposlo[k] = poslo/(16777216.0f);
+    //~ }
+//~ }
+
+
+
+
 
 /*
  * Computes the Oscillator (Mixing)

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1498,7 +1498,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
         //if I use VoiceOut[] as modulator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[vce.FMVoice].VoiceOut;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 for (int i = 0; i < synth.buffersize; ++i)
                     tw[i] = -smps[i];
@@ -1513,7 +1513,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             int    freqhiFM = vce.oscfreqhiFM[k];
             int    freqloFM = (int)(vce.oscfreqloFM[k] * (1<<24));
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[nvoice].FMSmp;
+            const float *smps = vce.FMSmp;
 
             for(int i = 0; i < synth.buffersize; ++i) {
                 tw[i] = (smps[poshiFM] * ((1<<24) - posloFM)
@@ -1614,7 +1614,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             int carposhi = poshi + FMmodposhi;
             int carposlo = poslo + FMmodposlo;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
-                carposhi += NoteVoicePar[nvoice].phase_offset;
+                carposhi += vce.phase_offset;
 
             if(carposlo >= (1<<24)) {
                 carposhi++;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -91,9 +91,12 @@ ADnote::ADnote(ADnoteParameters *pars_, const SynthParams &spars,
 
 
     tmpwave_unison = memory.valloc<float*>(max_unison);
+    tmpwave_mod = memory.valloc<float*>(max_unison);
     for(int k = 0; k < max_unison; ++k) {
         tmpwave_unison[k] = memory.valloc<float>(synth.buffersize);
+        tmpwave_mod[k] = memory.valloc<float>(synth.buffersize);
         memset(tmpwave_unison[k], 0, synth.bufferbytes);
+        memset(tmpwave_mod[k], 0, synth.bufferbytes);
     }
 
     initparameters(wm, prefix);
@@ -232,8 +235,11 @@ void ADnote::setupVoice(int nvoice)
     voice.FMAmpEnvelope  = NULL;
 
     voice.FMoldsmp = memory.valloc<float>(unison);
-    for(int k = 0; k < unison; ++k)
+    voice.FMtw_orig = memory.valloc<float>(unison);
+    for(int k = 0; k < unison; ++k) {
         voice.FMoldsmp[k] = 0.0f; //this is for FM (integration)
+        voice.FMtw_orig[k] = 0.0f; //this is for the original modulator
+    }
 
     voice.firsttick = 1;
     voice.DelayTicks =
@@ -1548,10 +1554,12 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
 
     //normalize: makes all sample-rates, oscil_sizes to produce same sound
-    if(FMmode == FMTYPE::FREQ_MOD) { //Frequency modulation
+    if(FMmode == FMTYPE::FREQ_MOD) { // make frequency modulation from phase modulation by integrating phase
         const float normalize = synth.oscilsize_f / 262144.0f * 44100.0f
                           / synth.samplerate_f;
         for(int k = 0; k < vce.unison_size; ++k) {
+            // backup phase modulator buffer before it gets integrated for FM
+            memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
@@ -1572,24 +1580,28 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
     //do the modulation
     for(int k = 0; k < vce.unison_size; ++k) {
-        float *smps   = NoteVoicePar[nvoice].OscilSmp;
+        float *smps   = vce.OscilSmp;
         float *tw     = tmpwave_unison[k];
-        float  fmold = vce.FMoldsmp[k];
+        float *tw_orig = tmpwave_mod[k];
+        //~ float  fmold = vce.FMoldsmp[k];
         int    poshi  = vce.oscposhi[k];
         int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
         int    freqhi = vce.oscfreqhi[k];
         int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
-
+        float tw_orig_old = vce.FMtw_orig[k];
         for(int i = 0; i < synth.buffersize; ++i) {
 
-            if(NoteVoicePar[nvoice].syncEnabled &&
-                         vce.FMVoice >= 0 &&  // B1
-   ( (tw[i]>0.0f && fmold <=0.0f) || (tw[i]>=0.0f && fmold <0.0f) ) &&  // B2
-   ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)) {
-                poshi = 0.0f;
-                poslo = 0.0f;
+            if(  vce.syncEnabled &&
+                 vce.FMVoice >= 0 && // works only with "external" modulator
+                 ( (tw_orig[i]>0.0f && tw_orig_old <=0.0f) || (tw_orig[i]>=0.0f && tw_orig_old <0.0f) ) &&  // sync at zero crossing
+                   ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || // soft sync
+                   FMmode != FMTYPE::NONE) // no soft sync with other modulation
+              ) {
+                  //~ printf("%d  synced vce.FMEnabled: %d\n", i, (int)vce.FMEnabled);
+                poshi = 0;
+                poslo = 0;
             }
-            fmold = tw[i];
+            tw_orig_old = tw_orig[i];
 
             // REVERT-FM-CHANGE: use explicit 24-bit fixed point for FM fractional part
             int FMmodposhi = 0;
@@ -1606,7 +1618,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
             if(carposlo >= (1<<24)) {
                 carposhi++;
-                carposlo &= 0xffffff;//fmod(carposlo, 1.0f);
+                carposlo &= 0xffffff;// fmod(carposlo, 1.0f);
             }
             carposhi &= (synth.oscilsize - 1);
 
@@ -1641,9 +1653,6 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                 // Scale output based on step size
                 tw[i] = out * static_cast<float>(stpsize);
             } else {
-
-
-
 
                         tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
                                 + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -91,12 +91,9 @@ ADnote::ADnote(ADnoteParameters *pars_, const SynthParams &spars,
 
 
     tmpwave_unison = memory.valloc<float*>(max_unison);
-    tmpwave_mod = memory.valloc<float*>(max_unison);
     for(int k = 0; k < max_unison; ++k) {
         tmpwave_unison[k] = memory.valloc<float>(synth.buffersize);
-        tmpwave_mod[k] = memory.valloc<float>(synth.buffersize);
         memset(tmpwave_unison[k], 0, synth.bufferbytes);
-        memset(tmpwave_mod[k], 0, synth.bufferbytes);
     }
 
     initparameters(wm, prefix);
@@ -151,6 +148,7 @@ void ADnote::setupVoice(int nvoice)
     voice.oscposlo    = memory.valloc<float>(unison);
     voice.oscposhiFM  = memory.valloc<unsigned int>(unison);
     voice.oscposloFM  = memory.valloc<float>(unison);
+    voice.twold       = memory.valloc<float>(unison);
 
     voice.Enabled     = ON;
     voice.fixedfreq   = pars.VoicePar[nvoice].Pfixedfreq;
@@ -163,6 +161,7 @@ void ADnote::setupVoice(int nvoice)
         voice.oscposlo[k]   = 0.0f;
         voice.oscposhiFM[k] = 0;
         voice.oscposloFM[k] = 0.0f;
+        voice.twold[k] = 0.0f;
     }
 
     //the extra points contains the first point
@@ -179,7 +178,6 @@ void ADnote::setupVoice(int nvoice)
         pars.VoicePar[vc].OscilGn->get(NoteVoicePar[nvoice].OscilSmp,
                 getvoicebasefreq(nvoice),
                 pars.VoicePar[nvoice].Presonance);
-    voice.OscilSmpMax = pars.VoicePar[vc].OscilGn->getMaxFreq();
 
     // This code was planned for biasing the carrier in MOD_RING
     // but that's on hold for the moment.  Disabled 'cos small
@@ -235,11 +233,8 @@ void ADnote::setupVoice(int nvoice)
     voice.FMAmpEnvelope  = NULL;
 
     voice.FMoldsmp = memory.valloc<float>(unison);
-    voice.FMtw_orig = memory.valloc<float>(unison);
-    for(int k = 0; k < unison; ++k) {
+    for(int k = 0; k < unison; ++k)
         voice.FMoldsmp[k] = 0.0f; //this is for FM (integration)
-        voice.FMtw_orig[k] = 0.0f; //this is for the original modulator
-    }
 
     voice.firsttick = 1;
     voice.DelayTicks =
@@ -444,7 +439,7 @@ void ADnote::setupVoiceMod(int nvoice, bool first_run)
     voice.FMFreqFixed  = param.PFMFixedFreq;
 
     //Triggers when a user enables modulation on a running voice
-    if(!first_run && (voice.FMEnabled != FMTYPE::NONE || voice.syncEnabled) && voice.FMSmp == NULL && voice.FMVoice < 0) {
+    if(!first_run && (voice.FMEnabled != FMTYPE::NONE || voice.syncEnabled) && voice.FMSmp == NULL && voice.FMVoice == -1) {
         param.FmGn->newrandseed(prng());
         voice.FMSmp = memory.valloc<float>(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES);
         memset(voice.FMSmp, 0, sizeof(float)*(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES));
@@ -493,6 +488,7 @@ void ADnote::setupVoiceMod(int nvoice, bool first_run)
                 * fmvoldamp * 4.0f;
             break;
         case FMTYPE::FREQ_MOD:
+        case FMTYPE::SELFPM_MOD:
             FMVolume = (expf(fmvolume_ * FM_AMP_MULTIPLIER) - 1.0f)
                 * fmvoldamp * 4.0f;
             break;
@@ -626,6 +622,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
                           * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
                 break;
             case FMTYPE::FREQ_MOD:
+            case FMTYPE::SELFPM_MOD:
                 FMVolume =
                     (expf(pars.VoicePar[nvoice].FMvolume / 100.0f
                           * FM_AMP_MULTIPLIER) - 1.0f) * fmvoldamp * 4.0f;
@@ -665,7 +662,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
     // Forbids the Modulation Voice to be greater or equal than voice
     for(int i = 0; i < NUM_VOICES; ++i)
-        if(NoteVoicePar[i].FMVoice >= i)
+        if(NoteVoicePar[i].FMVoice > i)
             NoteVoicePar[i].FMVoice = -1;
 
     // Voice Parameter init
@@ -713,7 +710,7 @@ void ADnote::legatonote(const LegatoParams &lpars)
 
         /* Voice Modulation Parameters Init */
         if((NoteVoicePar[nvoice].FMEnabled != FMTYPE::NONE || NoteVoicePar[nvoice].syncEnabled)
-           && (NoteVoicePar[nvoice].FMVoice < 0)) {
+           && (NoteVoicePar[nvoice].FMVoice == -1)) {
             pars.VoicePar[nvoice].FmGn->newrandseed(prng());
 
             //Perform Anti-aliasing only on MIX or RING MODULATION
@@ -769,7 +766,6 @@ void ADnote::KillVoice(int nvoice)
     memory.devalloc(voice.unison_freq_rap);
     memory.devalloc(voice.unison_invert_phase);
     memory.devalloc(voice.FMoldsmp);
-    memory.devalloc(voice.FMtw_orig);
     memory.devalloc(voice.unison_vibratto.step);
     memory.devalloc(voice.unison_vibratto.position);
 
@@ -802,12 +798,9 @@ ADnote::~ADnote()
     memory.devalloc(tmpwaver);
     memory.devalloc(bypassl);
     memory.devalloc(bypassr);
-    for(int k = 0; k < max_unison; ++k) {
+    for(int k = 0; k < max_unison; ++k)
         memory.devalloc(tmpwave_unison[k]);
-        memory.devalloc(tmpwave_mod[k]);
-    }
     memory.devalloc(tmpwave_unison);
-    memory.devalloc(tmpwave_mod);
 }
 
 
@@ -833,7 +826,7 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
 
     // Forbids the Modulation Voice to be greater or equal than voice
     for(int i = 0; i < NUM_VOICES; ++i)
-        if(NoteVoicePar[i].FMVoice >= i)
+        if(NoteVoicePar[i].FMVoice > i)
             NoteVoicePar[i].FMVoice = -1;
 
     // Voice Parameter init
@@ -910,7 +903,7 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
         }
 
         /* Voice Modulation Parameters Init */
-        if((vce.FMEnabled != FMTYPE::NONE) && (vce.FMVoice < 0)) {
+        if((vce.FMEnabled != FMTYPE::NONE) && (vce.FMVoice == -1)) {
             param.FmGn->newrandseed(prng());
             vce.FMSmp = memory.valloc<float>(synth.oscilsize + OSCIL_SMP_EXTRA_SAMPLES);
 
@@ -964,17 +957,54 @@ void ADnote::initparameters(WatchManager *wm, const char *prefix)
     }
 
     for(int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
-        for(int i = nvoice + 1; i < NUM_VOICES; ++i)
+        for(int i = nvoice; i < NUM_VOICES; ++i)
             tmp[i] = 0;
-        for(int i = nvoice + 1; i < NUM_VOICES; ++i)
-            if((NoteVoicePar[i].FMVoice == nvoice) && (tmp[i] == 0)) {
+        for(int i = nvoice; i < NUM_VOICES; ++i)
+            if((NoteVoicePar[i].FMVoice == nvoice ) && (tmp[i] == 0)) {
                 NoteVoicePar[nvoice].VoiceOut =
                     memory.valloc<float>(synth.buffersize);
                 tmp[i] = 1;
             }
 
+        // Also allocate VoiceOut if this voice is configured to receive
+        // Part post-effect feedback (FMVOICE_PART_FEEDBACK).
+
+        if(!NoteVoicePar[nvoice].VoiceOut && NoteVoicePar[nvoice].FMVoice == FMVOICE_PART_FEEDBACK) {
+            NoteVoicePar[nvoice].VoiceOut = memory.valloc<float>(synth.buffersize);
+            //~ printf("NoteVoicePar[nvoice].FMVoice: FMVOICE_PART_FEEDBACK\n");
+
+        }
+
         if(NoteVoicePar[nvoice].VoiceOut)
             memset(NoteVoicePar[nvoice].VoiceOut, 0, synth.bufferbytes);
+    }
+}
+
+void ADnote::applyPartEffectToRelevantVoices(const float *efxoutl,
+                                             const float *efxoutr)
+{
+    // Copy the post-effect buffers into any voice that requested
+    // part-feedback (FMVoice == FMVOICE_PART_FEEDBACK). This allows
+    // that voice to use the last-part-effect output as its modulation
+    // source on the next processing block.
+    //~ printf("applyPartEffectToRelevantVoices\n");
+    for (int nvoice = 0; nvoice < NUM_VOICES; ++nvoice) {
+        auto &voice = NoteVoicePar[nvoice];
+        if (voice.FMVoice != FMVOICE_PART_FEEDBACK)
+            continue;
+        if (!voice.VoiceOut)
+            continue; // allocation should have happened in init; be defensive
+        //~ printf("nvoice: %d\n", nvoice);
+        //~ printf("stereo: %d\n", stereo);
+        if (stereo) {
+            for (int i = 0; i < synth.buffersize; ++i) {
+                voice.VoiceOut[i] = efxoutl[i] + efxoutr[i];
+                //~ if(i==0) printf("voice.VoiceOut[i]: %f\n", voice.VoiceOut[i]);
+            }
+        } else {
+            // Mono: use left channel as the input
+            memcpy(voice.VoiceOut, efxoutl, synth.bufferbytes);
+        }
     }
 }
 
@@ -1250,6 +1280,7 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
         int    freqhi = vce.oscfreqhi[k];
         // same for phase increment:
         int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
+        float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);  // sanity check
         for (int i = 0; i < synth.buffersize; ++i) {
@@ -1300,13 +1331,13 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
                 poslo &= 0xFFFFFF;               // remove overflow from poslo (keep 24 bits)
                 poshi &= synth.oscilsize - 1;    // wrap around wavetable size
             }
-        }
 
         // save updated phase (convert back from fixed-point)
         vce.oscposhi[k] = poshi;
         vce.oscposlo[k] = poslo/(16777216.0f);
     }
 }
+
 
 /*
  * Computes the Oscillator (Mixing)
@@ -1324,7 +1355,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(NoteVoicePar[nvoice].FMVoice >= 0) {
+    if(NoteVoicePar[nvoice].FMVoice != -1) {
         //if I use VoiceOut[] as modullator
         int FMVoice = NoteVoicePar[nvoice].FMVoice;
         for(int k = 0; k < vce.unison_size; ++k) {
@@ -1335,7 +1366,7 @@ inline void ADnote::ComputeVoiceOscillatorMix(int nvoice)
                                             i,
                                             synth.buffersize);
                 tw[i] = tw[i]
-                    * (1.0f - amp) + amp * NoteVoicePar[FMVoice].VoiceOut[i];
+                    * (1.0f - amp) + amp * NoteVoicePar[FMVoice==-2 ? nvoice : FMVoice].VoiceOut[i];
             }
         }
     }
@@ -1383,20 +1414,20 @@ inline void ADnote::ComputeVoiceOscillatorRingModulation(int nvoice)
         vce.FMnewamplitude = 1.0f;
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
-    if(NoteVoicePar[nvoice].FMVoice >= 0)
+    if(NoteVoicePar[nvoice].FMVoice != -1)
         // if I use VoiceOut[] as modullator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
+            int FMVoice = NoteVoicePar[nvoice].FMVoice;
             for(int i = 0; i < synth.buffersize; ++i) {
                 const float amp = INTERPOLATE_AMPLITUDE(vce.FMoldamplitude,
                                             vce.FMnewamplitude,
                                             i,
                                             synth.buffersize);
-                int FMVoice = NoteVoicePar[nvoice].FMVoice;
-                tw[i] *= (1.0f - amp) + amp * NoteVoicePar[FMVoice].VoiceOut[i];
+                tw[i] *= (1.0f - amp) + amp * NoteVoicePar[FMVoice==-2 ? nvoice : FMVoice].VoiceOut[i];
             }
         }
-    else
+    else if(NoteVoicePar[nvoice].FMVoice == -1)
         for(int k = 0; k < vce.unison_size; ++k) {
             int    poshiFM  = vce.oscposhiFM[k];
             float  posloFM  = vce.oscposloFM[k];
@@ -1438,15 +1469,41 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
     if(vce.FMoldamplitude > 1.0f)
         vce.FMoldamplitude = 1.0f;
 
-    if(vce.FMVoice >= 0)
+    if(vce.FMVoice != -1)
         // if I use VoiceOut[] as modulator
         // copy it to tmpwave_unison[][]
-        // in sync oscillator this is the only option
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[NoteVoicePar[nvoice].FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : NoteVoicePar[nvoice].FMVoice].VoiceOut;
             memcpy(tw, smps, synth.bufferbytes);
         }
+    else{
+        //Compute the modulator and store it in tmpwave_unison[][]
+        for(int k = 0; k < vce.unison_size; ++k) {
+            int    poshiFM  = vce.oscposhiFM[k];
+            int    posloFM  = (int)(vce.oscposloFM[k]  * (1<<24));
+            int    freqhiFM = vce.oscfreqhiFM[k];
+            int    freqloFM = (int)(vce.oscfreqloFM[k] * (1<<24));
+
+            float *tw = tmpwave_unison[k];
+            const float *smps = NoteVoicePar[nvoice].FMSmp;
+
+            for(int i = 0; i < synth.buffersize; ++i) {
+                tw[i] = (smps[poshiFM] * ((1<<24) - posloFM)
+                         + smps[poshiFM + 1] * posloFM) / (1.0f*(1<<24));
+
+                posloFM += freqloFM;
+                if(posloFM >= (1<<24)) {
+                    posloFM &= 0xffffff;//fmod(posloFM, 1.0f);
+                    poshiFM++;
+                }
+                poshiFM += freqhiFM;
+                poshiFM &= synth.oscilsize - 1;
+            }
+            vce.oscposhiFM[k] = poshiFM;
+            vce.oscposloFM[k] = posloFM/((1<<24)*1.0f);
+        }
+    }
 
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
@@ -1463,7 +1520,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
             // if zero is crossed on the rising slope of the modulator
             // reset phase at the carrier
             // if no modulation is selected reset only in a timewindow narrowed by FMnewamplitude
-            if (vce.FMVoice >= 0 &&
+            if (
                  ( (tw[i]>0.0f && fmold <=0.0f) ||
                     (tw[i]>=0.0f && fmold <0.0f) )
                 && (( float(poshi)/float(synth.oscilsize) < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)
@@ -1497,11 +1554,11 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                                                               FMTYPE FMmode)
 {
     Voice& vce = NoteVoicePar[nvoice];
-    if(vce.FMVoice >= 0) {
+    if(vce.FMVoice != -1) {
         //if I use VoiceOut[] as modulator
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[vce.FMVoice].VoiceOut;
+            const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : vce.FMVoice].VoiceOut;
             if (FMmode == FMTYPE::PW_MOD && (k & 1))
                 for (int i = 0; i < synth.buffersize; ++i)
                     tw[i] = -smps[i];
@@ -1546,6 +1603,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                                                vce.FMnewamplitude,
                                                i,
                                                synth.buffersize);
+            vce.FMoldamplitude = vce.FMnewamplitude;
         }
     } else {
         for(int k = 0; k < vce.unison_size; ++k) {
@@ -1557,12 +1615,10 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
 
     //normalize: makes all sample-rates, oscil_sizes to produce same sound
-    if(FMmode == FMTYPE::FREQ_MOD) { // make frequency modulation from phase modulation by integrating phase
+    if(FMmode == FMTYPE::FREQ_MOD) { //Frequency modulation
         const float normalize = synth.oscilsize_f / 262144.0f * 44100.0f
                           / synth.samplerate_f;
         for(int k = 0; k < vce.unison_size; ++k) {
-            // backup phase modulator buffer before it gets integrated for FM
-            memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
@@ -1572,10 +1628,9 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             vce.FMoldsmp[k] = fmold;
         }
     }
-    else {  //Phase or PWM modulation
+    else if(FMmode == FMTYPE::PHASE_MOD || FMmode == FMTYPE::PW_MOD) {  //Phase or PWM modulation
         const float normalize = synth.oscilsize_f / 262144.0f;
         for(int k = 0; k < vce.unison_size; ++k) {
-            memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw = tmpwave_unison[k];
             for(int i = 0; i < synth.buffersize; ++i)
                 tw[i] *= normalize;
@@ -1584,30 +1639,44 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
     //do the modulation
     for(int k = 0; k < vce.unison_size; ++k) {
-        float *smps   = vce.OscilSmp;
+        float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
-        float *tw_orig = tmpwave_mod[k];
+        float  fmold = vce.FMoldsmp[k];
         int    poshi  = vce.oscposhi[k];
         int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
         int    freqhi = vce.oscfreqhi[k];
         int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
-        float tw_orig_old = vce.FMtw_orig[k];
+
         for(int i = 0; i < synth.buffersize; ++i) {
 
-            if(  vce.syncEnabled &&
-                 vce.FMVoice >= 0 && // works only with "external" modulator
-                 ( (tw_orig[i]>0.0f && tw_orig_old <=0.0f) || (tw_orig[i]>=0.0f && tw_orig_old <0.0f) ) &&  // sync at zero crossing
-                   ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || // soft sync
-                   FMmode != FMTYPE::NONE) // no soft sync with other modulation
-              ) {
-                poshi = 0;
-                poslo = 0;
+            if(NoteVoicePar[nvoice].syncEnabled &&
+                        ( (tw[i]>0.0f && fmold <=0.0f) ||
+                        (tw[i]>=0.0f && fmold <0.0f) )) {
+                poshi = 0.0f;
+                poslo = 0.0f;
             }
-            tw_orig_old = tw_orig[i];
+            fmold = tw[i];
+
+
+            float phoffs;
+            if(FMmode == FMTYPE::SELFPM_MOD) {
+            /* phoffs is computed from the previous carrier sample (twold).
+             * Multiply by a fixed factor to scale the range of
+             * self pm amount (FM Volume) to sane values
+             */
+                phoffs = vce.twold[k] * 0.00008f * INTERPOLATE_AMPLITUDE(vce.FMoldamplitude,
+                                               vce.FMnewamplitude,
+                                               i,
+                                               synth.buffersize);
+
+            }
+            else {
+                phoffs = tw[i];
+            }
 
             int FMmodfreqhi = 0;
-            F2I(tw[i], FMmodfreqhi);
-            float FMmodfreqlo = tw[i]-FMmodfreqhi;//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
+            F2I(phoffs, FMmodfreqhi);
+            float FMmodfreqlo = phoffs-FMmodfreqhi;//fmod(tw[i] /*+ 0.0000000001f*/, 1.0f);
             if(FMmodfreqlo < 0)
                 FMmodfreqlo++;
 
@@ -1623,41 +1692,10 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             }
             carposhi &= (synth.oscilsize - 1);
 
+            tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
+                    + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
+            vce.twold[k] = tw[i];
 
-            // do AA stuff
-            // Determine if anti-aliasing is necessary based on effective frequency
-            const float absfreq = fabsf(tw[i] + freqhi);  // includes FM offset
-            const bool needsAA = (absfreq * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
-
-            if (vce.AAEnabled && needsAA) {
-                // Determine kernel step size based on frequency (higher freq = lower step size)
-                int stpsize = roundf(WSOVERSAMPLING / absfreq);
-                stpsize = clamp(stpsize, 1, WSKERNELSIZE / 2);
-
-                // Calculate convolution range and position in wavetable
-                const int conv_steps = WSKERNELSIZE / stpsize;
-                const int startoffset = conv_steps / 2;
-                int ovsmpposhi = (carposhi - startoffset) & (synth.oscilsize - 1);
-
-                // Initial kernel sample index based on fractional position
-                const int startpos = ((16777216 - carposlo) * stpsize);
-                const int startposhi = startpos >> 24;
-
-                // Convolve wavetable with kernel
-                float out = 0.0f;
-                for (int l = startposhi; l < WSKERNELSIZE; l += stpsize) {
-                    const float kernel_sample = pars.GlobalPar.wskernel[l];
-                    out += kernel_sample * smps[ovsmpposhi];
-                    ovsmpposhi = (ovsmpposhi + 1) & (synth.oscilsize - 1);
-                }
-
-                // Scale output based on step size
-                tw[i] = out * static_cast<float>(stpsize);
-            } else {
-
-                        tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
-                                + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
-            }
             poslo += freqlo;
             if(poslo >= (1<<24)) {
                 poslo &= 0xffffff;//fmod(poslo, 1.0f);
@@ -1667,7 +1705,6 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             poshi += freqhi;
             poshi &= synth.oscilsize - 1;
         }
-        vce.FMtw_orig[k] = tw_orig_old;
         vce.oscposhi[k] = poshi;
         vce.oscposlo[k] = (poslo)/((1<<24)*1.0f);
     }
@@ -1759,11 +1796,14 @@ int ADnote::noteout(float *outl, float *outr)
                     case FMTYPE::FREQ_MOD:
                     case FMTYPE::PHASE_MOD:
                     case FMTYPE::PW_MOD:
+                    case FMTYPE::SELFPM_MOD:
                         ComputeVoiceOscillatorFrequencyModulation(nvoice,
                                                                   NoteVoicePar[nvoice].FMEnabled);
                         break;
                     default:
-
+                        if(NoteVoicePar[nvoice].AAEnabled)
+                            ComputeVoiceOscillator_SincInterpolation(nvoice);
+                        else
                             if(NoteVoicePar[nvoice].syncEnabled)
                                 ComputeVoiceOscillatorSync(nvoice);
                             else

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -91,9 +91,12 @@ ADnote::ADnote(ADnoteParameters *pars_, const SynthParams &spars,
 
 
     tmpwave_unison = memory.valloc<float*>(max_unison);
+    tmpwave_mod = memory.valloc<float*>(max_unison);
     for(int k = 0; k < max_unison; ++k) {
         tmpwave_unison[k] = memory.valloc<float>(synth.buffersize);
+        tmpwave_mod[k] = memory.valloc<float>(synth.buffersize);
         memset(tmpwave_unison[k], 0, synth.bufferbytes);
+        memset(tmpwave_mod[k], 0, synth.bufferbytes);
     }
 
     initparameters(wm, prefix);
@@ -178,6 +181,7 @@ void ADnote::setupVoice(int nvoice)
         pars.VoicePar[vc].OscilGn->get(NoteVoicePar[nvoice].OscilSmp,
                 getvoicebasefreq(nvoice),
                 pars.VoicePar[nvoice].Presonance);
+    voice.OscilSmpMax = pars.VoicePar[vc].OscilGn->getMaxFreq();
 
     // This code was planned for biasing the carrier in MOD_RING
     // but that's on hold for the moment.  Disabled 'cos small
@@ -233,8 +237,11 @@ void ADnote::setupVoice(int nvoice)
     voice.FMAmpEnvelope  = NULL;
 
     voice.FMoldsmp = memory.valloc<float>(unison);
-    for(int k = 0; k < unison; ++k)
+    voice.FMtw_orig = memory.valloc<float>(unison);
+    for(int k = 0; k < unison; ++k) {
         voice.FMoldsmp[k] = 0.0f; //this is for FM (integration)
+        voice.FMtw_orig[k] = 0.0f; //this is for the original modulator
+    }
 
     voice.firsttick = 1;
     voice.DelayTicks =
@@ -766,6 +773,7 @@ void ADnote::KillVoice(int nvoice)
     memory.devalloc(voice.unison_freq_rap);
     memory.devalloc(voice.unison_invert_phase);
     memory.devalloc(voice.FMoldsmp);
+    memory.devalloc(voice.FMtw_orig);
     memory.devalloc(voice.unison_vibratto.step);
     memory.devalloc(voice.unison_vibratto.position);
 
@@ -798,9 +806,12 @@ ADnote::~ADnote()
     memory.devalloc(tmpwaver);
     memory.devalloc(bypassl);
     memory.devalloc(bypassr);
-    for(int k = 0; k < max_unison; ++k)
+    for(int k = 0; k < max_unison; ++k) {
         memory.devalloc(tmpwave_unison[k]);
+        memory.devalloc(tmpwave_mod[k]);
+    }
     memory.devalloc(tmpwave_unison);
+    memory.devalloc(tmpwave_mod);
 }
 
 
@@ -1280,16 +1291,14 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
         int    freqhi = vce.oscfreqhi[k];
         // same for phase increment:
         int    freqlo = (int)(vce.oscfreqlo[k] * 16777216.0f);
-        float *smps   = NoteVoicePar[nvoice].OscilSmp;
         float *tw     = tmpwave_unison[k];
         assert(vce.oscfreqlo[k] < 1.0f);  // sanity check
+        const bool useAA = NoteVoicePar[nvoice].AAEnabled
+            && (freqhi * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
         for (int i = 0; i < synth.buffersize; ++i) {
             float out = 0.0f;
 
-            // Determine if Anti-Aliasing is needed:
-            const bool needsAA = (freqhi * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
-
-            if (NoteVoicePar[nvoice].AAEnabled && needsAA) {
+            if (useAA) {
 
                 // Calculate how many kernel samples to skip per step in the convolution loop.
                 // Higher oversampling → smaller step size → better filtering but more computation.
@@ -1331,13 +1340,13 @@ inline void ADnote::ComputeVoiceOscillator_LinearInterpolation(int nvoice)
                 poslo &= 0xFFFFFF;               // remove overflow from poslo (keep 24 bits)
                 poshi &= synth.oscilsize - 1;    // wrap around wavetable size
             }
+        }
 
         // save updated phase (convert back from fixed-point)
         vce.oscposhi[k] = poshi;
         vce.oscposlo[k] = poslo/(16777216.0f);
     }
 }
-
 
 /*
  * Computes the Oscillator (Mixing)
@@ -1472,38 +1481,12 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
     if(vce.FMVoice != -1)
         // if I use VoiceOut[] as modulator
         // copy it to tmpwave_unison[][]
+        // in sync oscillator this is the only option
         for(int k = 0; k < vce.unison_size; ++k) {
             float *tw = tmpwave_unison[k];
             const float *smps = NoteVoicePar[(vce.FMVoice == -2) ? nvoice : NoteVoicePar[nvoice].FMVoice].VoiceOut;
             memcpy(tw, smps, synth.bufferbytes);
         }
-    else{
-        //Compute the modulator and store it in tmpwave_unison[][]
-        for(int k = 0; k < vce.unison_size; ++k) {
-            int    poshiFM  = vce.oscposhiFM[k];
-            int    posloFM  = (int)(vce.oscposloFM[k]  * (1<<24));
-            int    freqhiFM = vce.oscfreqhiFM[k];
-            int    freqloFM = (int)(vce.oscfreqloFM[k] * (1<<24));
-
-            float *tw = tmpwave_unison[k];
-            const float *smps = NoteVoicePar[nvoice].FMSmp;
-
-            for(int i = 0; i < synth.buffersize; ++i) {
-                tw[i] = (smps[poshiFM] * ((1<<24) - posloFM)
-                         + smps[poshiFM + 1] * posloFM) / (1.0f*(1<<24));
-
-                posloFM += freqloFM;
-                if(posloFM >= (1<<24)) {
-                    posloFM &= 0xffffff;//fmod(posloFM, 1.0f);
-                    poshiFM++;
-                }
-                poshiFM += freqhiFM;
-                poshiFM &= synth.oscilsize - 1;
-            }
-            vce.oscposhiFM[k] = poshiFM;
-            vce.oscposloFM[k] = posloFM/((1<<24)*1.0f);
-        }
-    }
 
     for(int k = 0; k < vce.unison_size; ++k) {
         int    poshi  = vce.oscposhi[k];
@@ -1520,7 +1503,7 @@ inline void ADnote::ComputeVoiceOscillatorSync(int nvoice)
             // if zero is crossed on the rising slope of the modulator
             // reset phase at the carrier
             // if no modulation is selected reset only in a timewindow narrowed by FMnewamplitude
-            if (
+            if (vce.FMVoice >= 0 &&
                  ( (tw[i]>0.0f && fmold <=0.0f) ||
                     (tw[i]>=0.0f && fmold <0.0f) )
                 && (( float(poshi)/float(synth.oscilsize) < vce.FMnewamplitude) || vce.FMEnabled != FMTYPE::NONE)
@@ -1593,6 +1576,8 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             vce.oscposloFM[k] = posloFM/((1<<24)*1.0f);
         }
     }
+
+
     // Amplitude interpolation
     if(ABOVE_AMPLITUDE_THRESHOLD(vce.FMoldamplitude,
                                  vce.FMnewamplitude)) {
@@ -1615,10 +1600,13 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
 
     //normalize: makes all sample-rates, oscil_sizes to produce same sound
-    if(FMmode == FMTYPE::FREQ_MOD) { //Frequency modulation
+    if(FMmode == FMTYPE::FREQ_MOD) { // make frequency modulation from phase modulation by integrating phase
         const float normalize = synth.oscilsize_f / 262144.0f * 44100.0f
                           / synth.samplerate_f;
         for(int k = 0; k < vce.unison_size; ++k) {
+            // backup phase modulator buffer before it gets integrated for FM
+            if (vce.syncEnabled)
+                memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw    = tmpwave_unison[k];
             float  fmold = vce.FMoldsmp[k];
             for(int i = 0; i < synth.buffersize; ++i) {
@@ -1631,6 +1619,8 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
     else if(FMmode == FMTYPE::PHASE_MOD || FMmode == FMTYPE::PW_MOD) {  //Phase or PWM modulation
         const float normalize = synth.oscilsize_f / 262144.0f;
         for(int k = 0; k < vce.unison_size; ++k) {
+            if (vce.syncEnabled)
+                memcpy(tmpwave_mod[k], tmpwave_unison[k], synth.bufferbytes);
             float *tw = tmpwave_unison[k];
             for(int i = 0; i < synth.buffersize; ++i)
                 tw[i] *= normalize;
@@ -1639,23 +1629,26 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
 
     //do the modulation
     for(int k = 0; k < vce.unison_size; ++k) {
-        float *smps   = NoteVoicePar[nvoice].OscilSmp;
+        float *smps   = vce.OscilSmp;
         float *tw     = tmpwave_unison[k];
-        float  fmold = vce.FMoldsmp[k];
+        float *tw_orig = tmpwave_mod[k];
         int    poshi  = vce.oscposhi[k];
         int    poslo  = (int)(vce.oscposlo[k] * (1<<24));
         int    freqhi = vce.oscfreqhi[k];
         int    freqlo = (int)(vce.oscfreqlo[k] * (1<<24));
-
+        float tw_orig_old = vce.FMtw_orig[k];
         for(int i = 0; i < synth.buffersize; ++i) {
 
-            if(NoteVoicePar[nvoice].syncEnabled &&
-                        ( (tw[i]>0.0f && fmold <=0.0f) ||
-                        (tw[i]>=0.0f && fmold <0.0f) )) {
-                poshi = 0.0f;
-                poslo = 0.0f;
+            if(  vce.syncEnabled &&
+                 vce.FMVoice >= 0 && // works only with "external" modulator
+                 ( (tw_orig[i]>0.0f && tw_orig_old <=0.0f) || (tw_orig[i]>=0.0f && tw_orig_old <0.0f) ) &&  // sync at zero crossing
+                   ((float(poshi)/synth.oscilsize < vce.FMnewamplitude) || // soft sync
+                   FMmode != FMTYPE::NONE) // no soft sync with other modulation
+              ) {
+                poshi = 0;
+                poslo = 0;
             }
-            fmold = tw[i];
+            tw_orig_old = tw_orig[i];
 
 
             float phoffs;
@@ -1696,6 +1689,40 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
                     + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
             vce.twold[k] = tw[i];
 
+            // do AA stuff
+            // Determine if anti-aliasing is necessary based on effective frequency
+            const float absfreq = fabsf(tw[i] + freqhi);  // includes FM offset
+            const bool needsAA = (absfreq * vce.OscilSmpMax) > (0.5f * synth.oscilsize_f);
+
+            if (vce.AAEnabled && needsAA) {
+                // Determine kernel step size based on frequency (higher freq = lower step size)
+                int stpsize = roundf(WSOVERSAMPLING / absfreq);
+                stpsize = clamp(stpsize, 1, WSKERNELSIZE / 2);
+
+                // Calculate convolution range and position in wavetable
+                const int conv_steps = WSKERNELSIZE / stpsize;
+                const int startoffset = conv_steps / 2;
+                int ovsmpposhi = (carposhi - startoffset) & (synth.oscilsize - 1);
+
+                // Initial kernel sample index based on fractional position
+                const int startpos = ((16777216 - carposlo) * stpsize);
+                const int startposhi = startpos >> 24;
+
+                // Convolve wavetable with kernel
+                float out = 0.0f;
+                for (int l = startposhi; l < WSKERNELSIZE; l += stpsize) {
+                    const float kernel_sample = pars.GlobalPar.wskernel[l];
+                    out += kernel_sample * smps[ovsmpposhi];
+                    ovsmpposhi = (ovsmpposhi + 1) & (synth.oscilsize - 1);
+                }
+
+                // Scale output based on step size
+                tw[i] = out * static_cast<float>(stpsize);
+            } else {
+
+                        tw[i] = (smps[carposhi] * ((1<<24) - carposlo)
+                                + smps[carposhi + 1] * carposlo)/(1.0f*(1<<24));
+            }
             poslo += freqlo;
             if(poslo >= (1<<24)) {
                 poslo &= 0xffffff;//fmod(poslo, 1.0f);
@@ -1705,6 +1732,7 @@ inline void ADnote::ComputeVoiceOscillatorFrequencyModulation(int nvoice,
             poshi += freqhi;
             poshi &= synth.oscilsize - 1;
         }
+        vce.FMtw_orig[k] = tw_orig_old;
         vce.oscposhi[k] = poshi;
         vce.oscposlo[k] = (poslo)/((1<<24)*1.0f);
     }
@@ -1801,9 +1829,7 @@ int ADnote::noteout(float *outl, float *outr)
                                                                   NoteVoicePar[nvoice].FMEnabled);
                         break;
                     default:
-                        if(NoteVoicePar[nvoice].AAEnabled)
-                            ComputeVoiceOscillator_SincInterpolation(nvoice);
-                        else
+
                             if(NoteVoicePar[nvoice].syncEnabled)
                                 ComputeVoiceOscillatorSync(nvoice);
                             else
@@ -2124,7 +2150,7 @@ void ADnote::Voice::kill(Allocator &memory, const SYNTH_T &synth)
     memory.dealloc(FMFreqEnvelope);
     memory.dealloc(FMAmpEnvelope);
 
-    if((FMEnabled != FMTYPE::NONE) && (FMVoice < 0))
+    if((FMEnabled != FMTYPE::NONE) && (FMVoice == -1))
         memory.devalloc(FMSmp);
 
     if(VoiceOut)

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -54,6 +54,17 @@ class ADnote:public SynthNote
 
 
         virtual SynthNote *cloneLegato(void) override;
+    // special FMVoice value meaning: use Part post-effect output as modulator
+    static const int FMVOICE_PART_FEEDBACK = -2;
+
+    /**Hook called by Part after an effect writes its output.
+     * Implementations may copy the post-effect buffers into internal
+     * per-voice buffers (e.g. VoiceOut) so they can be used as
+     * modulation sources on the next processing block.
+     * Default behaviour is to do nothing (see SynthNote).
+     */
+    virtual void applyPartEffectToRelevantVoices(const float *efxoutl,
+                                                 const float *efxoutr);
     private:
 
         void setupVoice(int nvoice);
@@ -119,6 +130,7 @@ class ADnote:public SynthNote
         unsigned char     stereo; //if the note is stereo (allows note Panning)
         float note_log2_freq;
         float velocity;
+
 
         ONOFFTYPE   NoteEnabled;
 
@@ -252,6 +264,7 @@ class ADnote:public SynthNote
             // Voice Output used by other voices if use this as modullator
             float *VoiceOut;
 
+
             /* Wave of the Voice */
             float *FMSmp;
 
@@ -315,6 +328,8 @@ class ADnote:public SynthNote
 
             //1 - if it is the fitst tick (used to fade in the sound)
             char firsttick;
+
+            float *twold;
 
         } NoteVoicePar[NUM_VOICES];
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -315,6 +315,7 @@ class ADnote:public SynthNote
 
             //used by Frequency Modulation (for integration)
             float *FMoldsmp;
+            float *FMtw_orig;
 
             //1 - if it is the fitst tick (used to fade in the sound)
             char firsttick;
@@ -324,6 +325,7 @@ class ADnote:public SynthNote
         //temporary buffer
         float  *tmpwavel;
         float  *tmpwaver;
+        float **tmpwave_mod;
         int     max_unison;
         float **tmpwave_unison;
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -54,6 +54,17 @@ class ADnote:public SynthNote
 
 
         virtual SynthNote *cloneLegato(void) override;
+    // special FMVoice value meaning: use Part post-effect output as modulator
+    static const int FMVOICE_PART_FEEDBACK = -2;
+
+    /**Hook called by Part after an effect writes its output.
+     * Implementations may copy the post-effect buffers into internal
+     * per-voice buffers (e.g. VoiceOut) so they can be used as
+     * modulation sources on the next processing block.
+     * Default behaviour is to do nothing (see SynthNote).
+     */
+    virtual void applyPartEffectToRelevantVoices(const float *efxoutl,
+                                                 const float *efxoutr);
     private:
 
         void setupVoice(int nvoice);
@@ -119,6 +130,7 @@ class ADnote:public SynthNote
         unsigned char     stereo; //if the note is stereo (allows note Panning)
         float note_log2_freq;
         float velocity;
+
 
         ONOFFTYPE   NoteEnabled;
 
@@ -255,6 +267,7 @@ class ADnote:public SynthNote
             // Voice Output used by other voices if use this as modullator
             float *VoiceOut;
 
+
             /* Wave of the Voice */
             float *FMSmp;
 
@@ -319,6 +332,8 @@ class ADnote:public SynthNote
 
             //1 - if it is the fitst tick (used to fade in the sound)
             char firsttick;
+
+            float *twold;
 
         } NoteVoicePar[NUM_VOICES];
 

--- a/src/Synth/ADnote.h
+++ b/src/Synth/ADnote.h
@@ -196,6 +196,9 @@ class ADnote:public SynthNote
             /* Waveform of the Voice */
             float *OscilSmp;
 
+            /* max freq inside OscilSmp */
+            float OscilFreqMin;
+
             /* preserved for phase mod PWM emulation. */
             int phase_offset;
 

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -1131,6 +1131,17 @@ bool OscilGen::needPrepare(OscilGenBuffers& bfrs) const
     return outdated == true || bfrs.oscilprepared == false;
 }
 
+short int OscilGen::getMaxFreq(OscilGenBuffers& bfrs) const
+{
+    int nyquist = synth.oscilsize / 2;
+    for (int i = nyquist - 1; i > 0; --i)
+        {
+            if (fabsf(bfrs.outoscilFFTfreqs[i].real()) > 1e-6f || fabsf(bfrs.outoscilFFTfreqs[i].imag()) > 1e-6f)
+                return i;
+        }
+        return 0;
+
+}
 /*
  * Get the oscillator function
  */

--- a/src/Synth/OscilGen.cpp
+++ b/src/Synth/OscilGen.cpp
@@ -1129,6 +1129,17 @@ bool OscilGen::needPrepare(OscilGenBuffers& bfrs) const
     return outdated == true || bfrs.oscilprepared == false;
 }
 
+short int OscilGen::getMaxFreq(OscilGenBuffers& bfrs) const
+{
+    int nyquist = synth.oscilsize / 2;
+    for (int i = nyquist - 1; i > 0; --i)
+        {
+            if (fabsf(bfrs.outoscilFFTfreqs[i].real()) > 1e-6f || fabsf(bfrs.outoscilFFTfreqs[i].imag()) > 1e-6f)
+                return i;
+        }
+        return 0;
+
+}
 /*
  * Get the oscillator function
  */

--- a/src/Synth/OscilGen.h
+++ b/src/Synth/OscilGen.h
@@ -98,8 +98,12 @@ class OscilGen:public Presets, NoCopyNoMove
         /**do the antialiasing(cut off higher freqs.),apply randomness and do a IFFT*/
         //returns where should I start getting samples, used in block type randomness
         short get(OscilGenBuffers& bfrs, float *smps, float freqHz, int resonance = 0) const;
+        short getMaxFreq(OscilGenBuffers& bfrs) const;
         short get(float *smps, float freqHz, int resonance = 0) {
             return get(myBuffers(), smps, freqHz, resonance);
+        }
+        short getMaxFreq() {
+            return getMaxFreq(myBuffers());
         }
         //if freqHz is smaller than 0, return the "un-randomized" sample for UI
 

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -68,6 +68,14 @@ class SynthNote
 
         virtual SynthNote *cloneLegato(void) = 0;
 
+    /**
+     * Hook: deliver part-effect outputs to the note so the note
+     * implementation may copy them into internal buffers (e.g. VoiceOut).
+     * Called from Part after an insertion effect has produced its output.
+     * Default implementation does nothing.
+     */
+    virtual void applyPartEffectToRelevantVoices(const float *efxoutl, const float *efxoutr) { (void)efxoutl; (void)efxoutr; }
+
         /* For polyphonic aftertouch needed */
         void setVelocity(float velocity_);
 


### PR DESCRIPTION
rebased branch of FMAA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anti-aliasing oscillator path for clearer high-frequency audio.
  * High-quality windowed-sinc kernel generation for resampling/filtering.

* **Improvements**
  * Per-voice modulation buffering for cleaner FM/modulation results.
  * More accurate phase and fixed-point math for stable oscillator rendering.
  * Frequency-analysis helpers to detect and adapt to high-frequency content.

* **Chores**
  * Minor interface/signature tidy-ups and memory management updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->