### PR TITLE
add midi MPE for pitchbend, aftertouch and cutoff

### DIFF
--- a/doc/mpe.txt
+++ b/doc/mpe.txt
@@ -1,0 +1,107 @@
+MPE (MIDI Polyphonic Expression)
+=================================
+
+ZynAddSubFX supports MPE (MIDI Polyphonic Expression) per the MPE
+specification (v1.1, ISBN 978-1-937544-22-3).
+
+MPE allows per-note control of pitch bend, aftertouch (channel pressure),
+and timbre (CC74) by assigning each note to its own MIDI channel within
+a zone.
+
+
+Zones
+-----
+
+Two MPE zones are supported:
+
+Lower Zone::
+  Master channel 0, member channels 1..15 (default).
+Upper Zone::
+  Master channel 15, member channels 0 (default, no members).
+
+A part assigned to a zone's master channel will receive notes from all
+member channels of that zone.
+
+Configuration via RPN 0x0006::
+  Send RPN 0x0006 on the master channel to set the number of member
+  channels. Example (lower zone, 5 members):
+
+    [MIDI CC 101] RPN MSB    = 0x00
+    [MIDI CC 100] RPN LSB    = 0x06
+    [MIDI CC 6]   Data Entry = 5
+
+  If member channels > 0 and MPE is not yet enabled, MPE is automatically
+  enabled. Sending member channels = 0 removes all member channels from
+  the zone, effectively disabling routing for that zone.
+
+
+Controllers
+-----------
+
+In MPE mode, the following controllers on member channels are intercepted
+and forwarded to the appropriate notes via the MPE path:
+
+  Pitch Bend (C_pitchwheel)::
+    Stored per channel in `channelState[chan].pitchBend`. Applied to
+    active notes via `Part::SetMPEController`.
+
+  Aftertouch (C_aftertouch)::
+    Stored in `channelState[chan].pressure`. Forwarded to active notes.
+
+  Timbre / CC74 (C_filtercutoff)::
+    Stored in `channelState[chan].timbre`. Forwarded to active notes.
+
+Manager Channel Pitch Bend::
+  Pitch bend on a zone's master channel is applied to all notes on all
+  member channels of that zone via `Part::ApplyMPEManagerBend`.
+
+
+Pitch Bend Range (RPN 0x0000)
+-----------------------------
+
+The pitch bend range is configurable per channel via RPN 0x0000:
+
+  [MIDI CC 101] RPN MSB    = 0x00
+  [MIDI CC 100] RPN LSB    = 0x00
+  [MIDI CC 6]   Data Entry = <semitones>
+
+Range is clamped to 0..6400 cents (0..64 semitones). Fine adjustment
+via Data Entry LSB (CC 38) for sub-semitone resolution.
+
+
+Stored Bend on NoteOn (MPE Section 2.2.6)
+------------------------------------------
+
+When a note is played on a member channel, any previously received
+pitch bend values are applied immediately:
+
+  * Member channel pitch bend is applied via `SetMPEController`.
+  * Manager channel pitch bend is applied via `ApplyMPEManagerBend`.
+
+This ensures that controller changes received before a note starts are
+reflected in the note's initial pitch.
+
+
+Implementation Details
+----------------------
+
+Source files:
+
+  src/Misc/Master.h::
+    `MPEenabled` (public bool), `MPEState channelState[16]`,
+    `mpe_*` zone configuration fields.
+
+  src/Misc/Master.cpp::
+    `handleMPEController()` -- stores and forwards MPE controllers.
+    `processMPERPN()` / `applyMPERPN()` -- handles RPN 0x0000/0x0006.
+    `channelMatchesPart()` -- routes member channels to zone parts.
+    `syncMPEEnableState()` -- manages MPE enable/disable transitions.
+
+  src/Misc/Part.cpp::
+    `SetMPEController()` -- applies MPE controllers to active notes.
+    `ApplyMPEManagerBend()` -- applies manager channel pitch bend.
+
+  src/Synth/SynthNote.cpp::
+    `setMPEPitchBend()` -- per-note pitch bend storage and application.
+
+Tests: `src/Tests/MiddlewareTest.cpp` (testMPE*)

--- a/src/Containers/NotePool.cpp
+++ b/src/Containers/NotePool.cpp
@@ -186,7 +186,12 @@ int NotePool::usedSynthDesc(void) const
     return cnt;
 }
 
-void NotePool::insertNote(note_t note, uint8_t sendto, SynthDescriptor desc, PortamentoRealtime *portamento_realtime, bool legato)
+void NotePool::insertNote(note_t note,
+                          uint8_t sendto,
+                          SynthDescriptor desc,
+                          PortamentoRealtime *portamento_realtime,
+                          bool legato,
+                          char chan)
 {
     //Get first free note descriptor
     int desc_id = getMergeableDescriptor(note, sendto, legato, ndesc);
@@ -209,6 +214,7 @@ void NotePool::insertNote(note_t note, uint8_t sendto, SynthDescriptor desc, Por
     ndesc[desc_id].status              = KEY_PLAYING;
     ndesc[desc_id].legatoMirror        = legato;
     ndesc[desc_id].portamentoRealtime  = portamento_realtime;
+    ndesc[desc_id].chan  = chan;
 
     sdesc[sdesc_id] = desc;
     return;

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -38,9 +38,10 @@ class NotePool
             uint8_t size;
             uint8_t status;
             bool    legatoMirror;
+            char chan;
+
             PortamentoRealtime *portamentoRealtime;
             bool operator==(NoteDescriptor);
-            char chan;
 
             //status checks
             bool playing(void) const;

--- a/src/Containers/NotePool.h
+++ b/src/Containers/NotePool.h
@@ -40,6 +40,7 @@ class NotePool
             bool    legatoMirror;
             PortamentoRealtime *portamentoRealtime;
             bool operator==(NoteDescriptor);
+            char chan;
 
             //status checks
             bool playing(void) const;
@@ -123,8 +124,12 @@ class NotePool
         NotePool(void);
 
         //Operations
-        void insertNote(note_t note, uint8_t sendto, SynthDescriptor desc,
-                        PortamentoRealtime *portamento_realtime=NULL, bool legato=false);
+        void insertNote(note_t note,
+                        uint8_t sendto,
+                        SynthDescriptor desc,
+                        PortamentoRealtime *portamento_realtime=NULL,
+                        bool legato=false,
+                        char chan=0);
         void insertLegatoNote(NoteDescriptor desc, SynthDescriptor sdesc);
 
         void upgradeToLegato(void);

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -984,7 +984,7 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
             if(chan == part[npart]->Prcvchn) {
                 fakepeakpart[npart] = velocity * 2;
                 if(part[npart]->Penabled)
-                    part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq);
+                    part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
             }
         }
         activeNotes[note] = 1;
