### PR TITLE
Extract PitchDrop as standalone effect with LFO modulation

### DIFF
--- a/src/Effects/CMakeLists.txt
+++ b/src/Effects/CMakeLists.txt
@@ -10,6 +10,7 @@ set(zynaddsubfx_effect_SRCS
 	Effects/EffectMgr.cpp
 	Effects/EQ.cpp
 	Effects/Phaser.cpp
+	Effects/PitchDrop.cpp
 	Effects/Reverb.cpp
 	Effects/Sympathetic.cpp
 	Effects/Reverse.cpp

--- a/src/Effects/CombFilterBank.cpp
+++ b/src/Effects/CombFilterBank.cpp
@@ -3,23 +3,35 @@
 #include "../Misc/Util.h"
 #include "CombFilterBank.h"
 
+//maxDrop = (float)(PmaxDrop+1)/32.0f
+#define maxDrop_min 0.03125f // 1/32
+
 namespace zyn {
+
+    struct FloatTuple {
+        float A;  // Gain or Phase for read head A
+        float B;  // Gain or Phase for read head B
+    };
 
     CombFilterBank::CombFilterBank(Allocator *alloc, unsigned int samplerate_, int buffersize_, float initgain):
     inputgain(1.0f),
     outgain(1.0f),
     gainbwd(initgain),
-    baseFreq(110.0f),
-    nrOfStrings(0),
     memory(*alloc),
     samplerate(samplerate_),
     buffersize(buffersize_)
     {
         // setup the smoother for gain parameter
-        gain_smoothing.cutoff(1.0f);
         gain_smoothing.sample_rate(samplerate/16);
         gain_smoothing.thresh(0.02f); // TBD: 2% jump audible?
+        gain_smoothing.cutoff(1.0f);
         gain_smoothing.reset(gainbwd);
+        pos_writer = 0;
+        // setup the smoother for offset parameter
+        offset_smoothing.sample_rate(samplerate);
+        offset_smoothing.thresh(0.02f); // TBD: 2% jump audible?
+        offset_smoothing.cutoff(0.2f);
+        offset_smoothing.reset(0.0f);
         pos_writer = 0;
     }
 
@@ -33,43 +45,57 @@ namespace zyn {
         // limit nrOfStringsNew
         nrOfStringsNew = min(NUM_SYMPATHETIC_STRINGS,nrOfStringsNew);
 
-        if(nrOfStringsNew == nrOfStrings && baseFreqNew == baseFreq)
+        if((nrOfStringsNew == nrOfStrings && baseFreqNew == baseFreq) || baseFreqNew < 0.85f)
             return;
 
+        baseFreq = baseFreqNew;
         const unsigned int mem_size_new = (int)ceilf(( (float)samplerate/baseFreqNew*1.03f + buffersize + 2)/16) * 16;
+        setStrings(nrOfStringsNew, mem_size_new);
+    }
+
+    void CombFilterBank::setStrings(unsigned int nrOfStringsNew, unsigned int mem_size_new)
+    {
+
         if(mem_size_new == mem_size)
         {
             if(nrOfStringsNew>nrOfStrings)
             {
+                // allocate more combs of the same mem_size
                 for(unsigned int i = nrOfStrings; i < nrOfStringsNew; ++i)
                 {
-                    string_smps[i] = memory.valloc<float>(mem_size);
-                    memset(string_smps[i], 0, mem_size*sizeof(float));
+                    comb_smps[i] = memory.valloc<float>(mem_size);
+                    memset(comb_smps[i], 0, mem_size*sizeof(float));
                 }
             }
-            else if(nrOfStringsNew<nrOfStrings)
+            else if(nrOfStringsNew<nrOfStrings) // free some combs
                 for(unsigned int i = nrOfStringsNew; i < nrOfStrings; ++i)
-                    memory.devalloc(string_smps[i]);
-        } else
+                    memory.devalloc(comb_smps[i]);
+        } else // different mem_size
         {
-            // free the old buffers (wrong size for baseFreqNew)
+            // free the old combs (wrong size for baseFreqNew)
             for(unsigned int i = 0; i < nrOfStrings; ++i)
-                memory.devalloc(string_smps[i]);
+                memory.devalloc(comb_smps[i]);
 
             // allocate buffers with new size
             for(unsigned int i = 0; i < nrOfStringsNew; ++i)
             {
-                string_smps[i] = memory.valloc<float>(mem_size_new);
-                memset(string_smps[i], 0, mem_size_new*sizeof(float));
+                comb_smps[i] = memory.valloc<float>(mem_size_new);
+                memset(comb_smps[i], 0, mem_size_new*sizeof(float));
             }
             // update mem_size and baseFreq
             mem_size = mem_size_new;
-            baseFreq = baseFreqNew;
             // reset writer position
             pos_writer = 0;
         }
         // update nrOfStrings
         nrOfStrings = nrOfStringsNew;
+    }
+
+    inline float CombFilterBank::sampleLerp(const float *smp, const float pos) const {
+        int poshi = (int)pos; // integer part (pos >= 0)
+        float poslo = pos - (float) poshi; // decimal part
+        // linear interpolation between samples
+        return smp[poshi] + poslo * (smp[(poshi+1)%mem_size]-smp[poshi]);
     }
 
     inline float CombFilterBank::tanhX(const float x)
@@ -80,58 +106,200 @@ namespace zyn {
         return (x*(105.0f+10.0f*x2)/(105.0f+(45.0f+x2)*x2));
     }
 
-    inline float CombFilterBank::sampleLerp(const float *smp, const float pos) const {
-        int poshi = (int)pos; // integer part (pos >= 0)
-        float poslo = pos - (float) poshi; // decimal part
-        // linear interpolation between samples
-        return smp[poshi] + poslo * (smp[(poshi+1)%mem_size]-smp[poshi]);
+
+    /**
+     * Generates two 180° phase shifted rising sawtooth signals
+     * at positive dropRate: 0 ... +maxDrop
+     * at negative dropRate: 0 ... -maxDrop
+     */
+    inline FloatTuple generatePhasedSawtooth(float& masterCounter, float dropRate, float maxDrop) {
+        FloatTuple result;
+
+        // increase(decrease) master
+        masterCounter += dropRate;
+
+        if (dropRate >= 0) {
+            // Positive direction: 0 ... +maxDrop
+            if (masterCounter >= maxDrop) {
+                masterCounter -= floorf(masterCounter);
+            }
+
+            result.A = masterCounter;
+            result.B = masterCounter + (maxDrop * 0.5f);
+            if (result.B >= maxDrop) {
+                result.B -= floorf(result.B);
+            }
+
+        } else {
+            // Negative direction: 0 ... -maxDrop
+            if (masterCounter <= -maxDrop) {
+                masterCounter = 0;
+            }
+
+            result.A = masterCounter;
+            result.B = masterCounter - (maxDrop * 0.5f);
+            if (result.B <= -maxDrop) {
+                result.B -= floorf(result.B);
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * Calculates symmetric equal-power crossfade gains for two read heads
+     *
+     * @param normalizedPhase Normalized phase position in range [0.0, 1.0]
+     * @param crossoverWidth Width of transition zones in range [0.0, 1.0]
+     * @return CrossfadeGains structure with gainA and gainB (gainA² + gainB² = 1.0)
+     */
+    inline FloatTuple calculateSymmetricCrossfade(float phase, float crossoverWidth) {
+
+        FloatTuple gains;
+
+        // crossoverWidth = 0 → hard switch
+        if (crossoverWidth <= 1e-6f) {
+            gains.A = (phase < 0.5f) ? 1.0f : 0.0f;
+            gains.B = (phase < 0.5f) ? 0.0f : 1.0f;
+            return gains;
+        }
+
+        // Calculate zone boundaries
+        const float stableZone = 0.5f * (1.0 - crossoverWidth);  // Length of each stable zone
+        const float transitionZone = crossoverWidth*0.5f;     // Length of each transition zone
+
+        // Zone 1: A stable (left side)
+        const float zone1End = stableZone;
+        // Zone 2: A→B crossfade
+        const float zone2End = zone1End + transitionZone;
+        // Zone 3: B stable (center)
+        const float zone3End = zone2End + stableZone;
+        // Zone 4: B→A crossfade
+        // zone4End = 1.0 (implicit)
+
+        if (phase < zone1End) {
+            // Zone 1: A on, B off
+            gains.A = 1.0f;
+            gains.B = 0.0f;
+        }
+        else if (phase < zone2End) {
+            // Zone 2: A→B linear crossfade
+            float fadeFactor = (phase - zone1End) / transitionZone;
+            assert(fadeFactor <= 1.0f);
+            assert(fadeFactor >= 0.0f);
+            gains.A = (1.0f - fadeFactor);
+            gains.B = (fadeFactor);
+        }
+        else if (phase < zone3End) {
+            // Zone 3: A off, B on
+            gains.A = 0.0f;
+            gains.B = 1.0f;
+        }
+        else {
+            // Zone 4: B→A linear crossfade
+            float fadeFactor = (phase - zone3End) / transitionZone;
+            assert(fadeFactor <= 1.0f);
+            assert(fadeFactor >= 0.0f);
+            gains.A = (fadeFactor);
+            gains.B = (1.0f - fadeFactor);
+        }
+
+        return gains;
     }
 
     void CombFilterBank::filterout(float *smp)
     {
-        // no string -> no sound
-        if (nrOfStrings==0) return;
 
         // interpolate gainbuf values over buffer length using value smoothing filter (lp)
         // this should prevent popping noise when controlled binary with 0 / 127
         // new control rate = samplerate / 16
-        const unsigned int gainbufsize = buffersize / 16;
-        STACKALLOC(float, gainbuf, gainbufsize); // buffer for value smoothing filter
-        if (!gain_smoothing.apply( gainbuf, gainbufsize, gainbwd ) ) // interpolate the gain value
-            std::fill(gainbuf, gainbuf+gainbufsize, gainbwd); // if nothing to interpolate (constant value)
+        const unsigned int gain_bufsize = buffersize / 16;
+        //~ const unsigned int offset_bufsize = buffersize / 4;
+        float gainbuf[gain_bufsize]; // buffer for value smoothing filter
+        if (!gain_smoothing.apply( gainbuf, gain_bufsize, gainbwd ) ) // interpolate the gain value
+            std::fill(gainbuf, gainbuf+gain_bufsize, gainbwd); // if nothing to interpolate (constant value)
+
+        float offsetbuf[buffersize]; // buffer for value smoothing filter
+        if (!offset_smoothing.apply( offsetbuf, buffersize, pitchOffset ) ) // interpolate the offset value
+            std::fill(offsetbuf, offsetbuf+buffersize, pitchOffset); // if nothing to interpolate (constant value)
 
         for (unsigned int i = 0; i < buffersize; ++i)
         {
-            // apply input gain
-            const float input_smp = smp[i]*inputgain;
 
-            for (unsigned int j = 0; j < nrOfStrings; ++j)
-            {
-                if (delays[j] == 0.0f) continue;
-                assert(float(mem_size)>delays[j]);
-                // calculate the feedback sample positions in the buffer
-                const float pos_reader = fmodf(float(pos_writer+mem_size) - delays[j], float(mem_size));
+            const float input_smp = smp[i] * inputgain;
+            if (maxDrop <= maxDrop_min)
+            {   //Pitch drop deactivated
+                for (unsigned int j = 0; j < nrOfStrings; ++j)
+                {
+                    if (delays[j] == 0.0f) continue;
+                    // apply pitchoffset to comb delay
+                    const float delay = min(delays[j] * powf(2.0f, offsetbuf[i]), float(mem_size));
+                    // calculate reading position and care for ring buffer range
+                    const float pos_reader = fmodf(float(pos_writer + mem_size) - delay, float(mem_size));
+                    // sample at that position
+                    const float feedbackSample = sampleLerp(comb_smps[j], pos_reader);
+                    // add saturated feedback to comb
+                    comb_smps[j][pos_writer] = input_smp + tanhX(feedbackSample * gainbuf[i/16]);
+                }
+            }
+            else
+            {   // Pitch drop Feature
+                // instead of reading with constant delay or with offset
+                // pitch drop keeps constantly changing the delay
+                // because the delay is limited, we use two alternating reading heads
+                // they jump back to 0 while their gain is 0
 
-                // sample at that position
-                const float sample = sampleLerp(string_smps[j], pos_reader);
-                string_smps[j][pos_writer] = input_smp + tanhX(sample*gainbuf[i/16]);
+                // calculate phases for both reading heads
+                const FloatTuple phases = generatePhasedSawtooth(sampleCounter, dropRate, maxDrop);
+                const float normalizedPhase = fmodf(fabsf(sampleCounter) / maxDrop + 0.5f, 1.0f);
+                // calculate the gains with given cross fadeing time
+                const FloatTuple gains = calculateSymmetricCrossfade(normalizedPhase, fadingTime);
+
+                for (unsigned int j = 0; j < nrOfStrings; ++j)
+                {
+                    if (delays[j] == 0.0f) continue;
+                    const float baseDelay = delays[j] * powf(2.0f, offsetbuf[i]);
+
+                    // Reading Head A
+                    float sampleA = 0.0f;
+                    if (gains.A > 0.0f)
+                    {
+                        const float delay1 = min(baseDelay * powf(2.0f, phases.A), float(mem_size));
+                        const float pos_reader1 = fmodf(float(pos_writer + mem_size - delay1), float(mem_size));
+                        sampleA = sampleLerp(comb_smps[j], pos_reader1) * gains.A;
+
+                    }
+
+                    // Reading Head B
+                    float sampleB = 0.0f;
+                    if (gains.B > 0.0f) {
+                        const float delay2 = min(baseDelay * powf(2.0f, phases.B), float(mem_size));
+                        const float pos_reader2 = fmodf(float(pos_writer + mem_size) - delay2, float(mem_size));
+                        sampleB = sampleLerp(comb_smps[j], pos_reader2)* gains.B;
+
+                    }
+
+                    float feedbackSample = (sampleA + sampleB);
+                    comb_smps[j][pos_writer] = input_smp + tanhX(feedbackSample * gainbuf[i/16]);
+                }
             }
             // mix output buffer samples to output sample
             smp[i]=0.0f;
-            unsigned int nrOfActualStrings = 0;
+            unsigned int nrOfNonZeroStrings = 0;
             for (unsigned int j = 0; j < nrOfStrings; ++j)
                 if (delays[j] != 0.0f) {
-                    smp[i] += string_smps[j][pos_writer];
-                    nrOfActualStrings++;
+                    smp[i] += comb_smps[j][pos_writer];
+                    nrOfNonZeroStrings++;
                 }
 
             // apply output gain to sum of strings and
             // divide by nrOfStrings to get mean value
-            // division by zero is catched at the beginning filterOut()
-            smp[i] *= outgain / (float)nrOfActualStrings;
+            smp[i] *= outgain;
+            if(nrOfNonZeroStrings>0)
+                smp[i] /= (float)nrOfNonZeroStrings;
 
-            // increment writing position
-            ++pos_writer %= mem_size;
+        // proceed to next position in ringbuffer
+        ++pos_writer %= mem_size;
         }
     }
 }

--- a/src/Effects/CombFilterBank.h
+++ b/src/Effects/CombFilterBank.h
@@ -14,33 +14,66 @@ class CombFilterBank
     CombFilterBank(Allocator *alloc, unsigned int samplerate_, int buffersize_, float initgain);
     ~CombFilterBank();
     void filterout(float *smp);
+    void updateOffsets(float maxDrop);
 
+    /** Individual delay times for each comb filter in seconds */
     float delays[NUM_SYMPATHETIC_STRINGS]={};
+
+    /** Gain applied to the input signal before processing */
     float inputgain;
+
+    /** Overall output gain applied after filter bank processing */
     float outgain;
+
+    /** Feedback gain coefficient for the comb filter recursion */
     float gainbwd;
 
     void setStrings(unsigned int nr, const float basefreq);
+    void setStrings(unsigned int nrOfStringsNew, unsigned int mem_size_new);
 
+    /** Maximum drop amount for pitch modulation effects in octaves */
+    float maxDrop = 2.0f;
+
+    /** Rate at which pitch drops occur for modulation effects */
+    float dropRate = 0.0f;
+
+    /** Time constant for fade-in/fade-out effects in % default: 5/127 */
+    float fadingTime = 0.03937007874f;
+
+    /** Global pitch offset applied to all strings in semitones */
+    float pitchOffset = 0.0f;
 
     private:
     static float tanhX(const float x);
     float sampleLerp(const float *smp, const float pos) const;
 
-    float* string_smps[NUM_SYMPATHETIC_STRINGS] = {};
-    float baseFreq;
+    /** Array of delay line buffers for each comb filter*/
+    float* comb_smps[NUM_SYMPATHETIC_STRINGS] = {};
+
+    /** Base frequency reference for tuning calculations in Hz */
+    float baseFreq=110.0f;
+
+    /** Current number of active sympathetic strings */
     unsigned int nrOfStrings=0;
+
+    /** Write position pointer for circular buffer operation */
     unsigned int pos_writer = 0;
 
-    /* for smoothing gain jump when using binary valued sustain pedal */
+    /** Smoothing filter to prevent gain discontinuities when sustain pedal changes */
     Value_Smoothing_Filter gain_smoothing;
 
+    /** Smoothing filter for gradual pitch offset changes */
+    Value_Smoothing_Filter offset_smoothing;
+
+    /** Memory allocator reference for dynamic buffer allocation */
     Allocator &memory;
+
     unsigned int mem_size=0;
     int samplerate=0;
     unsigned int buffersize=0;
 
-
+    /** Sample counter for timing-based delay modulation */
+    float sampleCounter = 0.0f;
 };
 
 }

--- a/src/Effects/EffectMgr.cpp
+++ b/src/Effects/EffectMgr.cpp
@@ -27,6 +27,7 @@
 #include "DynamicFilter.h"
 #include "Phaser.h"
 #include "Sympathetic.h"
+#include "PitchDrop.h"
 #include "../Effects/Reverse.h"
 #include "../Misc/XMLwrapper.h"
 #include "../Misc/Util.h"
@@ -233,7 +234,7 @@ static const rtosc::Ports local_ports = {
             d.reply(d.loc, "bb", sizeof(a), a, sizeof(b), b);
         }},
     {"efftype::i:c:S", rOptions(Disabled, Reverb, Echo, Chorus,
-     Phaser, Alienwah, Distortion, EQ, DynFilter, Sympathetic, Reverse) rDefault(Disabled)
+     Phaser, Alienwah, Distortion, EQ, DynFilter, Sympathetic, Reverse, PitchDrop) rDefault(Disabled)
      rProp(parameter) rDoc("Get Effect Type"), NULL,
      rCOptionCb(obj->nefx, obj->changeeffectrt(var))},
     {"efftype:b", rProp(internal) rDoc("Pointer swap EffectMgr"), NULL,
@@ -262,6 +263,7 @@ static const rtosc::Ports local_ports = {
     rSubtype(Phaser),
     rSubtype(Reverb),
     rSubtype(Sympathetic),
+    rSubtype(PitchDrop),
     rSubtype(Reverse),
 };
 
@@ -357,6 +359,9 @@ void EffectMgr::changeeffectrt(int _nefx, bool avoidSmash)
             case 10:
                 efx = memory.alloc<Reverse>(pars, time);
                 if(sync) sync->attach(efx);
+                break;
+            case 11:
+                efx = memory.alloc<PitchDrop>(pars);
                 break;
             //put more effect here
             default:

--- a/src/Effects/PitchDrop.cpp
+++ b/src/Effects/PitchDrop.cpp
@@ -1,0 +1,213 @@
+#include <cmath>
+#include <rtosc/ports.h>
+#include <rtosc/port-sugar.h>
+#include "../Misc/Allocator.h"
+#include "PitchDrop.h"
+#include "CombFilterBank.h"
+
+namespace zyn {
+
+#define rObject PitchDrop
+#define rBegin [](const char *msg, rtosc::RtData &d) {
+#define rEnd }
+
+const float drop_freeverb_freqs[8] = {1116.0f, 1188.0f, 1277.0f, 1356.0f, 1422.0f, 1491.0f, 1557.0f, 1617.0f};
+
+rtosc::Ports PitchDrop::ports = {
+    {"preset::i", rProp(parameter)
+                  rOptions(Freeverb)
+                  rProp(alias)
+                  rDefault(0)
+                  rDoc("Preset"), 0,
+                  rBegin;
+                  rObject *o = (rObject*)d.obj;
+                  if(rtosc_narguments(msg))
+                      o->setpreset(rtosc_argument(msg, 0).i);
+                  else
+                      d.reply(d.loc, "i", o->Ppreset);
+                  rEnd},
+    rEffParVol(rDefault(90)),
+    rEffParPan(rDefault(64)),
+    rEffPar(PdropRate, 2, rShort("drop"), rDefault(64), "Pitch Drop Rate"),
+    rEffPar(PmaxDrop, 3, rShort("max"), rDefault(0), "Max Drop"),
+    rEffPar(PfadingTime, 4, rShort("fade"), rDefault(5), "Fading Time"),
+    rEffPar(PfreqOffset, 5, rShort("offset"), rDefault(64), "Pitch Offset"),
+    rEffPar(lfo.Pfreq, 6, rShort("freq"), rDefault(32), "LFO frequency"),
+    rEffPar(lfo.Prandomness, 7, rShort("rnd"), rDefault(0), "LFO randomness"),
+    rEffParOpt(lfo.PLFOtype, 8, rShort("type"), rDefault(sine),
+            rOptions(sine, tri), "LFO shape"),
+    rEffPar(lfo.Pstereo, 9, rShort("stereo"), rDefault(64),
+            "LFO stereo phase"),
+    rEffPar(Plfodepth, 10, rShort("mod"), rDefault(0), "LFO modulation depth"),
+};
+
+#undef rBegin
+#undef rEnd
+#undef rObject
+
+PitchDrop::PitchDrop(EffectParams pars)
+    :Effect(pars),
+      Pvolume(90),
+      lfo(pars.srate, pars.bufsize),
+      srate(pars.srate)
+{
+    filterBank = memory.alloc<CombFilterBank>(&memory, pars.srate, pars.bufsize, 0.938f);
+
+    // Setup 8 freeverb-style comb filters
+    const unsigned int nstrings = 8;
+    for(unsigned int i = 0; i < nstrings; i++)
+        filterBank->delays[i] = ((float)samplerate) * drop_freeverb_freqs[i] / 44100.0f;
+
+    const unsigned int mem_size_new = (int)ceilf((filterBank->delays[0] * 32.0f * 1.03f + buffersize + 2) / 16) * 16;
+    filterBank->setStrings(nstrings, mem_size_new);
+
+    setpreset(Ppreset);
+    cleanup();
+}
+
+PitchDrop::~PitchDrop()
+{
+    memory.dealloc(filterBank);
+}
+
+void PitchDrop::cleanup(void)
+{
+}
+
+void PitchDrop::out(const Stereo<float *> &smp)
+{
+    float inputvol = powf(2.0f, 0.0f) / 2.0f;
+
+    // Apply LFO modulation to dropRate
+    Stereo<float> lfoVal(0.0f, 0.0f);
+    lfo.effectlfoout(&lfoVal.l, &lfoVal.r);
+    float baseDrop = (float)(PdropRate - 64) / (-256.0f * float(srate));
+    float lfoAmp = lfoVal.l * (float)Plfodepth / 127.0f * 64.0f / (-256.0f * float(srate));
+    filterBank->dropRate = baseDrop + lfoAmp;
+
+    for(int i = 0; i < buffersize; ++i)
+        efxoutl[i] = (smp.l[i] * pangainL + smp.r[i] * pangainR) * inputvol;
+
+    filterBank->filterout(efxoutl);
+
+    memcpy(efxoutr, efxoutl, bufferbytes);
+
+    float level = dB2rap(60.0f * Pvolume / 127.0f - 40.0f);
+    for(int i = 0; i < buffersize; ++i) {
+        float lout = efxoutl[i];
+        float rout = efxoutr[i];
+        float l    = lout * (1.0f - lrcross) + rout * lrcross;
+        float r    = rout * (1.0f - lrcross) + lout * lrcross;
+        lout = l;
+        rout = r;
+
+        efxoutl[i] = lout * 2.0f * level;
+        efxoutr[i] = rout * 2.0f * level;
+    }
+}
+
+void PitchDrop::setvolume(unsigned char _Pvolume)
+{
+    Pvolume = _Pvolume;
+
+    if(insertion == 0) {
+        outvolume = powf(0.01f, (1.0f - Pvolume / 127.0f)) * 4.0f;
+        volume    = 1.0f;
+    }
+    else
+        volume = outvolume = Pvolume / 127.0f;
+    if(Pvolume == 0)
+        cleanup();
+}
+
+unsigned char PitchDrop::getpresetpar(unsigned char npreset, unsigned int npar)
+{
+    static const unsigned char presets[1][11] = {
+        //Vol Pan drop max fade offset freq rnd type stereo mod
+        {90, 64, 64, 0, 5, 64, 32, 0, 0, 64, 0},
+    };
+    if(npreset < 1 && npar < 11) {
+        if(npar == 0 && insertion == 0)
+            return (2 * presets[npreset][npar]) / 3;
+        return presets[npreset][npar];
+    }
+    return 0;
+}
+
+void PitchDrop::setpreset(unsigned char npreset)
+{
+    if(npreset >= 1)
+        npreset = 0;
+    for(int n = 0; n != 128; n++)
+        changepar(n, getpresetpar(npreset, n));
+    Ppreset = npreset;
+}
+
+void PitchDrop::changepar(int npar, unsigned char value)
+{
+    switch(npar) {
+        case 0:
+            setvolume(value);
+            break;
+        case 1:
+            setpanning(value);
+            break;
+        case 2:
+            PdropRate = value;
+            filterBank->dropRate = (float)(PdropRate-64)/(-256.0f * float(srate));
+            break;
+        case 3:
+            PmaxDrop = value;
+            filterBank->maxDrop = (float)(PmaxDrop+1)/32.0f;
+            break;
+        case 4:
+            PfadingTime = value;
+            filterBank->fadingTime = (float)value/127.0f;
+            break;
+        case 5:
+            PfreqOffset = value;
+            filterBank->pitchOffset = (float)(PfreqOffset-64)/-64.0f;
+            break;
+        case 6:
+            lfo.Pfreq = value;
+            lfo.updateparams();
+            break;
+        case 7:
+            lfo.Prandomness = value;
+            lfo.updateparams();
+            break;
+        case 8:
+            lfo.PLFOtype = value;
+            lfo.updateparams();
+            break;
+        case 9:
+            lfo.Pstereo = value;
+            lfo.updateparams();
+            break;
+        case 10:
+            Plfodepth = value;
+            break;
+        default:
+            break;
+    }
+}
+
+unsigned char PitchDrop::getpar(int npar) const
+{
+    switch(npar) {
+        case 0:  return Pvolume;
+        case 1:  return Ppanning;
+        case 2:  return PdropRate;
+        case 3:  return PmaxDrop;
+        case 4:  return PfadingTime;
+        case 5:  return PfreqOffset;
+        case 6:  return lfo.Pfreq;
+        case 7:  return lfo.Prandomness;
+        case 8:  return lfo.PLFOtype;
+        case 9:  return lfo.Pstereo;
+        case 10: return Plfodepth;
+        default: return 0;
+    }
+}
+
+}

--- a/src/Effects/PitchDrop.cpp
+++ b/src/Effects/PitchDrop.cpp
@@ -11,7 +11,7 @@ namespace zyn {
 #define rBegin [](const char *msg, rtosc::RtData &d) {
 #define rEnd }
 
-const float drop_freeverb_freqs[8] = {1116.0f, 1188.0f, 1277.0f, 1356.0f, 1422.0f, 1491.0f, 1557.0f, 1617.0f};
+const float drop_freeverb_delays[8] = {1116.0f, 1188.0f, 1277.0f, 1356.0f, 1422.0f, 1491.0f, 1557.0f, 1617.0f};
 
 rtosc::Ports PitchDrop::ports = {
     {"preset::i", rProp(parameter)
@@ -56,7 +56,7 @@ PitchDrop::PitchDrop(EffectParams pars)
     // Setup 8 freeverb-style comb filters
     const unsigned int nstrings = 8;
     for(unsigned int i = 0; i < nstrings; i++)
-        filterBank->delays[i] = ((float)samplerate) * drop_freeverb_freqs[i] / 44100.0f;
+        filterBank->delays[i] = ((float)samplerate) * drop_freeverb_delays[i] / 44100.0f;
 
     const unsigned int mem_size_new = (int)ceilf((filterBank->delays[0] * 32.0f * 1.03f + buffersize + 2) / 16) * 16;
     filterBank->setStrings(nstrings, mem_size_new);

--- a/src/Effects/PitchDrop.h
+++ b/src/Effects/PitchDrop.h
@@ -1,0 +1,40 @@
+#ifndef PITCHDROP_H
+#define PITCHDROP_H
+
+#include "Effect.h"
+#include "EffectLFO.h"
+
+namespace zyn {
+
+class CombFilterBank;
+
+class PitchDrop final:public Effect
+{
+    public:
+        PitchDrop(EffectParams pars);
+        ~PitchDrop();
+        void out(const Stereo<float *> &smp);
+        unsigned char getpresetpar(unsigned char npreset, unsigned int npar);
+        void setpreset(unsigned char npreset);
+        void changepar(int npar, unsigned char value);
+        unsigned char getpar(int npar) const;
+        void cleanup(void);
+
+        static rtosc::Ports ports;
+    private:
+        unsigned char Pvolume;
+        unsigned char PdropRate = 64;
+        unsigned char PmaxDrop  = 0;
+        unsigned char PfadingTime = 96;
+        unsigned char PfreqOffset = 64;
+        unsigned char Plfodepth = 0;
+
+        void setvolume(unsigned char _Pvolume);
+
+        EffectLFO lfo;
+        unsigned int srate;
+        CombFilterBank *filterBank;
+};
+
+}
+#endif

--- a/src/Effects/PitchDrop.h
+++ b/src/Effects/PitchDrop.h
@@ -25,7 +25,7 @@ class PitchDrop final:public Effect
         unsigned char Pvolume;
         unsigned char PdropRate = 64;
         unsigned char PmaxDrop  = 0;
-        unsigned char PfadingTime = 96;
+        unsigned char PfadingTime = 5;
         unsigned char PfreqOffset = 64;
         unsigned char Plfodepth = 0;
 


### PR DESCRIPTION
Extracts the Pitch Drop feature from the Sympathetic effect (previously added in #349) into its own standalone effect.

**New effect: PitchDrop (type 11)**

- 6 base parameters: Volume, Panning, Drop Rate, Max Drop, Fading Time, Pitch Offset
- 4 LFO parameters: Frequency, Randomness, Shape, Stereo + Modulation Depth
- LFO modulates dropRate symmetrically around the DC value (preserves original PdropRate)
- 1 preset: Freeverb (8 comb filters with freeverb-style frequencies)

**CombFilterBank changes:**
- Added public members: maxDrop, dropRate, fadingTime, pitchOffset
- Added private members: offset_smoothing, sampleCounter
- Added dual-read-head crossfade algorithm for pitch drop mode
- Added setStrings(unsigned int, unsigned int) overload

Standalone GUI: https://github.com/mruby-zest/mruby-zest-build/pull/139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new **Pitch Drop** audio effect with controls for pitch-drop rate, maximum drop, fade time, pitch offset, volume, pan, and LFO parameters.
  * Added **presets** and **real-time parameter control** for the new effect.

* **Improvements**
  * Enhanced the effect’s pitch-drop processing for smoother, more natural transitions, including improved multi-string delay handling and buffer management for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->