### PR TITLE
Add tRelease to fix watch discontinuity on forced release

### DIFF
--- a/src/Synth/Envelope.cpp
+++ b/src/Synth/Envelope.cpp
@@ -76,6 +76,7 @@ Envelope::Envelope(EnvelopeParams &pars, float basefreq, float bufferdt,
     currentpoint = 1; //the envelope starts from 1
     keyreleased  = false;
     t = 0.0f;
+    tRelease = 0.0f;
     envfinish = false;
     inct      = envdt[1];
     envoutval = 0.0f;
@@ -93,8 +94,10 @@ void Envelope::releasekey()
     if(keyreleased)
         return;
     keyreleased = true;
-    if(forcedrelease)
+    if(forcedrelease) {
+        tRelease = t;
         t = 0.0f;
+    }
 }
 
 void Envelope::forceFinish(void)
@@ -217,7 +220,7 @@ float Envelope::envout(bool doWatch)
     envoutval = out;
 
     if(doWatch) {
-        watch(currentpoint + t, envoutval);
+        watch(currentpoint + t + tRelease, envoutval);
     }
     return out;
 }

--- a/src/Synth/Envelope.h
+++ b/src/Synth/Envelope.h
@@ -53,6 +53,7 @@ class Envelope
         bool  keyreleased;    //if the key was released
         bool  envfinish;
         float t; // the time from the last point
+        float tRelease; // watch offset for forced release
         float inct; // the time increment
         float envoutval; //used to do the forced release
 


### PR DESCRIPTION
When forced release triggers, t is reset to 0.0 to start the release segment. Save the previous t as tRelease and add it to the watch time offset, so the watch display shows a continuous timeline without jumping backwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved envelope timing reports when a forced release occurs.
  * Ensured monitored output positions remain accurate across forced releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->