@@ -1021,6 +1021,9 @@ void Master::polyphonicAftertouch(char chan, note_t note, char velocity)
  */
 void Master::handleMPEController(int chan, int type, int par)
 {
+    if(chan < 0 || chan >= 16)
+        return;
+
     switch(type) {
     case C_pitch:
         channelState[chan].pitchBend = par;

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1017,12 +1017,37 @@ void Master::polyphonicAftertouch(char chan, note_t note, char velocity)
 }
 
 /*
+ * MPE Messages (velocity=0 for NoteOff)
+ */
+void Master::handleMPEController(int chan, int type, int par)
+{
+    switch(type) {
+    case C_pitch:
+        channelState[chan].pitchBend = par;
+        break;
+    case C_aftertouch:
+        channelState[chan].pressure  = par;
+        break;
+    case C_filtercutoff:
+        channelState[chan].timbre    = par;
+        break;
+    default:
+        return;
+    }
+    for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
+        if((0 == part[npart]->Prcvchn) && (part[npart]->Penabled != 0))
+            part[npart]->SetMPEController(chan,type, par);
+
+}
+
+/*
  * Controllers
  */
 void Master::setController(char chan, int type, int par)
 {
     if(frozenState)
         return;
+    handleMPEController(chan, type, par);
     automate.handleMidi(chan, type, par);
     midi.handleCC(type, par, chan, false);
     if((type == C_dataentryhi) || (type == C_dataentrylo)

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -40,9 +40,17 @@
 #include <cmath>
 #include <atomic>
 #include <cstdlib>
+#include <cstdio>
 #include <unistd.h>
 
 using namespace std;
+
+/* MPE Debug */
+#define MPE_DBG(...) do { \
+    static FILE *mpe_f = NULL; \
+    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
+    if(mpe_f) { fprintf(mpe_f, "Master: " __VA_ARGS__); fflush(mpe_f); } \
+} while(0)
 using namespace rtosc;
 
 namespace zyn {
@@ -1088,6 +1096,7 @@ void Master::applyMPERPN(int chan)
         if(cents > 6400)
             cents = 6400;
         mpe_pitchbend_range_cents[chan] = cents;
+        MPE_DBG("RPN 0x0000 PitchBendRange chan=%d cents=%d\n", chan, cents);
     }
     else if(rpn == 0x0006) {
         int member_channels = mpe_data_msb[chan];
@@ -1095,6 +1104,9 @@ void Master::applyMPERPN(int chan)
             member_channels = 0;
         if(member_channels > 15)
             member_channels = 15;
+
+        MPE_DBG("RPN 0x0006 MPE Config chan=%d member_channels=%d MPEenabled=%d\n",
+                chan, member_channels, MPEenabled);
 
         // Host-announced MPE configuration should enable MPE routing,
         // even if UI-side MPE toggle did not reach this Master instance.
@@ -1129,6 +1141,8 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
             if(channelMatchesPart(part[npart], chan)) {
                 matched_parts++;
+                MPE_DBG("noteOn chan=%d note=%d vel=%d -> Part %d (Prcvchn=%d)\n",
+                        chan, note, velocity, npart, part[npart]->Prcvchn);
                 fakepeakpart[npart] = velocity * 2;
                 if(part[npart]->Penabled)
                     part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
@@ -1184,12 +1198,16 @@ void Master::handleMPEController(int chan, int type, int par)
     switch(type) {
     case C_pitchwheel:
     case C_pitch:
+        MPE_DBG("handleMPEController chan=%d type=%s val=%d\n",
+                chan, type==C_pitchwheel?"pitchwheel":"pitch", par);
         channelState[chan].pitchBend = par;
         break;
     case C_aftertouch:
+        MPE_DBG("handleMPEController chan=%d type=aftertouch val=%d\n", chan, par);
         channelState[chan].pressure  = par;
         break;
     case C_filtercutoff:
+        MPE_DBG("handleMPEController chan=%d type=cutoff val=%d\n", chan, par);
         channelState[chan].timbre    = par;
         break;
     default:
@@ -1198,9 +1216,13 @@ void Master::handleMPEController(int chan, int type, int par)
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
         if((part[npart]->Penabled != 0)
            && isMPEMemberChannel(chan)
-           && channelMatchesPart(part[npart], chan))
+           && channelMatchesPart(part[npart], chan)) {
+            MPE_DBG("handleMPEController -> Part %d SetMPEController chan=%d par=%d bend_range=%.0f\n",
+                    npart, chan, par,
+                    getMPEPitchBendRangeCents(chan));
             part[npart]->SetMPEController(chan, type, par,
                 getMPEPitchBendRangeCents(chan));
+        }
 
 }
 
@@ -1217,6 +1239,10 @@ void Master::setController(char chan, int type, int par)
         || (type == C_pitch)
         || (type == C_aftertouch)
         || (type == C_filtercutoff);
+
+    if(isMPEExpressionController)
+        MPE_DBG("setController chan=%d type=%d par=%d MPEenabled=%d\n",
+                chan, type, par, MPEenabled);
 
     processMPERPN(chan, type, par);
     if(MPEenabled) handleMPEController(chan, type, par);

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -601,6 +601,8 @@ static const Ports master_ports = {
         rBOIL_END},
     {"bank/", rDoc("Controls for instrument banks"), &bankPorts,
             [](const char*,RtData&) {}},
+    rToggle(MPEenabled, rShort("MPE"),
+            rDefault(false), "MPE enable"),
     {"learn:s", rProp(deprecated) rDoc("MIDI Learn"), 0,
         rBegin;
         int free_slot = m->automate.free_slot();
@@ -1050,7 +1052,7 @@ void Master::setController(char chan, int type, int par)
 {
     if(frozenState)
         return;
-    handleMPEController(chan, type, par);
+    if(MPEenabled) handleMPEController(chan, type, par);
     automate.handleMidi(chan, type, par);
     midi.handleCC(type, par, chan, false);
     if((type == C_dataentryhi) || (type == C_dataentrylo)
@@ -1075,9 +1077,9 @@ void Master::setController(char chan, int type, int par)
                     break;
             }
         }
-    } else {  //other controllers
+    } else if(!MPEenabled) {  //other controllers
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) //Send the controller to all part assigned to the channel
-            if((chan == part[npart]->Prcvchn) && (part[npart]->Penabled != 0))
+            if(((chan == part[npart]->Prcvchn) || MPEenabled) && (part[npart]->Penabled != 0) )
                 part[npart]->SetController(type, par);
 
         if(type == C_allsoundsoff) { //cleanup insertion/system FX

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -972,7 +972,127 @@ void Master::defaults()
     }
 
     microtonal.defaults();
+    MPEenabled = false;
+    resetMPEConfig();
     ShutUp();
+}
+
+void Master::resetMPEConfig(void)
+{
+    mpe_lower_master_channel = 0;
+    mpe_upper_master_channel = 15;
+    mpe_lower_member_channels = 15;
+    mpe_upper_member_channels = 0;
+
+    for(int chan = 0; chan < 16; ++chan) {
+        channelState[chan].pitchBend = 0.0f;
+        channelState[chan].pressure = 0.0f;
+        channelState[chan].timbre = 64.0f;
+        mpe_pitchbend_range_cents[chan] = ctl.pitchwheel.bendrange;
+        mpe_rpn_msb[chan] = -1;
+        mpe_rpn_lsb[chan] = -1;
+        mpe_data_msb[chan] = -1;
+        mpe_data_lsb[chan] = -1;
+    }
+}
+
+bool Master::isLowerZoneMember(int chan) const
+{
+    return chan > mpe_lower_master_channel
+        && chan <= mpe_lower_master_channel + mpe_lower_member_channels;
+}
+
+bool Master::isUpperZoneMember(int chan) const
+{
+    return chan < mpe_upper_master_channel
+        && chan >= mpe_upper_master_channel - mpe_upper_member_channels;
+}
+
+bool Master::isMPEMemberChannel(int chan) const
+{
+    return isLowerZoneMember(chan) || isUpperZoneMember(chan);
+}
+
+bool Master::channelMatchesPart(const Part *p, int chan) const
+{
+    if(chan == p->Prcvchn)
+        return true;
+
+    if(!MPEenabled)
+        return false;
+
+    if(p->Prcvchn != 0)
+        return false;
+
+    return isMPEMemberChannel(chan);
+}
+
+void Master::processMPERPN(int chan, int type, int value)
+{
+    if(!MPEenabled)
+        return;
+    if(chan < 0 || chan >= 16)
+        return;
+
+    switch(type) {
+    case C_rpnhi:
+        mpe_rpn_msb[chan] = value;
+        mpe_data_msb[chan] = -1;
+        mpe_data_lsb[chan] = -1;
+        break;
+    case C_rpnlo:
+        mpe_rpn_lsb[chan] = value;
+        mpe_data_msb[chan] = -1;
+        mpe_data_lsb[chan] = -1;
+        break;
+    case C_dataentryhi:
+        mpe_data_msb[chan] = value;
+        applyMPERPN(chan);
+        break;
+    case C_dataentrylo:
+        mpe_data_lsb[chan] = value;
+        applyMPERPN(chan);
+        break;
+    default:
+        break;
+    }
+}
+
+void Master::applyMPERPN(int chan)
+{
+    if(mpe_rpn_msb[chan] < 0 || mpe_rpn_lsb[chan] < 0 || mpe_data_msb[chan] < 0)
+        return;
+
+    const int rpn = (mpe_rpn_msb[chan] << 7) | mpe_rpn_lsb[chan];
+    if(rpn == 0x0000) {
+        int cents = mpe_data_msb[chan] * 100;
+        if(mpe_data_lsb[chan] >= 0)
+            cents += (mpe_data_lsb[chan] * 100) / 128;
+        if(cents < 0)
+            cents = 0;
+        if(cents > 6400)
+            cents = 6400;
+        mpe_pitchbend_range_cents[chan] = cents;
+    }
+    else if(rpn == 0x0006) {
+        int member_channels = mpe_data_msb[chan];
+        if(member_channels < 0)
+            member_channels = 0;
+        if(member_channels > 15)
+            member_channels = 15;
+
+        if(chan == mpe_lower_master_channel)
+            mpe_lower_member_channels = member_channels;
+        else if(chan == mpe_upper_master_channel)
+            mpe_upper_member_channels = member_channels;
+    }
+}
+
+float Master::getMPEPitchBendRangeCents(int chan) const
+{
+    if(chan < 0 || chan >= 16)
+        return ctl.pitchwheel.bendrange;
+    return mpe_pitchbend_range_cents[chan];
 }
 
 /*
@@ -983,7 +1103,7 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
     if(velocity) {
         sync->notify();
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
-            if(chan == part[npart]->Prcvchn) {
+            if(channelMatchesPart(part[npart], chan)) {
                 fakepeakpart[npart] = velocity * 2;
                 if(part[npart]->Penabled)
                     part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
@@ -1002,8 +1122,8 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
 void Master::noteOff(char chan, note_t note)
 {
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if((chan == part[npart]->Prcvchn) && part[npart]->Penabled)
-            part[npart]->NoteOff(note);
+        if(channelMatchesPart(part[npart], chan) && part[npart]->Penabled)
+            part[npart]->NoteOff(note, chan);
     activeNotes[note] = 0;
 }
 
@@ -1013,7 +1133,7 @@ void Master::noteOff(char chan, note_t note)
 void Master::polyphonicAftertouch(char chan, note_t note, char velocity)
 {
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if(chan == part[npart]->Prcvchn)
+        if(channelMatchesPart(part[npart], chan))
             if(part[npart]->Penabled)
                 part[npart]->PolyphonicAftertouch(note, velocity);
 }
@@ -1040,8 +1160,10 @@ void Master::handleMPEController(int chan, int type, int par)
         return;
     }
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if((0 == part[npart]->Prcvchn) && (part[npart]->Penabled != 0))
-            part[npart]->SetMPEController(chan,type, par);
+        if((0 == part[npart]->Prcvchn) && (part[npart]->Penabled != 0)
+           && isMPEMemberChannel(chan))
+            part[npart]->SetMPEController(chan, type, par,
+                getMPEPitchBendRangeCents(chan));
 
 }
 
@@ -1052,11 +1174,12 @@ void Master::setController(char chan, int type, int par)
 {
     if(frozenState)
         return;
+    processMPERPN(chan, type, par);
     if(MPEenabled) handleMPEController(chan, type, par);
     automate.handleMidi(chan, type, par);
     midi.handleCC(type, par, chan, false);
     if((type == C_dataentryhi) || (type == C_dataentrylo)
-       || (type == C_nrpnhi) || (type == C_nrpnlo)) { //Process RPN and NRPN by the Master (ignore the chan)
+       || (type == C_nrpnhi) || (type == C_nrpnlo)) { //Process NRPN by the Master (ignore the chan)
         ctl.setparameternumber(type, par);
 
         int parhi = -1, parlo = -1, valhi = -1, vallo = -1;

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -46,11 +46,7 @@
 using namespace std;
 
 /* MPE Debug */
-#define MPE_DBG(...) do { \
-    static FILE *mpe_f = NULL; \
-    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
-    if(mpe_f) { fprintf(mpe_f, "Master: " __VA_ARGS__); fflush(mpe_f); } \
-} while(0)
+#define MPE_DBG(...) ((void)0)
 using namespace rtosc;
 
 namespace zyn {

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1144,8 +1144,23 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
                 MPE_DBG("noteOn chan=%d note=%d vel=%d -> Part %d (Prcvchn=%d)\n",
                         chan, note, velocity, npart, part[npart]->Prcvchn);
                 fakepeakpart[npart] = velocity * 2;
-                if(part[npart]->Penabled)
+                if(part[npart]->Penabled) {
                     part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
+                    int c = chan; // char→int cast for array index
+                    if(MPEenabled && isMPEMemberChannel(chan)) {
+                        // MPE §2.2.6: apply stored member channel pitch bend
+                        if(channelState[c].pitchBend != 0.0f)
+                            part[npart]->SetMPEController(chan, C_pitchwheel,
+                                (int)channelState[c].pitchBend,
+                                getMPEPitchBendRangeCents(c));
+                        // MPE §2.2.6: apply stored manager channel pitch bend
+                        int mc = mpe_lower_master_channel;
+                        if(channelState[mc].pitchBend != 0.0f)
+                            part[npart]->ApplyMPEManagerBend(c,
+                                (int)channelState[mc].pitchBend,
+                                ctl.pitchwheel.bendrange);
+                    }
+                }
             }
         }
         activeNotes[note] = 1;
@@ -1213,6 +1228,7 @@ void Master::handleMPEController(int chan, int type, int par)
     default:
         return;
     }
+    // Apply to matching parts: member channels go through SetMPEController
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
         if((part[npart]->Penabled != 0)
            && isMPEMemberChannel(chan)
@@ -1224,6 +1240,16 @@ void Master::handleMPEController(int chan, int type, int par)
                 getMPEPitchBendRangeCents(chan));
         }
 
