### PR TITLE
Fix #393: Don't let "pause" write WAV file

### DIFF
--- a/src/Misc/MiddleWare.cpp
+++ b/src/Misc/MiddleWare.cpp
@@ -1788,6 +1788,7 @@ static rtosc::Ports middwareSnoopPortsWithoutNonRtParams = {
         rEnd},
     //drop this message into the abyss
     {"ui/title:", 0, 0, [](const char *, RtData &) {}},
+    {"isPlugin:", rDoc("Returns whether zyn is operating in plugin mode (and not standalone)"), 0, [](const char* , RtData& d) {d.reply(d.loc, isPlugin ? "T" : "F");}},
     {"quit:", rDoc("Stops the Zynaddsubfx process"),
      0, [](const char *, RtData&) {Pexitprogram = 1;}},
     // may only be called when Master is not being run

--- a/src/Misc/Recorder.cpp
+++ b/src/Misc/Recorder.cpp
@@ -85,7 +85,7 @@ void Recorder::stop()
 void Recorder::pause()
 {
     status = 0;
-    Nio::waveStop();
+    Nio::wavePause();
 }
 
 int Recorder::recording()

--- a/src/Nio/Nio.cpp
+++ b/src/Nio/Nio.cpp
@@ -177,6 +177,11 @@ void Nio::waveStart(void)
     out->wave->Start();
 }
 
+void Nio::wavePause(void)
+{
+    out->wave->Pause();
+}
+
 void Nio::waveStop(void)
 {
     out->wave->Stop();

--- a/src/Nio/Nio.h
+++ b/src/Nio/Nio.h
@@ -54,6 +54,7 @@ namespace Nio
     //Wave writing
     void waveNew(class WavFile *wave);
     void waveStart(void);
+    void wavePause(void);
     void waveStop(void);
     void waveEnd(void);
 

--- a/src/Nio/WavEngine.cpp
+++ b/src/Nio/WavEngine.cpp
@@ -46,7 +46,7 @@ bool WavEngine::Start()
     return true;
 }
 
-void WavEngine::Stop()
+void WavEngine::Pause()
 {
     if(!running.test())
         return;
@@ -55,6 +55,11 @@ void WavEngine::Stop()
     work.post();
     thread.join();
 
+}
+
+void WavEngine::Stop()
+{
+    Pause();
     destroyFile();
 }
 

--- a/src/Nio/WavEngine.h
+++ b/src/Nio/WavEngine.h
@@ -32,6 +32,7 @@ class WavEngine:public AudioOut
 
         bool openAudio();
         bool Start();
+        void Pause();
         void Stop();
 
         void setAudioEn(bool /*nval*/) {}

--- a/src/Output/DSSIaudiooutput.cpp
+++ b/src/Output/DSSIaudiooutput.cpp
@@ -39,6 +39,7 @@ namespace Nio {
     void masterSwap(zyn::Master *){};
     void waveNew(WavFile *){}
     void waveStart(void){}
+    void wavePause(void){}
     void waveStop(void){}
     void waveEnd(void){}
     bool setSource(string){return true;}

--- a/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
+++ b/src/Plugin/ZynAddSubFX/ZynAddSubFX.cpp
@@ -641,6 +641,7 @@ namespace Nio {
    std::string getSink(void){return "";}
    void waveNew(WavFile*){}
    void waveStart(){}
+   void wavePause(){}
    void waveStop(){}
    void setAudioCompressor(bool){}
    bool getAudioCompressor(void){return false;}


### PR DESCRIPTION
Fixup of 5b52108f1e950ef06e26ce11f7d69fa1020764ec .

Solves #393 .

Tested with both UIs.

Can be reviewed, but mruby-zest/mruby-zest-build#137 should be merged first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-controlled recording pause/resume now supported so recordings can be paused and continued.

* **Bug Fixes**
  * Pausing retains the open recording file so data is preserved; stopping still terminates and closes recordings correctly.

* **Chores**
  * Added an OSC admin query to report current plugin mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zynaddsubfx/zynaddsubfx/pull/394)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->