### PR TITLE
Bump C++ version to C++20

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 
 #checking include/library paths
 message(STATUS "Checking Include Path" $ENV{CMAKE_INCLUDE_PATH} ${CMAKE_INCLUDE_PATH})

--- a/src/UI/ADnoteUI.fl
+++ b/src/UI/ADnoteUI.fl
@@ -243,7 +243,7 @@ adnoteui->currentvoicecounter->do_callback();
     };
     nvoice=0;} {}
   }
-  Function {init(int nvoice_, std::string loc_, Fl_Osc_Interface *osc_)} {open
+  Function {init(int nvoice_, std::string loc_, [[maybe_unused]] Fl_Osc_Interface *osc_)} {open
   } {
     code {assert(osc_);
 assert(!loc_.empty());

--- a/src/UI/Fl_Osc_TSlider.cpp
+++ b/src/UI/Fl_Osc_TSlider.cpp
@@ -14,13 +14,8 @@
 //Copyright (c) 2015 Christopher Oliver
 //License: GNU GPL version 2 or later
 
-static float identity(float value)
-{
-    return value;
-}
-
 Fl_Osc_TSlider::Fl_Osc_TSlider(int x, int y, int w, int h, const char *label)
-    :Fl_Osc_Slider(x, y, w, h, label), transform(identity)
+    :Fl_Osc_Slider(x, y, w, h, label), transform([](float value) -> float { return value; })
 {
     Fl_Group *save = Fl_Group::current();
     tipwin = new TipWin();

--- a/src/UI/WidgetPDial.cpp
+++ b/src/UI/WidgetPDial.cpp
@@ -21,15 +21,10 @@
 
 //static int numobj = 0;
 
-static float identity(float value)
-{
-    return value;
-}
-
 WidgetPDial::WidgetPDial(int x, int y, int w, int h, const char *label)
     :Fl_Dial(x, y, w, h, label), reset_value(0), integer_step(true),
      use_rounding(false),  oldvalue(0.0f), pos(false), textset(false),
-     transform(identity)
+     transform([](float value) -> float { return value; })
 {
     //cout << "[" << label << "] There are now " << ++numobj << endl;
     Fl_Group *save = Fl_Group::current();


### PR DESCRIPTION
@fundamental After some discussions with AI about #372 , it would be better if I use `std::thread*` instead of `std::thread` *everywhere* in that PR (all classes that I changed) because `std::thread::joinable()` is not reliable, and I don't want to introduce new issues. However, using pointers/`new` just for that does not seem idiomatic for me, so the only real alternative is C++20 to me, since it has guaranteed lock-free `std::atomic_flag::test()`. So, I pushed this branch. Please take a look at it, and please also compile it with your system, which seems to be a good testing candidate for an old Linux.

---

We require this change in order to use `std::atomic_flag::test()`.

Changes in this PR:

- Raise C++ version in CMakeLists.txt
- Fix `identity` clashing with
- Fix (probably) unrelated compiler warning in ADnoteUI.fl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project to use C++20 standard for improved language features and compatibility.
  * Implemented code modernization improvements including parameter annotations and lambda optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->