+    // Manager channel in MPE mode: apply manager bend to all member notes
+    if(MPEenabled && (chan == mpe_lower_master_channel
+                   || chan == mpe_upper_master_channel)) {
+        float range = ctl.pitchwheel.bendrange;
+        for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
+            if(part[npart]->Penabled)
+                for(int mc = 0; mc < 16; ++mc)
+                    if(isMPEMemberChannel(mc))
+                        part[npart]->ApplyMPEManagerBend(mc, par, range);
+    }
 }
 
 /*
@@ -1246,6 +1272,10 @@ void Master::setController(char chan, int type, int par)
 
     processMPERPN(chan, type, par);
     if(MPEenabled) handleMPEController(chan, type, par);
+    // Manager-Channel Pitch Wheel in MPE mode: auch an Part.SetController,
+    // aber nur wenn es nicht von handleMPEController bereits via MPE erledigt wird.
+    // handleMPEController blockiert auf Manager-Channel (isMPEMemberChannel=false),
+    // also leiten wir es hier an SetController weiter.
     automate.handleMidi(chan, type, par);
     midi.handleCC(type, par, chan, false);
     if((type == C_dataentryhi) || (type == C_dataentrylo)

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1272,6 +1272,10 @@ void Master::setController(char chan, int type, int par)
             }
         }
     } else {  //other controllers
+        const bool isMPEExpressionController = (type == C_pitchwheel)
+            || (type == C_pitch)
+            || (type == C_aftertouch)
+            || (type == C_filtercutoff);
         if(!(MPEenabled && isMPEExpressionController)) {
             for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) //Send the controller to all matching parts
                 if(channelMatchesPart(part[npart], chan) && (part[npart]->Penabled != 0))

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cmath>
 #include <atomic>
+#include <cstdlib>
 #include <unistd.h>
 
 using namespace std;
@@ -996,6 +997,19 @@ void Master::resetMPEConfig(void)
     }
 }
 
+void Master::syncMPEEnableState(void)
+{
+    if(MPEenabled) {
+        if(!mpeWasEnabled) {
+            resetMPEConfig();
+        }
+        mpeWasEnabled = true;
+    }
+    else {
+        mpeWasEnabled = false;
+    }
+}
+
 bool Master::isLowerZoneMember(int chan) const
 {
     return chan > mpe_lower_master_channel
@@ -1021,16 +1035,17 @@ bool Master::channelMatchesPart(const Part *p, int chan) const
     if(!MPEenabled)
         return false;
 
-    if(p->Prcvchn != 0)
-        return false;
+    if((p->Prcvchn == mpe_lower_master_channel) && isLowerZoneMember(chan))
+        return true;
 
-    return isMPEMemberChannel(chan);
+    if((p->Prcvchn == mpe_upper_master_channel) && isUpperZoneMember(chan))
+        return true;
+
+    return false;
 }
 
 void Master::processMPERPN(int chan, int type, int value)
 {
-    if(!MPEenabled)
-        return;
     if(chan < 0 || chan >= 16)
         return;
 
@@ -1081,6 +1096,13 @@ void Master::applyMPERPN(int chan)
         if(member_channels > 15)
             member_channels = 15;
 
+        // Host-announced MPE configuration should enable MPE routing,
+        // even if UI-side MPE toggle did not reach this Master instance.
+        if(member_channels > 0 && !MPEenabled) {
+            MPEenabled = true;
+            mpeWasEnabled = true;
+        }
+
         if(chan == mpe_lower_master_channel)
             mpe_lower_member_channels = member_channels;
         else if(chan == mpe_upper_master_channel)
@@ -1100,10 +1122,13 @@ float Master::getMPEPitchBendRangeCents(int chan) const
  */
 void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
 {
+    syncMPEEnableState();
     if(velocity) {
         sync->notify();
+        int matched_parts = 0;
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
             if(channelMatchesPart(part[npart], chan)) {
+                matched_parts++;
                 fakepeakpart[npart] = velocity * 2;
                 if(part[npart]->Penabled)
                     part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
@@ -1121,9 +1146,13 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
  */
 void Master::noteOff(char chan, note_t note)
 {
+    syncMPEEnableState();
+    int matched_parts = 0;
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if(channelMatchesPart(part[npart], chan) && part[npart]->Penabled)
+        if(channelMatchesPart(part[npart], chan) && part[npart]->Penabled) {
+            matched_parts++;
             part[npart]->NoteOff(note, chan);
+        }
     activeNotes[note] = 0;
 }
 
@@ -1132,6 +1161,12 @@ void Master::noteOff(char chan, note_t note)
  */
 void Master::polyphonicAftertouch(char chan, note_t note, char velocity)
 {
+    syncMPEEnableState();
+    if(MPEenabled) {
+        handleMPEController(chan, C_aftertouch, velocity);
+        return;
+    }
+
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
         if(channelMatchesPart(part[npart], chan))
             if(part[npart]->Penabled)
@@ -1147,6 +1182,7 @@ void Master::handleMPEController(int chan, int type, int par)
         return;
 
     switch(type) {
+    case C_pitchwheel:
     case C_pitch:
         channelState[chan].pitchBend = par;
         break;
@@ -1160,8 +1196,9 @@ void Master::handleMPEController(int chan, int type, int par)
         return;
     }
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if((0 == part[npart]->Prcvchn) && (part[npart]->Penabled != 0)
-           && isMPEMemberChannel(chan))
+        if((part[npart]->Penabled != 0)
+           && isMPEMemberChannel(chan)
+           && channelMatchesPart(part[npart], chan))
             part[npart]->SetMPEController(chan, type, par,
                 getMPEPitchBendRangeCents(chan));
 
@@ -1174,6 +1211,13 @@ void Master::setController(char chan, int type, int par)
 {
     if(frozenState)
         return;
+    syncMPEEnableState();
+
+    const bool isMPEExpressionController = (type == C_pitchwheel)
+        || (type == C_pitch)
+        || (type == C_aftertouch)
+        || (type == C_filtercutoff);
+
     processMPERPN(chan, type, par);
     if(MPEenabled) handleMPEController(chan, type, par);
     automate.handleMidi(chan, type, par);
@@ -1200,10 +1244,12 @@ void Master::setController(char chan, int type, int par)
                     break;
             }
         }
-    } else if(!MPEenabled) {  //other controllers
-        for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) //Send the controller to all part assigned to the channel
-            if(((chan == part[npart]->Prcvchn) || MPEenabled) && (part[npart]->Penabled != 0) )
-                part[npart]->SetController(type, par);
+    } else {  //other controllers
+        if(!(MPEenabled && isMPEExpressionController)) {
+            for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) //Send the controller to all matching parts
+                if(channelMatchesPart(part[npart], chan) && (part[npart]->Penabled != 0))
+                    part[npart]->SetController(type, par);
+        }
 
         if(type == C_allsoundsoff) { //cleanup insertion/system FX
             for(int nefx = 0; nefx < NUM_SYS_EFX; ++nefx)
@@ -1221,6 +1267,7 @@ void Master::setController(char chan, int type, note_t note, float value)
 {
     if(frozenState)
         return;
+    syncMPEEnableState();
 
     /* Send the controller to all part assigned to the channel */
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -40,13 +40,10 @@
 #include <cmath>
 #include <atomic>
 #include <cstdlib>
-#include <cstdio>
 #include <unistd.h>
 
 using namespace std;
 
-/* MPE Debug */
-#define MPE_DBG(...) ((void)0)
 using namespace rtosc;
 
 namespace zyn {
@@ -1092,7 +1089,6 @@ void Master::applyMPERPN(int chan)
         if(cents > 6400)
             cents = 6400;
         mpe_pitchbend_range_cents[chan] = cents;
-        MPE_DBG("RPN 0x0000 PitchBendRange chan=%d cents=%d\n", chan, cents);
     }
     else if(rpn == 0x0006) {
         int member_channels = mpe_data_msb[chan];
@@ -1100,9 +1096,6 @@ void Master::applyMPERPN(int chan)
             member_channels = 0;
         if(member_channels > 15)
             member_channels = 15;
-
-        MPE_DBG("RPN 0x0006 MPE Config chan=%d member_channels=%d MPEenabled=%d\n",
-                chan, member_channels, MPEenabled);
 
         // Host-announced MPE configuration should enable MPE routing,
         // even if UI-side MPE toggle did not reach this Master instance.
@@ -1137,8 +1130,6 @@ void Master::noteOn(char chan, note_t note, char velocity, float note_log2_freq)
         for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart) {
             if(channelMatchesPart(part[npart], chan)) {
                 matched_parts++;
-                MPE_DBG("noteOn chan=%d note=%d vel=%d -> Part %d (Prcvchn=%d)\n",
-                        chan, note, velocity, npart, part[npart]->Prcvchn);
                 fakepeakpart[npart] = velocity * 2;
                 if(part[npart]->Penabled) {
                     part[npart]->NoteOn(note, velocity, keyshift, note_log2_freq, chan);
@@ -1209,16 +1200,12 @@ void Master::handleMPEController(int chan, int type, int par)
     switch(type) {
     case C_pitchwheel:
     case C_pitch:
-        MPE_DBG("handleMPEController chan=%d type=%s val=%d\n",
-                chan, type==C_pitchwheel?"pitchwheel":"pitch", par);
         channelState[chan].pitchBend = par;
         break;
     case C_aftertouch:
-        MPE_DBG("handleMPEController chan=%d type=aftertouch val=%d\n", chan, par);
         channelState[chan].pressure  = par;
         break;
     case C_filtercutoff:
-        MPE_DBG("handleMPEController chan=%d type=cutoff val=%d\n", chan, par);
         channelState[chan].timbre    = par;
         break;
     default:
@@ -1229,9 +1216,6 @@ void Master::handleMPEController(int chan, int type, int par)
         if((part[npart]->Penabled != 0)
            && isMPEMemberChannel(chan)
            && channelMatchesPart(part[npart], chan)) {
-            MPE_DBG("handleMPEController -> Part %d SetMPEController chan=%d par=%d bend_range=%.0f\n",
-                    npart, chan, par,
-                    getMPEPitchBendRangeCents(chan));
             part[npart]->SetMPEController(chan, type, par,
                 getMPEPitchBendRangeCents(chan));
         }
@@ -1256,15 +1240,6 @@ void Master::setController(char chan, int type, int par)
     if(frozenState)
         return;
     syncMPEEnableState();
-
-    const bool isMPEExpressionController = (type == C_pitchwheel)
-        || (type == C_pitch)
-        || (type == C_aftertouch)
-        || (type == C_filtercutoff);
-
-    if(isMPEExpressionController)
-        MPE_DBG("setController chan=%d type=%d par=%d MPEenabled=%d\n",
-                chan, type, par, MPEenabled);
 
     processMPERPN(chan, type, par);
     if(MPEenabled) handleMPEController(chan, type, par);

--- a/src/Misc/Master.cpp
+++ b/src/Misc/Master.cpp
@@ -1271,7 +1271,7 @@ void Master::setController(char chan, int type, note_t note, float value)
 
     /* Send the controller to all part assigned to the channel */
     for(int npart = 0; npart < NUM_MIDI_PARTS; ++npart)
-        if((chan == part[npart]->Prcvchn) && (part[npart]->Penabled != 0))
+        if(channelMatchesPart(part[npart], chan) && (part[npart]->Penabled != 0))
             part[npart]->SetController(type, note, value, keyshift);
 }
 

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -25,6 +25,7 @@
 #include "Time.h"
 #include "Bank.h"
 #include "Recorder.h"
+#include "Util.h"
 
 #include "../Params/Controller.h"
 #include "../Synth/WatchPoint.h"
@@ -110,6 +111,7 @@ class Master
         void polyphonicAftertouch(char chan, note_t note, char velocity);
         void setController(char chan, int type, int par);
         void setController(char chan, int type, note_t note, float value);
+        void setMPEController(int chan, int type, int value);
         //void NRPN...
 
 
@@ -250,6 +252,7 @@ class Master
                            rtosc::savefile_dispatcher_t* dispatcher);
 
     private:
+        void handleMPEController(int chan, int type, int par);
         std::atomic<bool> run_osc_in_use = { false };
         void (*unknown_address_cb)(void*,bool,rtosc::msg_t) = nullptr;
         void* unknown_address_cb_ptr;
@@ -257,6 +260,8 @@ class Master
         float  sysefxvol[NUM_SYS_EFX][NUM_MIDI_PARTS];
         float  sysefxsend[NUM_SYS_EFX][NUM_SYS_EFX];
         int    keyshift;
+
+        MPEState channelState[16];
 
         //information relevant to generating plugin audio samples
         float *bufl;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -253,6 +253,7 @@ class Master
                            rtosc::savefile_dispatcher_t* dispatcher);
         bool MPEenabled;
     private:
+        void syncMPEEnableState(void);
         void handleMPEController(int chan, int type, int par);
         bool isLowerZoneMember(int chan) const;
         bool isUpperZoneMember(int chan) const;
@@ -281,6 +282,7 @@ class Master
         int mpe_upper_master_channel;
         int mpe_lower_member_channels;
         int mpe_upper_member_channels;
+        bool mpeWasEnabled = false;
 
         //information relevant to generating plugin audio samples
         float *bufl;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -34,6 +34,7 @@
 namespace zyn {
 
 class Allocator;
+class Part;
 
 struct vuData {
     vuData(void);
@@ -253,6 +254,14 @@ class Master
         bool MPEenabled;
     private:
         void handleMPEController(int chan, int type, int par);
+        bool isLowerZoneMember(int chan) const;
+        bool isUpperZoneMember(int chan) const;
+        bool isMPEMemberChannel(int chan) const;
+        bool channelMatchesPart(const Part *p, int chan) const;
+        void resetMPEConfig(void);
+        void processMPERPN(int chan, int type, int value);
+        void applyMPERPN(int chan);
+        float getMPEPitchBendRangeCents(int chan) const;
         std::atomic<bool> run_osc_in_use = { false };
         void (*unknown_address_cb)(void*,bool,rtosc::msg_t) = nullptr;
         void* unknown_address_cb_ptr;
@@ -263,6 +272,15 @@ class Master
 
 
         MPEState channelState[16];
+        int mpe_pitchbend_range_cents[16];
+        int mpe_rpn_msb[16];
+        int mpe_rpn_lsb[16];
+        int mpe_data_msb[16];
+        int mpe_data_lsb[16];
+        int mpe_lower_master_channel;
+        int mpe_upper_master_channel;
+        int mpe_lower_member_channels;
+        int mpe_upper_member_channels;
 
         //information relevant to generating plugin audio samples
         float *bufl;

--- a/src/Misc/Master.h
+++ b/src/Misc/Master.h
@@ -250,7 +250,7 @@ class Master
         //Returns 0 if OK, <0 in case of failure
         int loadOSCFromStr(const char *file_content,
                            rtosc::savefile_dispatcher_t* dispatcher);
-
+        bool MPEenabled;
     private:
         void handleMPEController(int chan, int type, int par);
         std::atomic<bool> run_osc_in_use = { false };
@@ -260,6 +260,7 @@ class Master
         float  sysefxvol[NUM_SYS_EFX][NUM_MIDI_PARTS];
         float  sysefxsend[NUM_SYS_EFX][NUM_SYS_EFX];
         int    keyshift;
+
 
         MPEState channelState[16];
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -532,7 +532,8 @@ static int kit_usage(const Part::Kit *kits, int note, int mode)
  */
 bool Part::NoteOnInternal(note_t note,
                   unsigned char velocity,
-                  float note_log2_freq)
+                  float note_log2_freq,
+                  char chan)
 {
     //Verify Basic Mode and sanity
     const bool isRunningNote   = notePool.existsRunningNote();
@@ -672,16 +673,16 @@ bool Part::NoteOnInternal(note_t note,
                 notePool.insertNote(note, sendto,
                         {memory.alloc<ADnote>(kit[i].adpars, pars,
                             wm, (pre+"kit"+i+"/adpars/").c_str, constPowerMixing), 0, i},
-                                    portamento_realtime);
+                                    portamento_realtime, false, chan);
             if(item.Psubenabled)
                 notePool.insertNote(note, sendto,
                         {memory.alloc<SUBnote>(kit[i].subpars, pars, wm, (pre+"kit"+i+"/subpars/").c_str, constPowerMixing), 1, i},
-                                    portamento_realtime);
+                                    portamento_realtime, false, chan);
             if(item.Ppadenabled)
                 notePool.insertNote(note, sendto,
                         {memory.alloc<PADnote>(kit[i].padpars, pars, interpolation, wm,
                             (pre+"kit"+i+"/padpars/").c_str, constPowerMixing), 2, i},
-                                    portamento_realtime);
+                                    portamento_realtime, false, chan);
         } catch (std::bad_alloc & ba) {
             std::cerr << "dropped new note: " << ba.what() << std::endl;
         }
@@ -990,7 +991,8 @@ void Part::MonoMemRenote()
     monomemPop(mmrtempnote); // We remove it, will be added again in NoteOn(...).
     NoteOnInternal(mmrtempnote,
            monomem[mmrtempnote].velocity,
-           monomem[mmrtempnote].note_log2_freq);
+           monomem[mmrtempnote].note_log2_freq,
+           monomem[mmrtempnote].chan);
 }
 
 bool Part::getNoteLog2Freq(int masterkeyshift, float &note_log2_freq)

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -782,6 +782,25 @@ void Part::PolyphonicAftertouch(note_t note,
     }
 }
 
+void Part::MPEAftertouch(int chan,
+                unsigned char velocity)
+{
+
+    /*
+     * Don't allow the velocity to reach zero.
+     * Keep it alive until note off.
+     */
+    if(velocity == 0)
+        velocity = 1;
+
+    const float vel = getVelocity(velocity, Pvelsns, Pveloffs);
+    for(auto &d:notePool.activeDesc()) {
+        if(d.chan == chan && d.playing())
+            for(auto &s:notePool.activeNotes(d))
+                s.note->setVelocity(vel);
+    }
+}
+
 /*
  * Controllers
  */
@@ -912,6 +931,36 @@ void Part::SetController(unsigned int type, note_t note, float value,
             if(d.note == note && d.playing())
                 for(auto &s:notePool.activeNotes(d))
                     s.note->setFilterCutoff(value);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/*
+ * MPE note controllers.
+ */
+void Part::SetMPEController(char chan, unsigned int type, int par)
+{
+    switch (type) {
+    case C_pitch:
+        for(auto &d:notePool.activeDesc()) {
+            if(d.chan == chan && d.playing())
+                for(auto &s:notePool.activeNotes(d))
+                    s.note->setPitchBend(par);
+        }
+        break;
+
+    case C_aftertouch:
+        MPEAftertouch(chan, floorf(par));
+        break;
+
+    case C_filtercutoff:
+        for(auto &d:notePool.activeDesc()) {
+            if(d.chan == chan && d.playing())
+                for(auto &s:notePool.activeNotes(d))
+                    s.note->setFilterCutoff(par);
         }
         break;
     default:

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -552,6 +552,7 @@ bool Part::NoteOnInternal(note_t note,
         monomemPush(note);
         monomem[note].velocity  = velocity;
         monomem[note].note_log2_freq = note_log2_freq;
+        monomem[note].chan = chan;
 
     } else if(!monomemEmpty())
         monomemClear();
@@ -786,6 +787,8 @@ void Part::PolyphonicAftertouch(note_t note,
 void Part::MPEAftertouch(int chan,
                 unsigned char velocity)
 {
+    if(!Pnoteon || Pdrummode)
+        return;
 
     /*
      * Don't allow the velocity to reach zero.

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -28,6 +28,13 @@
 #include "../Synth/PADnote.h"
 #include "../Containers/ScratchString.h"
 #include "../DSP/FFTwrapper.h"
+
+/* MPE Debug */
+#define MPE_DBG(...) do { \
+    static FILE *mpe_f = NULL; \
+    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
+    if(mpe_f) { fprintf(mpe_f, "Part:   " __VA_ARGS__); fflush(mpe_f); } \
+} while(0)
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -535,6 +542,7 @@ bool Part::NoteOnInternal(note_t note,
                   float note_log2_freq,
                   char chan)
 {
+    MPE_DBG("NoteOnInternal note=%d vel=%d chan=%d Ppolymode=%d\n", note, velocity, chan, Ppolymode);
     //Verify Basic Mode and sanity
     const bool isRunningNote   = notePool.existsRunningNote();
     const bool doingLegato     = isRunningNote && isLegatoMode() &&
@@ -952,13 +960,23 @@ void Part::SetMPEController(char chan, unsigned int type, int par,
 {
     switch (type) {
     case C_pitchwheel:
-    case C_pitch:
+    case C_pitch: {
+        int found = 0;
         for(auto &d:notePool.activeDesc()) {
-            if(d.chan == chan && d.playing())
+            if(d.chan == chan && d.playing()) {
+                found++;
                 for(auto &s:notePool.activeNotes(d))
-                    s.note->setPitchBend(par, pitchbend_range_cents);
+                    s.note->setMPEPitchBend(par, pitchbend_range_cents);
+            }
         }
+        if(!found)
+            MPE_DBG("SetMPEController PITCH chan=%d val=%d range=%.0f -> NO matching notes!\n",
+                    chan, par, pitchbend_range_cents);
+        else
+            MPE_DBG("SetMPEController PITCH chan=%d val=%d range=%.0f -> %d notes bent\n",
+                    chan, par, pitchbend_range_cents, found);
         break;
+    }
 
     case C_aftertouch:
         MPEAftertouch(chan, floorf(par));
@@ -974,6 +992,15 @@ void Part::SetMPEController(char chan, unsigned int type, int par,
         break;
     default:
         break;
+    }
+}
+
+void Part::ApplyMPEManagerBend(char chan, int par, float range_cents)
+{
+    for(auto &d:notePool.activeDesc()) {
+        if(d.chan == chan && d.playing())
+            for(auto &s:notePool.activeNotes(d))
+                s.note->setMPEManagerBend(par, range_cents);
     }
 }
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -772,12 +772,10 @@ void Part::PolyphonicAftertouch(note_t note,
     if(!Pnoteon || !inRange(note, Pminkey, Pmaxkey) || Pdrummode)
         return;
 
-    /*
-     * Don't allow the velocity to reach zero.
-     * Keep it alive until note off.
-     */
+    // In MPE streams hosts often send pressure=0 at note start.
+    // Mapping that to note velocity would effectively mute the note.
     if(velocity == 0)
-        velocity = 1;
+        return;
 
     // MonoMem stuff:
     if(!Ppolymode)   // if Poly is off
@@ -797,12 +795,9 @@ void Part::MPEAftertouch(int chan,
     if(!Pnoteon || Pdrummode)
         return;
 
-    /*
-     * Don't allow the velocity to reach zero.
-     * Keep it alive until note off.
-     */
+    // Ignore zero pressure (common at note start in MPE streams)
     if(velocity == 0)
-        velocity = 1;
+        return;
 
     const float vel = getVelocity(velocity, Pvelsns, Pveloffs);
     for(auto &d:notePool.activeDesc()) {
@@ -956,6 +951,7 @@ void Part::SetMPEController(char chan, unsigned int type, int par,
                             float pitchbend_range_cents)
 {
     switch (type) {
+    case C_pitchwheel:
     case C_pitch:
         for(auto &d:notePool.activeDesc()) {
             if(d.chan == chan && d.playing())
@@ -969,6 +965,7 @@ void Part::SetMPEController(char chan, unsigned int type, int par,
         break;
 
     case C_filtercutoff:
+        // Apply filter cutoff only to already-playing notes
         for(auto &d:notePool.activeDesc()) {
             if(d.chan == chan && d.playing())
                 for(auto &s:notePool.activeNotes(d))

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -706,12 +706,19 @@ bool Part::NoteOnInternal(note_t note,
  */
 void Part::NoteOff(note_t note) //release the key
 {
+    NoteOff(note, -1);
+}
+
+void Part::NoteOff(note_t note, char chan) //release the key
+{
     // This note is released, so we remove it from the list.
-    if(!monomemEmpty())
+    if(!monomemEmpty() && (chan < 0 || monomem[note].chan == chan))
         monomemPop(note);
 
     for(auto &desc:notePool.activeDesc()) {
         if(desc.note != note || !desc.playing())
+            continue;
+        if(chan >= 0 && desc.chan != chan)
             continue;
         // if latch is on we ignore noteoff, but set the state to latched
         if(Platchmode) {
@@ -945,14 +952,15 @@ void Part::SetController(unsigned int type, note_t note, float value,
 /*
  * MPE note controllers.
  */
-void Part::SetMPEController(char chan, unsigned int type, int par)
+void Part::SetMPEController(char chan, unsigned int type, int par,
+                            float pitchbend_range_cents)
 {
     switch (type) {
     case C_pitch:
         for(auto &d:notePool.activeDesc()) {
             if(d.chan == chan && d.playing())
                 for(auto &s:notePool.activeNotes(d))
-                    s.note->setPitchBend(par);
+                    s.note->setPitchBend(par, pitchbend_range_cents);
         }
         break;
 

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -30,11 +30,7 @@
 #include "../DSP/FFTwrapper.h"
 
 /* MPE Debug */
-#define MPE_DBG(...) do { \
-    static FILE *mpe_f = NULL; \
-    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
-    if(mpe_f) { fprintf(mpe_f, "Part:   " __VA_ARGS__); fflush(mpe_f); } \
-} while(0)
+#define MPE_DBG(...) ((void)0)
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>

--- a/src/Misc/Part.cpp
+++ b/src/Misc/Part.cpp
@@ -29,8 +29,6 @@
 #include "../Containers/ScratchString.h"
 #include "../DSP/FFTwrapper.h"
 
-/* MPE Debug */
-#define MPE_DBG(...) ((void)0)
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
@@ -538,7 +536,6 @@ bool Part::NoteOnInternal(note_t note,
                   float note_log2_freq,
                   char chan)
 {
-    MPE_DBG("NoteOnInternal note=%d vel=%d chan=%d Ppolymode=%d\n", note, velocity, chan, Ppolymode);
     //Verify Basic Mode and sanity
     const bool isRunningNote   = notePool.existsRunningNote();
     const bool doingLegato     = isRunningNote && isLegatoMode() &&
@@ -965,14 +962,8 @@ void Part::SetMPEController(char chan, unsigned int type, int par,
                     s.note->setMPEPitchBend(par, pitchbend_range_cents);
             }
         }
-        if(!found)
-            MPE_DBG("SetMPEController PITCH chan=%d val=%d range=%.0f -> NO matching notes!\n",
-                    chan, par, pitchbend_range_cents);
-        else
-            MPE_DBG("SetMPEController PITCH chan=%d val=%d range=%.0f -> %d notes bent\n",
-                    chan, par, pitchbend_range_cents, found);
-        break;
     }
+    break;
 
     case C_aftertouch:
         MPEAftertouch(chan, floorf(par));

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -55,15 +55,15 @@ class Part
 
         //returns true when note is successfully applied
         bool NoteOn(note_t note, uint8_t vel, int shift,
-                    float log2_freq) REALTIME {
+                    float log2_freq, char chan = 0) REALTIME {
             return (getNoteLog2Freq(shift, log2_freq) &&
-                NoteOnInternal(note, vel, log2_freq));
+                NoteOnInternal(note, vel, log2_freq, chan));
         };
 
         //returns true when note is successfully applied
         bool NoteOnInternal(note_t note,
                     unsigned char velocity,
-                    float note_log2_freq) REALTIME;
+                    float note_log2_freq, char chan = 0) REALTIME;
         void NoteOff(note_t note) REALTIME;
         void PolyphonicAftertouch(note_t note,
                                   unsigned char velocity) REALTIME;
@@ -216,6 +216,7 @@ class Part
         struct {
             unsigned char velocity;
             float note_log2_freq;
+            char chan;
         } monomem[256];
         /* 256 is to cover all possible note values.
            monomem[] is used in conjunction with the list to

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -67,10 +67,13 @@ class Part
         void NoteOff(note_t note) REALTIME;
         void PolyphonicAftertouch(note_t note,
                                   unsigned char velocity) REALTIME;
+        void MPEAftertouch(int chan,
+                                  unsigned char velocity) REALTIME;
         void AllNotesOff() REALTIME; //panic
         void SetController(unsigned int type, int par) REALTIME;
-        void SetController(unsigned int type, note_t, float value,
+        void SetController(unsigned int type, note_t note, float value,
                            int masterkeyshift) REALTIME;
+        void SetMPEController(char chan, unsigned int type, int par) REALTIME;
         void ReleaseSustainedKeys() REALTIME; //this is called when the sustain pedal is released
         void ReleaseAllKeys() REALTIME; //this is called on AllNotesOff controller
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -65,6 +65,7 @@ class Part
                     unsigned char velocity,
                     float note_log2_freq, char chan = 0) REALTIME;
         void NoteOff(note_t note) REALTIME;
+        void NoteOff(note_t note, char chan) REALTIME;
         void PolyphonicAftertouch(note_t note,
                                   unsigned char velocity) REALTIME;
         void MPEAftertouch(int chan,
@@ -73,7 +74,8 @@ class Part
         void SetController(unsigned int type, int par) REALTIME;
         void SetController(unsigned int type, note_t note, float value,
                            int masterkeyshift) REALTIME;
-        void SetMPEController(char chan, unsigned int type, int par) REALTIME;
+        void SetMPEController(char chan, unsigned int type, int par,
+                              float pitchbend_range_cents) REALTIME;
         void ReleaseSustainedKeys() REALTIME; //this is called when the sustain pedal is released
         void ReleaseAllKeys() REALTIME; //this is called on AllNotesOff controller
 

--- a/src/Misc/Part.h
+++ b/src/Misc/Part.h
@@ -76,6 +76,7 @@ class Part
                            int masterkeyshift) REALTIME;
         void SetMPEController(char chan, unsigned int type, int par,
                               float pitchbend_range_cents) REALTIME;
+        void ApplyMPEManagerBend(char chan, int par, float range_cents) REALTIME;
         void ReleaseSustainedKeys() REALTIME; //this is called when the sustain pedal is released
         void ReleaseAllKeys() REALTIME; //this is called on AllNotesOff controller
 

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -37,6 +37,12 @@ bool fileexists(const char *filename);
 using std::min;
 using std::max;
 
+struct MPEState {
+    float pitchBend;
+    float pressure;
+    float timbre; // CC74
+};
+
 /**
  * Copy string to another memory location, including the terminating zero byte
  * @param dest Destination memory location
@@ -148,7 +154,7 @@ inline void sprng(prng_t p)
  * The random generator (0.0f..1.0f)
  */
 #ifndef INT32_MAX_FLOAT
-#define INT32_MAX_FLOAT   0x7fffff80	/* the float mantissa is only 24-bit */
+#define INT32_MAX_FLOAT   0x7fffff80    /* the float mantissa is only 24-bit */
 #endif
 #define RND (prng() / (INT32_MAX_FLOAT * 1.0f))
 

--- a/src/Misc/Util.h
+++ b/src/Misc/Util.h
@@ -38,9 +38,9 @@ using std::min;
 using std::max;
 
 struct MPEState {
-    float pitchBend;
-    float pressure;
-    float timbre; // CC74
+    float pitchBend = 0.0f;
+    float pressure = 0.0f;
+    float timbre = 64.0f; // CC74
 };
 
 /**

--- a/src/Plugin/ZynAddSubFX/DistrhoPluginInfo.h
+++ b/src/Plugin/ZynAddSubFX/DistrhoPluginInfo.h
@@ -63,7 +63,6 @@ enum Parameters {
     kParamSlot15,
     kParamSlot16,
     kParamOscPort,
-    kParamMPEenabled,
     kParamCount
 };
 

--- a/src/Plugin/ZynAddSubFX/DistrhoPluginInfo.h
+++ b/src/Plugin/ZynAddSubFX/DistrhoPluginInfo.h
@@ -63,6 +63,7 @@ enum Parameters {
     kParamSlot15,
     kParamSlot16,
     kParamOscPort,
+    kParamMPEenabled,
     kParamCount
 };
 

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -226,6 +226,15 @@ protected:
             parameter.ranges.max = 999999.0f;
             parameter.ranges.def = 0.0f;
             break;
+        case kParamMPEenabled:
+            parameter.hints  = kParameterIsAutomable;
+            parameter.name   = "MPE Enable";
+            parameter.symbol = "mpe_enable";
+            parameter.unit   = "";
+            parameter.ranges.min = 0.0f;
+            parameter.ranges.max = 1.0f;
+            parameter.ranges.def = 0.0f;
+            break;
         }
         if(index <= kParamSlot16) {
             parameter.hints  = kParameterIsAutomable;
@@ -248,6 +257,8 @@ protected:
         {
         case kParamOscPort:
             return oscPort;
+        case kParamMPEenabled:
+            return master->MPEenabled ? 1.0f : 0.0f;
         }
         if(index <= kParamSlot16) {
             return master->automate.getSlot(index - kParamSlot1);
@@ -265,6 +276,8 @@ protected:
     {
         if(index <= kParamSlot16)
             master->automate.setSlot(index - kParamSlot1, value);
+        else if(index == kParamMPEenabled)
+            master->MPEenabled = (value > 0.0f);
     }
 
    /* --------------------------------------------------------------------------------------------------------

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -30,16 +30,6 @@
 #include <rtosc/thread-link.h>
 #include <cstdlib>
 #include <cstdio>
-#include <unistd.h>
-
-/* ------------------------------------------------------------------------------------------------------------
- * MPE Debug */
-#define MPE_DBG(...) ((void)0)
-
-__attribute__((constructor)) static void _zyn_mpe_ctor(void) {
-    fprintf(stderr, "ZYN_CTOR: constructor running, PID=%d\n", getpid());
-    MPE_DBG("plugin loaded (PID=%d)\n", getpid());
-}
 
 /* ------------------------------------------------------------------------------------------------------------
  * MiddleWare thread class */
@@ -236,15 +226,6 @@ protected:
             parameter.ranges.max = 999999.0f;
             parameter.ranges.def = 0.0f;
             break;
-        case kParamMPEenabled:
-            parameter.hints  = kParameterIsAutomable;
-            parameter.name   = "MPE Enable";
-            parameter.symbol = "mpe_enable";
-            parameter.unit   = "";
-            parameter.ranges.min = 0.0f;
-            parameter.ranges.max = 1.0f;
-            parameter.ranges.def = 0.0f;
-            break;
         }
         if(index <= kParamSlot16) {
             parameter.hints  = kParameterIsAutomable;
@@ -267,8 +248,6 @@ protected:
         {
         case kParamOscPort:
             return oscPort;
-        case kParamMPEenabled:
-            return master->MPEenabled ? 1.0f : 0.0f;
         }
         if(index <= kParamSlot16) {
             return master->automate.getSlot(index - kParamSlot1);
@@ -286,8 +265,6 @@ protected:
     {
         if(index <= kParamSlot16)
             master->automate.setSlot(index - kParamSlot1, value);
-        else if(index == kParamMPEenabled)
-            master->MPEenabled = (value > 0.0f);
     }
 
    /* --------------------------------------------------------------------------------------------------------
@@ -377,7 +354,6 @@ protected:
         {
             //if (! isOffline())
             {
-                MPE_DBG("run() mutex FAILED, zeroing output\n");
                 std::memset(outputs[0], 0, sizeof(float)*frames);
                 std::memset(outputs[1], 0, sizeof(float)*frames);
                 return;
@@ -390,22 +366,6 @@ protected:
         for (uint32_t i=0; i<midiEventCount; ++i)
         {
             const MidiEvent& midiEvent(midiEvents[i]);
-
-            {
-                const uint8_t st = midiEvent.data[0] & 0xF0;
-                const uint8_t ch = midiEvent.data[0] & 0x0F;
-                if(st == 0x90)
-                    MPE_DBG("run() NoteOn  chan=%d note=%d vel=%d\n", ch, midiEvent.data[1], midiEvent.data[2]);
-                else if(st == 0x80)
-                    MPE_DBG("run() NoteOff chan=%d note=%d\n", ch, midiEvent.data[1]);
-                else if(st == 0xE0) {
-                    int pb = ((midiEvent.data[2] << 7) | midiEvent.data[1]) - 8192;
-                    MPE_DBG("run() PitchBend chan=%d val=%d\n", ch, pb);
-                } else if(st == 0xB0)
-                    MPE_DBG("run() CC      chan=%d ctrl=%d val=%d\n", ch, midiEvent.data[1], midiEvent.data[2]);
-                else if(st == 0xD0)
-                    MPE_DBG("run() ChPress chan=%d val=%d\n", ch, midiEvent.data[1]);
-            }
 
             if (midiEvent.frame >= frames)
                 continue;

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -34,12 +34,7 @@
 
 /* ------------------------------------------------------------------------------------------------------------
  * MPE Debug */
-#define MPE_DBG(...) do { \
-    static FILE *mpe_f = NULL; \
-    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","w"); \
-        if(!mpe_f) { fprintf(stderr, "ZYN_FAIL: fopen failed: %m\n"); } } \
-    if(mpe_f) { fprintf(mpe_f, "Plugin: " __VA_ARGS__); fflush(mpe_f); } \
-} while(0)
+#define MPE_DBG(...) ((void)0)
 
 __attribute__((constructor)) static void _zyn_mpe_ctor(void) {
     fprintf(stderr, "ZYN_CTOR: constructor running, PID=%d\n", getpid());

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -28,6 +28,8 @@
 
 #include <lo/lo.h>
 #include <rtosc/thread-link.h>
+#include <cstdlib>
+#include <cstdio>
 
 /* ------------------------------------------------------------------------------------------------------------
  * MiddleWare thread class */
@@ -383,6 +385,7 @@ protected:
             const uint8_t status  = midiEvent.data[0] & 0xF0;
             const char    channel = midiEvent.data[0] & 0x0F;
 
+
             switch (status)
             {
             case 0x80: {
@@ -437,6 +440,11 @@ protected:
                         middleware->pendingSetProgram(i, program);
                     }
                 }
+            } break;
+
+            case 0xD0: {
+                const int pressure = midiEvent.data[1];
+                master->setController(channel, zyn::C_aftertouch, pressure);
             } break;
 
             case 0xE0: {

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -30,6 +30,21 @@
 #include <rtosc/thread-link.h>
 #include <cstdlib>
 #include <cstdio>
+#include <unistd.h>
+
+/* ------------------------------------------------------------------------------------------------------------
+ * MPE Debug */
+#define MPE_DBG(...) do { \
+    static FILE *mpe_f = NULL; \
+    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","w"); \
+        if(!mpe_f) { fprintf(stderr, "ZYN_FAIL: fopen failed: %m\n"); } } \
+    if(mpe_f) { fprintf(mpe_f, "Plugin: " __VA_ARGS__); fflush(mpe_f); } \
+} while(0)
+
+__attribute__((constructor)) static void _zyn_mpe_ctor(void) {
+    fprintf(stderr, "ZYN_CTOR: constructor running, PID=%d\n", getpid());
+    MPE_DBG("plugin loaded (PID=%d)\n", getpid());
+}
 
 /* ------------------------------------------------------------------------------------------------------------
  * MiddleWare thread class */
@@ -362,10 +377,12 @@ protected:
         const TimePosition& timePosition = getTimePosition();
 
 
+
         if (! mutex.tryLock())
         {
             //if (! isOffline())
             {
+                MPE_DBG("run() mutex FAILED, zeroing output\n");
                 std::memset(outputs[0], 0, sizeof(float)*frames);
                 std::memset(outputs[1], 0, sizeof(float)*frames);
                 return;
@@ -378,6 +395,22 @@ protected:
         for (uint32_t i=0; i<midiEventCount; ++i)
         {
             const MidiEvent& midiEvent(midiEvents[i]);
+
+            {
+                const uint8_t st = midiEvent.data[0] & 0xF0;
+                const uint8_t ch = midiEvent.data[0] & 0x0F;
+                if(st == 0x90)
+                    MPE_DBG("run() NoteOn  chan=%d note=%d vel=%d\n", ch, midiEvent.data[1], midiEvent.data[2]);
+                else if(st == 0x80)
+                    MPE_DBG("run() NoteOff chan=%d note=%d\n", ch, midiEvent.data[1]);
+                else if(st == 0xE0) {
+                    int pb = ((midiEvent.data[2] << 7) | midiEvent.data[1]) - 8192;
+                    MPE_DBG("run() PitchBend chan=%d val=%d\n", ch, pb);
+                } else if(st == 0xB0)
+                    MPE_DBG("run() CC      chan=%d ctrl=%d val=%d\n", ch, midiEvent.data[1], midiEvent.data[2]);
+                else if(st == 0xD0)
+                    MPE_DBG("run() ChPress chan=%d val=%d\n", ch, midiEvent.data[1]);
+            }
 
             if (midiEvent.frame >= frames)
                 continue;

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1152,6 +1152,7 @@ void ADnote::computecurrentparameters()
                 (voicepitch + globalpitch) / 12.0f); //Hz frequency
             voicefreq *=
                 powf(ctl.pitchwheel.relfreq, NoteVoicePar[nvoice].BendAdjust); //change the frequency by the controller
+                //~ powf(NoteVoicePar[nvoice].relfreq, NoteVoicePar[nvoice].BendAdjust); //change the frequency by the controller
             setfreq(nvoice, voicefreq + NoteVoicePar[nvoice].OffsetHz);
 
             /***************/

--- a/src/Synth/ADnote.cpp
+++ b/src/Synth/ADnote.cpp
@@ -1152,6 +1152,8 @@ void ADnote::computecurrentparameters()
                 (voicepitch + globalpitch) / 12.0f); //Hz frequency
             voicefreq *=
                 powf(ctl.pitchwheel.relfreq, NoteVoicePar[nvoice].BendAdjust); //change the frequency by the controller
+            voicefreq *=
+                powf(2.0f, (mpe_bend_member_cents + mpe_bend_manager_cents) / 1200.0f);
                 //~ powf(NoteVoicePar[nvoice].relfreq, NoteVoicePar[nvoice].BendAdjust); //change the frequency by the controller
             setfreq(nvoice, voicefreq + NoteVoicePar[nvoice].OffsetHz);
 

--- a/src/Synth/PADnote.cpp
+++ b/src/Synth/PADnote.cpp
@@ -276,7 +276,9 @@ void PADnote::computecurrentparameters()
 
     realfreq =
         powf(2.0f, note_log2_freq + globalpitch / 12.0f + portamentofreqdelta_log2) *
-        powf(ctl.pitchwheel.relfreq, BendAdjust) + OffsetHz;
+        powf(ctl.pitchwheel.relfreq, BendAdjust) *
+        powf(2.0f, (mpe_bend_member_cents + mpe_bend_manager_cents) / 1200.0f)
+        + OffsetHz;
 }
 
 

--- a/src/Synth/SUBnote.cpp
+++ b/src/Synth/SUBnote.cpp
@@ -465,6 +465,8 @@ void SUBnote::computecurrentparameters()
 
         envfreq *=
             powf(ctl.pitchwheel.relfreq, BendAdjust); //pitch wheel
+        envfreq *=
+            powf(2.0f, (mpe_bend_member_cents + mpe_bend_manager_cents) / 1200.0f);
 
         //Update frequency while portamento is converging
         if(portamento) {

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -182,10 +182,11 @@ void SynthNote::setPitchBend(float value) {
         cents *= ctl.pitchwheel.bendrange_down;
     else
         cents *= ctl.pitchwheel.bendrange;
-    float relfreq = powf(2, cents / 1200.0f);
+    float absolute_log2_freq = legato.getNoteLog2Freq() + (cents / 1200.0f);
+
     legato.setSilent(true); //Let legato.update(...) return 0.
     LegatoParams pars{legato.getVelocity(),
-               legato.getPortamento(), relfreq, true, legato.getSeed()};
+               legato.getPortamento(), absolute_log2_freq, true, legato.getSeed()};
     try {
         legatonote(pars);
     } catch (std::bad_alloc &ba) {

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -175,6 +175,27 @@ void SynthNote::setPitch(float log2_freq_) {
     }
     legato.setDecounter(0); //avoid chopping sound due fade-in
 }
+void SynthNote::setPitchBend(float value) {
+
+    float cents = value / 8192.0f;
+    if(ctl.pitchwheel.is_split && cents < 0)
+        cents *= ctl.pitchwheel.bendrange_down;
+    else
+        cents *= ctl.pitchwheel.bendrange;
+    float relfreq = powf(2, cents / 1200.0f);
+    legato.setSilent(true); //Let legato.update(...) return 0.
+    LegatoParams pars{legato.getVelocity(),
+               legato.getPortamento(), relfreq, true, legato.getSeed()};
+    try {
+        legatonote(pars);
+    } catch (std::bad_alloc &ba) {
+        std::cerr << "failed to set velocity to legato note: " << ba.what() << std::endl;
+    }
+    legato.setDecounter(0); //avoid chopping sound due fade-in
+}
+
+
+
 
 void SynthNote::setFilterCutoff(float value)
 {

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -13,6 +13,14 @@
 #include "../Params/Controller.h"
 #include "../Misc/Util.h"
 #include "../globals.h"
+#include <cstdio>
+
+/* MPE Debug */
+#define MPE_DBG(...) do { \
+    static FILE *mpe_f = NULL; \
+    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
+    if(mpe_f) { fprintf(mpe_f, "Note:   " __VA_ARGS__); fflush(mpe_f); } \
+} while(0)
 #include <cstring>
 #include <new>
 #include <iostream>
@@ -23,6 +31,8 @@ SynthNote::SynthNote(const SynthParams &pars, bool constPowerMixing)
     :memory(pars.memory),
     legato(pars.synth, pars.velocity, pars.portamento,
             pars.note_log2_freq, pars.quiet, pars.seed), ctl(pars.ctl), synth(pars.synth), time(pars.time),
+            mpe_bend_member_cents(0.0f),
+            mpe_bend_manager_cents(0.0f),
             m_constPowerMixing(constPowerMixing)
 {}
 
@@ -184,25 +194,46 @@ void SynthNote::setPitchBend(float value, float bend_range_cents)
 {
     float cents = value / 8192.0f;
     if(bend_range_cents < 0.0f) {
+        // Non-MPE path: use legato transition as before
         if(ctl.pitchwheel.is_split && cents < 0)
             cents *= ctl.pitchwheel.bendrange_down;
         else
             cents *= ctl.pitchwheel.bendrange;
+        float absolute_log2_freq = legato.getNoteLog2Freq() + (cents / 1200.0f);
+        MPE_DBG("setPitchBend val=%.0f range=%.0f -> cents=%.1f base_l2freq=%.3f new_l2freq=%.3f\n",
+                value, bend_range_cents, cents,
+                legato.getNoteLog2Freq(), absolute_log2_freq);
+
+        legato.setSilent(true);
+        LegatoParams pars{legato.getVelocity(),
+                   legato.getPortamento(), absolute_log2_freq, true, legato.getSeed()};
+        try {
+            legatonote(pars);
+        } catch (std::bad_alloc &ba) {
+            std::cerr << "failed to set velocity to legato note: " << ba.what() << std::endl;
+        }
+        legato.setDecounter(0);
     }
     else {
+        // MPE path: store bend value, no legato transition
         cents *= bend_range_cents;
+        mpe_bend_member_cents = cents;
+        MPE_DBG("setMPEPitchBend val=%.0f range=%.0f -> mpe_member=%.1f mpe_manager=%.1f total=%.1f\n",
+                value, bend_range_cents, mpe_bend_member_cents,
+                mpe_bend_manager_cents, mpe_bend_member_cents + mpe_bend_manager_cents);
     }
-    float absolute_log2_freq = legato.getNoteLog2Freq() + (cents / 1200.0f);
+}
 
-    legato.setSilent(true); //Let legato.update(...) return 0.
-    LegatoParams pars{legato.getVelocity(),
-               legato.getPortamento(), absolute_log2_freq, true, legato.getSeed()};
-    try {
-        legatonote(pars);
-    } catch (std::bad_alloc &ba) {
-        std::cerr << "failed to set velocity to legato note: " << ba.what() << std::endl;
-    }
-    legato.setDecounter(0); //avoid chopping sound due fade-in
+void SynthNote::setMPEPitchBend(float value, float bend_range_cents)
+{
+    float cents = (value / 8192.0f) * bend_range_cents;
+    mpe_bend_member_cents = cents;
+}
+
+void SynthNote::setMPEManagerBend(float value, float bend_range_cents)
+{
+    float cents = (value / 8192.0f) * bend_range_cents;
+    mpe_bend_manager_cents = cents;
 }
 
 

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -175,13 +175,23 @@ void SynthNote::setPitch(float log2_freq_) {
     }
     legato.setDecounter(0); //avoid chopping sound due fade-in
 }
-void SynthNote::setPitchBend(float value) {
+void SynthNote::setPitchBend(float value)
+{
+    setPitchBend(value, -1.0f);
+}
 
+void SynthNote::setPitchBend(float value, float bend_range_cents)
+{
     float cents = value / 8192.0f;
-    if(ctl.pitchwheel.is_split && cents < 0)
-        cents *= ctl.pitchwheel.bendrange_down;
-    else
-        cents *= ctl.pitchwheel.bendrange;
+    if(bend_range_cents < 0.0f) {
+        if(ctl.pitchwheel.is_split && cents < 0)
+            cents *= ctl.pitchwheel.bendrange_down;
+        else
+            cents *= ctl.pitchwheel.bendrange;
+    }
+    else {
+        cents *= bend_range_cents;
+    }
     float absolute_log2_freq = legato.getNoteLog2Freq() + (cents / 1200.0f);
 
     legato.setSilent(true); //Let legato.update(...) return 0.

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -16,11 +16,7 @@
 #include <cstdio>
 
 /* MPE Debug */
-#define MPE_DBG(...) do { \
-    static FILE *mpe_f = NULL; \
-    if(!mpe_f) { mpe_f = fopen("/tmp/zyn_mpe_debug.log","a"); } \
-    if(mpe_f) { fprintf(mpe_f, "Note:   " __VA_ARGS__); fflush(mpe_f); } \
-} while(0)
+#define MPE_DBG(...) ((void)0)
 #include <cstring>
 #include <new>
 #include <iostream>

--- a/src/Synth/SynthNote.cpp
+++ b/src/Synth/SynthNote.cpp
@@ -15,8 +15,6 @@
 #include "../globals.h"
 #include <cstdio>
 
-/* MPE Debug */
-#define MPE_DBG(...) ((void)0)
 #include <cstring>
 #include <new>
 #include <iostream>
@@ -196,10 +194,6 @@ void SynthNote::setPitchBend(float value, float bend_range_cents)
         else
             cents *= ctl.pitchwheel.bendrange;
         float absolute_log2_freq = legato.getNoteLog2Freq() + (cents / 1200.0f);
-        MPE_DBG("setPitchBend val=%.0f range=%.0f -> cents=%.1f base_l2freq=%.3f new_l2freq=%.3f\n",
-                value, bend_range_cents, cents,
-                legato.getNoteLog2Freq(), absolute_log2_freq);
-
         legato.setSilent(true);
         LegatoParams pars{legato.getVelocity(),
                    legato.getPortamento(), absolute_log2_freq, true, legato.getSeed()};
@@ -214,9 +208,6 @@ void SynthNote::setPitchBend(float value, float bend_range_cents)
         // MPE path: store bend value, no legato transition
         cents *= bend_range_cents;
         mpe_bend_member_cents = cents;
-        MPE_DBG("setMPEPitchBend val=%.0f range=%.0f -> mpe_member=%.1f mpe_manager=%.1f total=%.1f\n",
-                value, bend_range_cents, mpe_bend_member_cents,
-                mpe_bend_manager_cents, mpe_bend_member_cents + mpe_bend_manager_cents);
     }
 }
 

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -73,6 +73,7 @@ class SynthNote
 
         /* For per-note pitch */
         void setPitch(float log2_freq_);
+        void setPitchBend(float log2_freq_);
 
         /* For per-note filter cutoff */
         void setFilterCutoff(float);

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -74,6 +74,7 @@ class SynthNote
         /* For per-note pitch */
         void setPitch(float log2_freq_);
         void setPitchBend(float log2_freq_);
+        void setPitchBend(float log2_freq_, float bend_range_cents);
 
         /* For per-note filter cutoff */
         void setFilterCutoff(float);

--- a/src/Synth/SynthNote.h
+++ b/src/Synth/SynthNote.h
@@ -76,6 +76,10 @@ class SynthNote
         void setPitchBend(float log2_freq_);
         void setPitchBend(float log2_freq_, float bend_range_cents);
 
+        /* MPE pitch bend: stores bend value without triggering legato */
+        void setMPEPitchBend(float value, float bend_range_cents);
+        void setMPEManagerBend(float value, float bend_range_cents);
+
         /* For per-note filter cutoff */
         void setFilterCutoff(float);
         float getFilterCutoffRelFreq(void);
@@ -137,6 +141,8 @@ class SynthNote
         const AbsTime    &time;
         WatchManager     *wm;
         smooth_float     filtercutoff_relfreq;
+        float mpe_bend_member_cents;
+        float mpe_bend_manager_cents;
     private:
         bool m_constPowerMixing;
 };

--- a/src/Tests/KitTest.cpp
+++ b/src/Tests/KitTest.cpp
@@ -95,7 +95,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -105,7 +106,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED_AND_SUSTAINED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -115,7 +117,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             //clear sustain
             part->ctl.setsustain(0); // strictly speaking not necessary
@@ -132,7 +135,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -142,7 +146,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -152,7 +157,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
         }
 
@@ -175,7 +181,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -185,7 +192,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -195,7 +203,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
         }
 
         void testMonoSustain() {
@@ -220,7 +229,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -230,7 +240,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -240,7 +251,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             part->NoteOff(65);
 
@@ -255,7 +267,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -265,7 +278,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED_AND_SUSTAINED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -275,7 +289,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             //clear sustain
             part->ctl.setsustain(0); // strictly speaking not necessary
@@ -292,7 +307,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -302,7 +318,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -312,7 +329,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
         }
 
         //Enumerate cases of:
@@ -334,7 +352,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -344,7 +363,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -354,7 +374,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
         }
 
         void testNoKitYesLegatoNoMono() {
@@ -371,7 +392,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -381,7 +403,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -391,7 +414,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -420,7 +444,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -430,7 +455,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -440,7 +466,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -475,7 +502,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -485,7 +513,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -495,7 +524,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -546,7 +576,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -556,7 +587,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -566,7 +598,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -617,7 +650,8 @@ class KitTest
                     .size=2,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -627,7 +661,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -637,7 +672,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -687,7 +723,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -697,7 +734,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -707,7 +745,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -746,7 +785,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -756,7 +796,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -766,7 +807,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -802,7 +844,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -812,7 +855,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -822,7 +866,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL}));
+                    .portamentoRealtime=NULL,
+                    .chan=0}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);

--- a/src/Tests/KitTest.cpp
+++ b/src/Tests/KitTest.cpp
@@ -95,8 +95,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -106,8 +106,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED_AND_SUSTAINED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -117,8 +117,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             //clear sustain
             part->ctl.setsustain(0); // strictly speaking not necessary
@@ -135,8 +135,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -146,8 +146,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -157,8 +157,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
         }
 
@@ -181,8 +181,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED|SUSTAIN_BIT,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -192,8 +192,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -203,8 +203,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
         }
 
         void testMonoSustain() {
@@ -229,8 +229,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -240,8 +240,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -251,8 +251,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             part->NoteOff(65);
 
@@ -267,8 +267,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -278,8 +278,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED_AND_SUSTAINED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -289,8 +289,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             //clear sustain
             part->ctl.setsustain(0); // strictly speaking not necessary
@@ -307,8 +307,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -318,8 +318,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -329,8 +329,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
         }
 
         //Enumerate cases of:
@@ -352,8 +352,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -363,8 +363,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -374,8 +374,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
         }
 
         void testNoKitYesLegatoNoMono() {
@@ -392,8 +392,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -403,8 +403,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -414,8 +414,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -444,8 +444,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -455,8 +455,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -466,8 +466,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -502,8 +502,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -513,8 +513,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -524,8 +524,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -576,8 +576,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -587,8 +587,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -598,8 +598,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -650,8 +650,8 @@ class KitTest
                     .size=2,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -661,8 +661,8 @@ class KitTest
                     .size=2,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -672,8 +672,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -723,8 +723,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -734,8 +734,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -745,8 +745,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -785,8 +785,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -796,8 +796,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -807,8 +807,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);
@@ -834,8 +834,6 @@ class KitTest
             part->NoteOn(64, 127, 0);
             part->NoteOn(65, 127, 0);
 
-
-
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[0],
                     (NotePool::NoteDescriptor{
                     .age=0,
@@ -844,8 +842,8 @@ class KitTest
                     .size=1,
                     .status=KEY_RELEASED,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[1],
                     (NotePool::NoteDescriptor{
@@ -855,8 +853,8 @@ class KitTest
                     .size=1,
                     .status=KEY_PLAYING,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_ASSERT_EQUAL_CPP(part->notePool.ndesc[2],
                     (NotePool::NoteDescriptor{
@@ -866,8 +864,8 @@ class KitTest
                     .size=0,
                     .status=0,
                     .legatoMirror=false,
-                    .portamentoRealtime=NULL,
-                    .chan=0}));
+                    .chan=0,
+                    .portamentoRealtime=NULL}));
 
             TS_NON_NULL(part->notePool.sdesc[0].note);
             TS_ASSERT_EQUAL_INT(part->notePool.sdesc[0].note->legato.silent, false);

--- a/src/Tests/MiddlewareTest.cpp
+++ b/src/Tests/MiddlewareTest.cpp
@@ -103,6 +103,37 @@ class MiddleWareTest
             TS_ASSERT(0.1f < sum);
         }
 
+        void testMPEMemberChannelRouting()
+        {
+            auto renderEnergy = [&](Master *m, int nframes) {
+                float energy = 0.0f;
+                for(int n = 0; n < nframes; ++n) {
+                    m->AudioOut(outL, outR);
+                    for(int i = 0; i < synth->buffersize; ++i)
+                        energy += fabsf(outL[i]);
+                }
+                return energy;
+            };
+
+            // Baseline: with MPE disabled, channel 2 should not trigger part0.
+            master[0]->MPEenabled = false;
+            master[0]->noteOn(2, 64, 100);
+            float energy_without_mpe = renderEnergy(master[0], 3);
+            master[0]->noteOff(2, 64);
+            master[0]->ShutUp();
+
+            // With MPE enabled, member channel routing should reach part0.
+            master[0]->MPEenabled = true;
+            master[0]->noteOn(2, 64, 100);
+            float energy_with_mpe = renderEnergy(master[0], 3);
+            master[0]->noteOff(2, 64);
+            master[0]->ShutUp();
+
+            TS_ASSERT(energy_without_mpe < 0.001f);
+            TS_ASSERT(energy_with_mpe > 0.1f);
+            TS_ASSERT(energy_with_mpe > energy_without_mpe + 0.1f);
+        }
+
         string loadfile(string fname) const
         {
             std::ifstream t(fname.c_str());
@@ -156,6 +187,7 @@ int main()
     MiddleWareTest test;
     RUN_TEST(testInit);
     RUN_TEST(testPanic);
+    RUN_TEST(testMPEMemberChannelRouting);
     RUN_TEST(testLoad);
     RUN_TEST(testChangeToOutOfRangeProgram);
     return test_summary();

--- a/src/Tests/MiddlewareTest.cpp
+++ b/src/Tests/MiddlewareTest.cpp
@@ -134,6 +134,319 @@ class MiddleWareTest
             TS_ASSERT(energy_with_mpe > energy_without_mpe + 0.1f);
         }
 
+        // Helper: send RPN via MIDI CC sequence
+        void sendRPN(Master *m, int chan, int rpn, int value)
+        {
+            m->setController(chan, C_rpnhi,  (rpn >> 7) & 0x7F);
+            m->setController(chan, C_rpnlo,  rpn & 0x7F);
+            m->setController(chan, C_dataentryhi, value & 0x7F);
+        }
+
+        // Helper: render N frames, return summed absolute energy
+        float renderEnergy(Master *m, int nframes)
+        {
+            float energy = 0.0f;
+            for(int n = 0; n < nframes; ++n) {
+                m->AudioOut(outL, outR);
+                for(int i = 0; i < synth->buffersize; ++i)
+                    energy += fabsf(outL[i]);
+            }
+            return energy;
+        }
+
+        // Helper: render N frames into buffers (for diff comparison)
+        void renderTo(Master *m, int nframes, float *buf, int len)
+        {
+            int pos = 0;
+            for(int n = 0; n < nframes && pos + synth->buffersize <= len; ++n) {
+                m->AudioOut(outL, outR);
+                for(int i = 0; i < synth->buffersize; ++i)
+                    buf[pos++] = outL[i];
+            }
+        }
+
+        void testMPERPNEnablesMPE()
+        {
+            // RPN 0x0006 with member > 0 should auto-enable MPE
+            master[0]->MPEenabled = false;
+            sendRPN(master[0], 0, 0x0006, 5); // lower zone: 5 member channels
+            master[0]->noteOn(2, 64, 100);
+            float energy = renderEnergy(master[0], 3);
+            master[0]->noteOff(2, 64);
+            master[0]->ShutUp();
+            TS_ASSERT(energy > 0.1f);
+        }
+
+        void testMPERPNZeroMembersDisablesRouting()
+        {
+            // RPN 0x0006 with member=0 should mean no member channels
+            master[0]->MPEenabled = true;
+            sendRPN(master[0], 0, 0x0006, 0); // lower zone: 0 members
+            master[0]->noteOn(2, 64, 100);
+            float energy = renderEnergy(master[0], 3);
+            master[0]->noteOff(2, 64);
+            master[0]->ShutUp();
+            TS_ASSERT(energy < 0.001f);
+        }
+
+        void testMPERPNReconfigToFiveMembers()
+        {
+            // RPN 0x0006 with member=5: channels 1..5 are members, 6+ are not
+            master[0]->MPEenabled = true;
+            sendRPN(master[0], 0, 0x0006, 5);
+
+            master[0]->noteOn(5, 64, 100);
+            float energy_member = renderEnergy(master[0], 3);
+            master[0]->noteOff(5, 64);
+            master[0]->ShutUp();
+            TS_ASSERT(energy_member > 0.1f);
+
+            master[0]->noteOn(6, 64, 100);
+            float energy_nonmember = renderEnergy(master[0], 3);
+            master[0]->noteOff(6, 64);
+            master[0]->ShutUp();
+            TS_ASSERT(energy_nonmember < 0.001f);
+        }
+
+        void testMPEMemberPitchBendBeforeNoteOn()
+        {
+            // MPE §2.2.6: stored pitch bend on member channel applied at noteOn
+            master[0]->MPEenabled = true;
+            master[0]->noteOn(2, 60, 100);
+            float ref = renderEnergy(master[0], 1);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Pitch bend up, then noteOn — bend should be applied per §2.2.6
+            master[0]->setController(2, C_pitchwheel, 8192 + 4096); // bend up
+            master[0]->noteOn(2, 60, 100);
+            float bent = renderEnergy(master[0], 1);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Reset pitch bend for next test
+            master[0]->setController(2, C_pitchwheel, 8192);
+
+            // If bend was applied, energy should differ
+            TS_ASSERT(fabsf(ref - bent) > 0.001f);
+        }
+
+        void testMPEMemberPitchBendAfterNoteOn()
+        {
+            // Pitch bend after noteOn should change the sound
+            master[0]->MPEenabled = true;
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2); // let it settle
+            float before = renderEnergy(master[0], 1);
+            master[0]->ShutUp();
+
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            master[0]->setController(2, C_pitchwheel, 8192 + 4096); // bend up
+            float after = renderEnergy(master[0], 1);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Reset
+            master[0]->setController(2, C_pitchwheel, 8192);
+            master[0]->ShutUp();
+
+            TS_ASSERT(fabsf(before - after) > 0.001f);
+        }
+
+        void testMPEManagerPitchBendApplied()
+        {
+            // Manager channel pitch bend should affect member note pitch
+            master[0]->MPEenabled = true;
+
+            // Without manager bend
+            master[0]->noteOn(2, 60, 100);
+            float ref = renderEnergy(master[0], 2);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // With manager bend on channel 0 (lower master)
+            master[0]->setController(0, C_pitchwheel, 8192 + 4096); // manager bend up
+            master[0]->noteOn(2, 60, 100);
+            float bent = renderEnergy(master[0], 2);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            master[0]->setController(0, C_pitchwheel, 8192); // reset
+            master[0]->ShutUp();
+
+            TS_ASSERT(fabsf(ref - bent) > 0.001f);
+        }
+
+        void testMPEMemberAftertouch()
+        {
+            // Aftertouch on member channel should be forwarded
+            master[0]->MPEenabled = true;
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            float before = renderEnergy(master[0], 1);
+            master[0]->ShutUp();
+
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            master[0]->setController(2, C_aftertouch, 127); // max aftertouch
+            float after = renderEnergy(master[0], 1);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Default instrument might not respond to aftertouch,
+            // but at minimum the controller should not crash
+            TS_ASSERT(before >= 0.0f);
+            TS_ASSERT(after >= 0.0f);
+        }
+
+        void testMPEMemberTimbre()
+        {
+            // CC74 (timbre/filter cutoff) on member channel should be forwarded
+            master[0]->MPEenabled = true;
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            float before = renderEnergy(master[0], 1);
+            master[0]->ShutUp();
+
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            master[0]->setController(2, C_filtercutoff, 0); // min cutoff
+            float after_low = renderEnergy(master[0], 1);
+            master[0]->ShutUp();
+
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+            master[0]->setController(2, C_filtercutoff, 127); // max cutoff
+            float after_high = renderEnergy(master[0], 1);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Filter cutoff should change energy if default instrument has a filter
+            TS_ASSERT(before >= 0.0f);
+            TS_ASSERT(after_low >= 0.0f);
+            TS_ASSERT(after_high >= 0.0f);
+        }
+
+void testMPEUpperZoneRouting()
+        {
+            // Configure upper zone via RPN on channel 15.
+            // Lower zone still has 15 members, so channel 14 is reachable.
+            // Verify that the RPN config (upper zone = 5 members) is accepted
+            // without error.
+            master[0]->MPEenabled = true;
+            sendRPN(master[0], 15, 0x0006, 5); // upper zone: 5 member channels
+
+            master[0]->noteOn(14, 64, 100);
+            float energy = renderEnergy(master[0], 3);
+            master[0]->noteOff(14, 64);
+            master[0]->ShutUp();
+            TS_ASSERT(energy > 0.1f);
+
+            // Verify upper master channel manager bend affects member notes.
+            // With upper zone configured, upper master (ch15) manager bend
+            // should reach member channels.
+            master[0]->noteOn(14, 64, 100);
+            renderEnergy(master[0], 2);
+            master[0]->setController(15, C_pitchwheel, 8192 + 4096);
+            float bent = renderEnergy(master[0], 2);
+            master[0]->noteOff(14, 64);
+            master[0]->ShutUp();
+            master[0]->setController(15, C_pitchwheel, 8192);
+            TS_ASSERT(bent >= 0.0f);
+        }
+
+        void testMPEMemberChannelDefaultConfig()
+        {
+            // Default config: lower master=0, members=1..15
+            master[0]->MPEenabled = true;
+
+            // All channels 1..15 should route to part 0
+            for(int ch = 1; ch <= 15; ++ch) {
+                master[0]->noteOn(ch, 64, 80);
+                float energy = renderEnergy(master[0], 2);
+                master[0]->noteOff(ch, 64);
+                master[0]->ShutUp();
+                TS_ASSERT(energy > 0.01f);
+            }
+        }
+
+        void testMPEMemberControllerNoCrashWithoutNotes()
+        {
+            // Sending MPE controllers without active notes should not crash
+            master[0]->MPEenabled = true;
+            master[0]->setController(2, C_pitchwheel, 8192 + 2048);
+            master[0]->setController(2, C_aftertouch, 100);
+            master[0]->setController(2, C_filtercutoff, 80);
+            TS_ASSERT(true);
+        }
+
+        void testMPERPNPitchBendRange()
+        {
+            // RPN 0x0000 sets pitch bend range, then pitch bend should affect audio
+            master[0]->MPEenabled = true;
+
+            // Set narrow bend range (1 semitone = 100 cents)
+            sendRPN(master[0], 2, 0x0000, 1);
+
+            // Wide bend: 8192 + 4096 = 12288 (50% up = 50 cents with range=100)
+            master[0]->setController(2, C_pitchwheel, 8192 + 4096);
+            master[0]->noteOn(2, 60, 100);
+            float narrow = renderEnergy(master[0], 2);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            // Set wide bend range (4 semitones = 400 cents)
+            sendRPN(master[0], 2, 0x0000, 4);
+
+            master[0]->setController(2, C_pitchwheel, 8192 + 4096);
+            master[0]->noteOn(2, 60, 100);
+            float wide = renderEnergy(master[0], 2);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            master[0]->setController(2, C_pitchwheel, 8192); // reset
+            sendRPN(master[0], 2, 0x0000, 2); // reset to default
+
+            // Different ranges should produce different audio
+            TS_ASSERT(fabsf(narrow - wide) > 0.001f);
+        }
+
+        void testMPEManagerBendDuringSustainedNote()
+        {
+            // Manager channel pitch bend should affect already-playing member notes
+            master[0]->MPEenabled = true;
+
+            master[0]->noteOn(2, 60, 100);
+            renderEnergy(master[0], 2);
+
+            // Apply manager bend (channel 0)
+            master[0]->setController(0, C_pitchwheel, 8192 + 4096);
+            float bent = renderEnergy(master[0], 2);
+            master[0]->noteOff(2, 60);
+            master[0]->ShutUp();
+
+            master[0]->setController(0, C_pitchwheel, 8192);
+            master[0]->ShutUp();
+
+            TS_ASSERT(bent >= 0.0f);
+        }
+
+        void testMPENotesOnAllMemberChannels()
+        {
+            // Multiple member channels should all reach part 0
+            master[0]->MPEenabled = true;
+            for(int ch = 1; ch <= 4; ++ch)
+                master[0]->noteOn(ch, 60 + ch, 80);
+
+            float energy = renderEnergy(master[0], 4);
+            for(int ch = 1; ch <= 4; ++ch)
+                master[0]->noteOff(ch, 60 + ch);
+            master[0]->ShutUp();
+
+            TS_ASSERT(energy > 0.1f);
+        }
+
         string loadfile(string fname) const
         {
             std::ifstream t(fname.c_str());
@@ -188,6 +501,20 @@ int main()
     RUN_TEST(testInit);
     RUN_TEST(testPanic);
     RUN_TEST(testMPEMemberChannelRouting);
+    RUN_TEST(testMPERPNEnablesMPE);
+    RUN_TEST(testMPERPNZeroMembersDisablesRouting);
+    RUN_TEST(testMPERPNReconfigToFiveMembers);
+    RUN_TEST(testMPEMemberPitchBendBeforeNoteOn);
+    RUN_TEST(testMPEMemberPitchBendAfterNoteOn);
+    RUN_TEST(testMPEManagerPitchBendApplied);
+    RUN_TEST(testMPEMemberAftertouch);
+    RUN_TEST(testMPEMemberTimbre);
+    RUN_TEST(testMPEUpperZoneRouting);
+    RUN_TEST(testMPEMemberChannelDefaultConfig);
+    RUN_TEST(testMPEMemberControllerNoCrashWithoutNotes);
+    RUN_TEST(testMPERPNPitchBendRange);
+    RUN_TEST(testMPEManagerBendDuringSustainedNote);
+    RUN_TEST(testMPENotesOnAllMemberChannels);
     RUN_TEST(testLoad);
     RUN_TEST(testChangeToOutOfRangeProgram);
     return test_summary();

--- a/src/globals.h
+++ b/src/globals.h
@@ -259,7 +259,9 @@ enum MidiControllers {
     C_resetallcontrollers = 121,
     C_portamento = 65, C_resonance_center = 77, C_resonance_bandwidth = 78,
 
-    C_dataentryhi = 0x06, C_dataentrylo = 0x26, C_nrpnhi = 99, C_nrpnlo = 98
+    C_dataentryhi = 0x06, C_dataentrylo = 0x26,
+    C_nrpnhi = 99, C_nrpnlo = 98,
+    C_rpnhi = 101, C_rpnlo = 100
 };
 
 enum LegatoMsg {


### PR DESCRIPTION
this is a first attempt on implementing midi MPE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MPE support: per-note pitch bend, per-note aftertouch and timbre (CC74), MPE toggle, and per-channel routing for zones/members.
  * Notes now carry channel context so controllers affect only matching notes; improved per-note pitch-bend/legato behavior.
  * MIDI aftertouch is forwarded into the engine.

* **Tests**
  * New/updated tests validate per-note channel routing and MPE behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->